### PR TITLE
Throw ProjectNotFound exception when adding a file to an orphan project

### DIFF
--- a/server/OmniSharp.Tests/AddToProject/AddToProjectTests.cs
+++ b/server/OmniSharp.Tests/AddToProject/AddToProjectTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using NUnit.Framework;
 using OmniSharp.AddToProject;
+using OmniSharp.Solution;
 
 namespace OmniSharp.Tests.AddToProject
 {
@@ -99,6 +100,39 @@ namespace OmniSharp.Tests.AddToProject
             handler.AddToProject(request);
 
             project.AsXml().ToString().Should().Be(expectedXml.ToString());
+        }
+
+        [Test, ExpectedException(typeof(ProjectNotFoundException))]
+        public void ShouldThrowProjectNotFoundExceptionWhenProjectNotFound()
+        {
+            var project = new FakeProject(fileName: @"/test/code/fake.csproj");
+            var solution = new FakeSolution(@"/test/fake.sln");
+            solution.Projects.Add(project);
+
+            var request = new AddToProjectRequest
+            {
+                FileName = @"/test/folder/Test.cs"
+            };
+
+            var handler = new AddToProjectHandler(solution);
+            handler.AddToProject(request);
+        }
+
+        [Test, ExpectedException(typeof (ProjectNotFoundException))]
+        public void ShouldThrowProjectNotFoundExceptionForOrphanProject()
+        {
+            var solution = new FakeSolution(@"/test/fake.sln");
+            var project = new OrphanProject(solution);
+            project.Files.Add(new CSharpFile(project, "/test/folder/Test.cs", "Some content..."));
+            solution.Projects.Add(project);
+
+            var request = new AddToProjectRequest
+            {
+                FileName = @"/test/folder/Test.cs"
+            };
+
+            var handler = new AddToProjectHandler(solution);
+            handler.AddToProject(request);
         }
     }
 }

--- a/server/OmniSharp/AddToProject/AddToProjectHandler.cs
+++ b/server/OmniSharp/AddToProject/AddToProjectHandler.cs
@@ -26,7 +26,7 @@ namespace OmniSharp.AddToProject
 
             var relativeProject = _solution.ProjectContainingFile(request.FileName);
 
-            if (relativeProject == null)
+            if (relativeProject == null || relativeProject is OrphanProject)
             {
                 throw new ProjectNotFoundException(string.Format("Unable to find project relative to file {0}", request.FileName));
             }


### PR DESCRIPTION
If a user tries to add a .cs file to a location (anywhere in the tree) not containing a csproj, it currently acts as an OrphanProject. We can't add a file to an OrphanProject, nor should a user try to add a file to a project that doesn't exist :) so for now just throw a ProjectNotFoundException.
