### PR TITLE
Fix message output method.

### DIFF
--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -35,7 +35,7 @@ def getResponse(endPoint, additionalParameters=None):
         response = urllib2.urlopen(target, parameters)
         return response.read()
     except:
-        vim.command("call confirm('Could not connect to " + target + "')")
+        vim.command("echo 'OmniSharp : Could not connect to " + target + "'")
         return ''
 
 


### PR DESCRIPTION
I changed the error message output when the server is not running.
- `call confirm` → `echo`

If the server is not running in this, the input does not prevent.
