### PR TITLE
Can't execute `http.exe` on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ OmniSharp listens to requests from Vim on port 2000 by default, so make sure tha
 Also if you are running OmniSharp as a non-privileged user, or without UAC elevation on Vista or later, you will need to run the following
 
 ```
-http add urlacl url=http://+:2000/ user=DOMAIN\user
+netsh http add urlacl url=http://+:2000/ user=DOMAIN\user
 ```
 
 This will give your user permission to bind to port 2000.


### PR DESCRIPTION
Hi.

On Windows I can't execute `http add urlacl url=http://+:2000/ user=DOMAIN\user`,
but can execute `netsh http add urlacl url=http://+:2000/ user=DOMAIN\user`.

Can you execute `http add urlacl url=http://+:2000/ user=DOMAIN\user`?
