### PR TITLE
Generalize server submodule ref so that all forkers may use it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server"]
 	path = server
-	url = git@github.com:nosami/OmniSharpServer.git
+        url = https://github.com/OmniSharpServer.git


### PR DESCRIPTION
$ git clone --recursive
failed on this commit (current master):

`a5cf600 * Merge pull request #57 from rbtnn/netsh`

Maybe this will fix it. Please test.
