### PR TITLE
Fix submodule url.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server"]
 	path = server
-        url = https://github.com/OmniSharpServer.git
+	url = https://github.com/nosami/OmniSharpServer.git


### PR DESCRIPTION
Following error occured.

```
Submodule 'server' (https://github.com/OmniSharpServer.git) registered for path 'server'
Cloning into 'server'...
fatal: https://github.com/OmniSharpServer.git/info/refs?service=git-upload-pack not found: did you run git update-server-info on the server?
Clone of 'https://github.com/OmniSharpServer.git' into submodule path 'server' failed
```
