### PR TITLE
Add b:undo_ftplugin feature.

### DIFF
--- a/ftplugin/cs_omnisharp.vim
+++ b/ftplugin/cs_omnisharp.vim
@@ -50,3 +50,34 @@ command! -buffer -nargs=1 -complete=file OmniSharpAddReference
 \   call OmniSharp#AddReference(<q-args>)
 
 setlocal omnifunc=OmniSharp#Complete
+
+
+
+if exists('b:undo_ftplugin')
+	let b:undo_ftplugin .= ' | '
+else
+	let b:undo_ftplugin = ''
+endif
+let b:undo_ftplugin .= '
+\	execute "autocmd! plugin-OmniSharp-SyntaxCheck * <buffer>"
+\
+\|	delcommand OmniSharpFindUsages
+\|	delcommand OmniSharpFindImplementations
+\|	delcommand OmniSharpGotoDefinition
+\|	delcommand OmniSharpFindSyntaxErrors
+\|	delcommand OmniSharpGetCodeActions
+\|	delcommand OmniSharpTypeLookup
+\|	delcommand OmniSharpBuild
+\|	delcommand OmniSharpBuildAsync
+\|	delcommand OmniSharpRename
+\|	delcommand OmniSharpReloadSolution
+\|	delcommand OmniSharpCodeFormat
+\|	delcommand OmniSharpStartServer
+\|	delcommand OmniSharpStopServer
+\|	delcommand OmniSharpAddToProject
+\
+\|	delcommand OmniSharpRenameTo
+\|	delcommand OmniSharpStartServerSolution
+\|	delcommand OmniSharpAddReference
+\
+\|	setlocal omnifunc<'


### PR DESCRIPTION
`:help undo_ftplugin`

> When the user does ":setfiletype xyz" the effect of the previous filetype
> should be undone.  Set the b:undo_ftplugin variable to the commands that will
> undo the settings in your filetype plugin.
