### PR TITLE
Fix setting options in BuildAsync.

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -142,8 +142,8 @@ endfunction
 
 function! OmniSharp#BuildAsync()
 	python buildcommand()
-	set errorformat=%f(%l\\,%c):\ error\ CS%n:\ %m
-	let &makeprg=b:buildcommand
+	setlocal errorformat=%f(%l\\,%c):\ error\ CS%n:\ %m
+	let &l:makeprg=b:buildcommand
 	Make
 endfunction
 

--- a/ftplugin/cs_omnisharp.vim
+++ b/ftplugin/cs_omnisharp.vim
@@ -80,4 +80,4 @@ let b:undo_ftplugin .= '
 \|	delcommand OmniSharpStartServerSolution
 \|	delcommand OmniSharpAddReference
 \
-\|	setlocal omnifunc<'
+\|	setlocal omnifunc< errorformat< makeprg<'


### PR DESCRIPTION
`makeprg` and `errorformat` is the global-local option.

`:help global-local`

> For example, you have two windows, both on C source code.  They use the global
> 'makeprg' option.  If you do this in one of the two windows:
> 
> ``` vim
> :set makeprg=gmake
> ```
> 
> then the other window will switch to the same value.  There is no need to set
> the 'makeprg' option in the other C source window too.
> However, if you start editing a Perl file in a new window, you want to use
> another 'makeprg' for it, without changing the value used for the C source
> files.  You use this command:
> 
> ``` vim
> :setlocal makeprg=perlmake
> ```
