### PR TITLE
AddReference call was always prefixing the reference with the drive path...

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -311,7 +311,11 @@ function! OmniSharp#StopServer()
 endfunction
 
 function! OmniSharp#AddReference(reference)
-	let a:ref = fnamemodify(a:reference, ':p')
+	if findfile(fnamemodify(a:reference, ':p')) != ''
+		let a:ref = fnamemodify(a:reference, ':p')
+	else
+		let a:ref = a:reference
+	endif
 	python addReference()
 endfunction
 


### PR DESCRIPTION
..., even for GAC references. We now check to see if the path is a file, if it is, prefix with full path otherwise just use what was supplied
