### PR TITLE
Only stop server if it was started by default

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -221,6 +221,9 @@ endfunction
 function! OmniSharp#StartServerIfNotRunning()
 	if !OmniSharp#ServerIsRunning()
 		call OmniSharp#StartServer()
+		if g:Omnisharp_stop_server==2
+			au VimLeavePre * call OmniSharp#StopServer()
+		endif
 	endif
 endfunction
 
@@ -256,7 +259,7 @@ function! OmniSharp#StartServer()
 		let array = split(solutionfiles, '\n')
 		if len(array) == 1
 			call OmniSharp#StartServerSolution(array[0])
-		elseif g:OmniSharp_sln_list_name != "" 
+		elseif g:OmniSharp_sln_list_name != ""
 			echom "Started with sln: " . g:OmniSharp_sln_list_name
 			call OmniSharp#StartServerSolution( g:OmniSharp_sln_list_name )
 		elseif g:OmniSharp_sln_list_index > -1 && g:OmniSharp_sln_list_index < len(array)
@@ -322,19 +325,27 @@ function! OmniSharp#AddToProject()
 	python getResponse("/addtoproject")
 endfunction
 
-function! OmniSharp#AskStopServerIfNotRunning()
+function! OmniSharp#AskStopServerIfRunning()
 	if OmniSharp#ServerIsRunning()
 		call inputsave()
 		let choice = input('Do you want to stop the OmniSharp server? (Y/n): ')
 		call inputrestore()
 		if choice != "n"
-			call OmniSharp#StopServer()
+			call OmniSharp#StopServer(1)
 		endif
 	endif
 endfunction
 
-function! OmniSharp#StopServer()
-	python getResponse("/stopserver")
+function! OmniSharp#StopServer(...)
+	if a:0 > 0
+		let force = a:1
+	else
+		let force = 0
+	endif
+
+	if force || OmniSharp#ServerIsRunning()
+		python getResponse("/stopserver")
+	endif
 endfunction
 
 function! OmniSharp#AddReference(reference)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -52,12 +52,15 @@ if g:Omnisharp_start_server==1
 endif
 
 " Automatically stop server
+" g:Omnisharp_stop_server == 0  :: never stop server
+" g:Omnisharp_stop_server == 1  :: always ask
+" g:Omnisharp_stop_server == 2  :: stop if this vim started
 if !exists("g:Omnisharp_stop_server")
-	let g:Omnisharp_stop_server = 1
+	let g:Omnisharp_stop_server = 2
 endif
 
 if g:Omnisharp_stop_server==1
-	au VimLeavePre * call OmniSharp#AskStopServerIfNotRunning()
+	au VimLeavePre * call OmniSharp#AskStopServerIfRunning()
 endif
 
 if !exists("g:Omnisharp_highlight_user_types")


### PR DESCRIPTION
Omnisharp's current setting for `g:Omnisharp_stop_server` asks to stop the server when _any_ vim session exits while the server is running.  I use numerous different vim sessions for different tasks, so this nagging quickly becomes annoying.  This change adds a new setting for `g:Omnisharp_stop_server`:

```
" g:Omnisharp_stop_server == 0  :: never stop server
" g:Omnisharp_stop_server == 1  :: always ask
" g:Omnisharp_stop_server == 2  :: stop if this vim started
```

The new setting is also the new default for `g:Omnisharp_stop_server`. It only stops the server if this vim session started it and does not ask.
