### PR TITLE
Don't override existing g:ctrlp_extensions setting

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -357,5 +357,16 @@ function! OmniSharp#AddReference(reference)
 	python addReference()
 endfunction
 
+function! OmniSharp#AppendCtrlPExtensions()
+	" Don't override settings made elsewhere
+	if !exists("g:ctrlp_extensions")
+		let g:ctrlp_extensions = []
+	endif
+	if !exists("g:OmniSharp_ctrlp_extensions_added")
+		let g:OmniSharp_ctrlp_extensions_added = 1
+		let g:ctrlp_extensions += ['findtype', 'findsymbols']
+	endif
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -2,7 +2,10 @@ if exists("g:OmniSharp_loaded")
 	finish
 endif
 
-let g:ctrlp_extensions = ['findtype', 'findsymbols']
+augroup OmniSharpCtrlP
+	au!
+	au FileType cs call OmniSharp#AppendCtrlPExtensions()
+augroup END
 
 let g:OmniSharp_loaded = 1
 


### PR DESCRIPTION
If `g:ctrlp_extensions` was set before Omnisharp loaded, that setting will be overwritten by Omnisharp.  This pull request makes two changes:
1.  Append to any existing `g:ctrlp_extensions` setting.
2.  Delay loading of Omnisharp's extensions until filetype `cs` is encountered.
