### PR TITLE
Check the server is running at UpdateBuffer()

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -226,7 +226,9 @@ function! OmniSharp#ReloadSolution()
 endfunction
 
 function! OmniSharp#UpdateBuffer()
-	python getResponse("/updatebuffer")
+	if OmniSharp#ServerIsRunning()
+		python getResponse("/updatebuffer")
+	endif
 endfunction
 
 function! OmniSharp#CodeFormat()


### PR DESCRIPTION
`Omnisharp#UpdateBuffer()` is called by `BufLeave`(https://github.com/nosami/Omnisharp/blob/master/ftplugin/cs_omnisharp.vim#L26).
If the server is not running, an error is displayed each time.
