### PR TITLE
Apply shellescape to solutionPath before launch.

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -335,7 +335,7 @@ function! OmniSharp#StartServerSolution(solutionPath)
 
 	let g:OmniSharp_running_slns += [a:solutionPath]
 	let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
-	let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . fnamemodify(a:solutionPath, ':8')
+	let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . shellescape(fnamemodify(a:solutionPath, ':8'))
 	if !has('win32') && !has('win32unix')
 		let command = 'mono ' . command
 	endif


### PR DESCRIPTION
Resolves #126

Applies shellescape to the solution path before starting the server.  A
solution path containing a space causes the OmniSharp server to crash on
launch on Win32 platforms.
