### PR TITLE
Change fname to shellescape when building command

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -336,7 +336,7 @@ function! OmniSharp#StartServerSolution(solutionPath)
 
 	let g:OmniSharp_running_slns += [a:solutionPath]
 	let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
-	let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . fnamemodify(a:solutionPath, ':8')
+	let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . shellescape(a:solutionPath, 1)
 	if !has('win32') && !has('win32unix')
 		let command = 'mono ' . command
 	endif


### PR DESCRIPTION
Resolves #127

Long file names break on win32/gvim where 8.3 filenames no longer work
(with gVim 7.4 build).  vim-dispatch has been fixed to handle quoted long
file name parameters, this commit changes fname to shellescape.

Note - vim-dispatch must be updated before applying this patch.

Tested with vim-dispatch and vimproc on win32/gvim 7.4.

See: https://github.com/tpope/vim-dispatch/commit/acfd302ffab5b67dc7a3498c107c844f70d9ee5c
