### PR TITLE
Fix indention

### DIFF
--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -19,7 +19,7 @@ function! GetCSIndent()
   let previous_line = getline(v:lnum - 1)
 
   " Hit the start of the file, use zero indent.
-  if a:lnum == 0
+  if v:lnum == 0
     return 0
   endif
 


### PR DESCRIPTION
It seemed that the `GetCsIndent()` function contained an error: it  tried to use the `lnum` argument to the function, which doesn't exist. At my installation this caused Omnisharp to throw an error whenever the function was called. It seems that `v:lnum` should've been used instead, so I fixed that. 
