### PR TITLE
Fix to prevent OmniSharp-Vim from treating a directory ended with '.sln'

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -390,6 +390,9 @@ function! OmniSharp#StartServer()
 			break
 		endif
 		let solutionfiles = globpath(folder , "*.sln", 1)
+        if isdirectory(solutionfiles)
+            let solutionfiles = ''
+        endif
 	endwhile
 
 	if solutionfiles != ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -390,9 +390,9 @@ function! OmniSharp#StartServer()
 			break
 		endif
 		let solutionfiles = globpath(folder , "*.sln", 1)
-        if isdirectory(solutionfiles)
-            let solutionfiles = ''
-        endif
+		if isdirectory(solutionfiles)
+			let solutionfiles = ''
+		endif
 	endwhile
 
 	if solutionfiles != ''


### PR DESCRIPTION
I have been working in a project that had one directory ending with '.sln' (wasn't me who created, but was there).

OmniSharp-Vim was passing this directory's path to Server as the solution file, causing wrong behavior to it. I know it is not a usual situation, but it can happen.