### PR TITLE
Use application/json for Python http requests from vim

### DIFF
--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -36,7 +36,7 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
     req = urllib2.Request(target)
     req.add_header('Content-Type', 'application/json')
     try:
-        response = urllib2.urlopen(req, json.dumps(parameters))
+        response = urllib2.urlopen(req, json.dumps(parameters), timeout)
         vim.command("let g:serverSeenRunning = 1")
         return response.read()
     except Exception:

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -189,12 +189,6 @@ def codeFormat():
 
 def fix_usings():
     response = getResponse('/fixusings')
-    f = open('/home/sdevadas/tmp/testfile.txt', 'w+')
-    f.write(response)
-    f.write("Hello world")
-    f.close()
-
-
     js = json.loads(response)
     setBuffer(js["Buffer"])
     return get_quickfix_list(response, 'AmbiguousResults')

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -33,10 +33,13 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
 
     target = urlparse.urljoin(host, endPoint)
 
+    proxy = urllib2.ProxyHandler({})
+    opener = urllib2.build_opener(proxy)
     req = urllib2.Request(target)
     req.add_header('Content-Type', 'application/json')
+
     try:
-        response = urllib2.urlopen(req, json.dumps(parameters), timeout)
+        response = opener.open(req, json.dumps(parameters), timeout)
         vim.command("let g:serverSeenRunning = 1")
         return response.read()
     except Exception:

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -32,12 +32,11 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
         host = vim.eval('b:OmniSharp_host')
 
     target = urlparse.urljoin(host, endPoint)
-    parameters = urllib.urlencode(parameters)
 
-    proxy = urllib2.ProxyHandler({})
-    opener = urllib2.build_opener(proxy)
+    req = urllib2.Request(target)
+    req.add_header('Content-Type', 'application/json')
     try:
-        response = opener.open(target, parameters, timeout)
+        response = urllib2.urlopen(req, json.dumps(parameters))
         vim.command("let g:serverSeenRunning = 1")
         return response.read()
     except Exception:


### PR DESCRIPTION
Allows omnisharp-vim to work with the v1 server and omnisharp-roslyn