### PR TITLE
Normalize formatting of vim scripts

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -8,65 +8,65 @@ let g:serverSeenRunning = 0
 let g:codeactionsinprogress = 0
 
 function! OmniSharp#Complete(findstart, base)
-	if a:findstart
-		"store the current cursor position
-		let s:column = col(".")
-		"locate the start of the word
-		let line = getline('.')
-		let start = col(".") - 1
-		let s:textBuffer = getline(1,'$')
-		while start > 0 && line[start - 1] =~ '\v[a-zA-z0-9_]'
-			let start -= 1
-		endwhile
+    if a:findstart
+        "store the current cursor position
+        let s:column = col(".")
+        "locate the start of the word
+        let line = getline('.')
+        let start = col(".") - 1
+        let s:textBuffer = getline(1,'$')
+        while start > 0 && line[start - 1] =~ '\v[a-zA-z0-9_]'
+            let start -= 1
+        endwhile
 
-		return start
-	else
-		return pyeval('Completion().get_completions("s:column", "a:base")')
-	endif
+        return start
+    else
+        return pyeval('Completion().get_completions("s:column", "a:base")')
+    endif
 endfunction
 
 function! OmniSharp#FindUsages()
-	let qf_taglist = pyeval('findUsages()')
+    let qf_taglist = pyeval('findUsages()')
 
-	" Place the tags in the quickfix window, if possible
-	if len(qf_taglist) > 0
-		call setqflist(qf_taglist)
-		copen 4
-	else
-		echo "No usages found"
-	endif
+    " Place the tags in the quickfix window, if possible
+    if len(qf_taglist) > 0
+        call setqflist(qf_taglist)
+        copen 4
+    else
+        echo "No usages found"
+    endif
 endfunction
 
 function! OmniSharp#FindImplementations()
-	let qf_taglist = pyeval("findImplementations()")
+    let qf_taglist = pyeval("findImplementations()")
 
-	if len(qf_taglist) == 0
+    if len(qf_taglist) == 0
         echo "No implementations found"
-    endif 
+    endif
 
-	if len(qf_taglist) == 1
+    if len(qf_taglist) == 1
         let usage = qf_taglist[0]
         call OmniSharp#JumpToLocation(usage.filename, usage.lnum, usage.col)
     endif
 
-	if len(qf_taglist) > 1
-		call setqflist(qf_taglist)
-		copen 4
-	endif
+    if len(qf_taglist) > 1
+        call setqflist(qf_taglist)
+        copen 4
+    endif
 endfunction
 
 function! OmniSharp#FindMembers()
-	let qf_taglist = pyeval("findMembers()")
+    let qf_taglist = pyeval("findMembers()")
 
-	" Place the tags in the quickfix window, if possible
-	if len(qf_taglist) > 1
-		call setqflist(qf_taglist)
-		copen 4
-	endif
+    " Place the tags in the quickfix window, if possible
+    if len(qf_taglist) > 1
+        call setqflist(qf_taglist)
+        copen 4
+    endif
 endfunction
 
 function! OmniSharp#NavigateUp()
-	let qf_taglist = pyeval("findMembers()")
+    let qf_taglist = pyeval("findMembers()")
     let column = col(".")
     let line = line('.')
     let l = len(qf_taglist) - 1
@@ -85,7 +85,7 @@ function! OmniSharp#NavigateUp()
 endfunction
 
 function! OmniSharp#NavigateDown()
-	let qf_taglist = pyeval("findMembers()")
+    let qf_taglist = pyeval("findMembers()")
     let column = col(".")
     let line = line('.')
     for l in range(0, len(qf_taglist) - 1)
@@ -100,7 +100,7 @@ function! OmniSharp#NavigateDown()
 endfunction
 
 function! OmniSharp#GotoDefinition()
-	python gotoDefinition()
+    python gotoDefinition()
 endfunction
 
 function! OmniSharp#JumpToLocation(filename, line, column)
@@ -133,24 +133,24 @@ function! OmniSharp#GetIssues()
     if pumvisible()
         return get(b:, "issues", [])
     endif
-	if g:serverSeenRunning == 1
+    if g:serverSeenRunning == 1
         let b:issues = pyeval("getCodeIssues()")
     endif
     return get(b:, "issues", [])
 endfunction
 
 function! OmniSharp#FixIssue()
-	python fixCodeIssue()
+    python fixCodeIssue()
 endfunction
 
 function! OmniSharp#FindSyntaxErrors()
     if pumvisible()
         return get(b:, "syntaxerrors", [])
     endif
-	if bufname('%') == ''
-		return []
-	endif
-	if g:serverSeenRunning == 1
+    if bufname('%') == ''
+        return []
+    endif
+    if g:serverSeenRunning == 1
         let b:syntaxerrors = pyeval("findSyntaxErrors()")
     endif
     return get(b:, "syntaxerrors", [])
@@ -160,10 +160,10 @@ function! OmniSharp#FindSemanticErrors()
     if pumvisible()
         return get(b:, "semanticerrors", [])
     endif
-	if bufname('%') == ''
-		return []
-	endif
-	if g:serverSeenRunning == 1
+    if bufname('%') == ''
+        return []
+    endif
+    if g:serverSeenRunning == 1
         let b:semanticerrors = pyeval("findSemanticErrors()")
     endif
     return get(b:, "semanticerrors", [])
@@ -173,45 +173,45 @@ endfunction
 " This is useful to accumulate results from successive operations.
 " Global function that can be called from other scripts.
 function! s:GoScratch()
-  let done = 0
-  for i in range(1, winnr('$'))
-    execute i . 'wincmd w'
-    if &buftype == 'nofile'
-      let done = 1
-      break
+    let done = 0
+    for i in range(1, winnr('$'))
+        execute i . 'wincmd w'
+        if &buftype == 'nofile'
+            let done = 1
+            break
+        endif
+    endfor
+    if !done
+        new
+        setlocal buftype=nofile bufhidden=hide noswapfile
     endif
-  endfor
-  if !done
-    new
-    setlocal buftype=nofile bufhidden=hide noswapfile
-  endif
 endfunction
 
 
 function! OmniSharp#TypeLookupWithoutDocumentation()
-	if g:serverSeenRunning == 1
-		call OmniSharp#TypeLookup('False')
-	endif
+    if g:serverSeenRunning == 1
+        call OmniSharp#TypeLookup('False')
+    endif
 endfunction
 
 function! OmniSharp#TypeLookupWithDocumentation()
-	call OmniSharp#TypeLookup('True')
+    call OmniSharp#TypeLookup('True')
 endfunction
 
 function! OmniSharp#TypeLookup(includeDocumentation)
-	let type = ""
+    let type = ""
 
-	if g:OmniSharp_typeLookupInPreview || a:includeDocumentation == 'True'
+    if g:OmniSharp_typeLookupInPreview || a:includeDocumentation == 'True'
         python typeLookup("type")
-		call s:GoScratch()
-		python vim.current.window.height = 5
-		set modifiable
-		exec 'python vim.current.buffer[:] = ["' . type . '"] + """' . s:documentation . '""".splitlines()'
-		set nomodifiable
-		"Return to original window
-		wincmd p
+        call s:GoScratch()
+        python vim.current.window.height = 5
+        set modifiable
+        exec 'python vim.current.buffer[:] = ["' . type . '"] + """' . s:documentation . '""".splitlines()'
+        set nomodifiable
+        "Return to original window
+        wincmd p
     else
-		let line = line('.')
+        let line = line('.')
         let found_line_in_loc_list = 0
         "don't display type lookup if we have a syntastic error
         if exists(':SyntasticCheck')
@@ -227,7 +227,7 @@ function! OmniSharp#TypeLookup(includeDocumentation)
             python typeLookup("type")
             call OmniSharp#Echo(type)
         endif
-	endif
+    endif
 endfunction
 
 function! OmniSharp#Echo(message)
@@ -235,44 +235,44 @@ function! OmniSharp#Echo(message)
 endfunction
 
 function! OmniSharp#Rename()
-	let renameto = inputdialog("Rename to:", expand('<cword>'))
-	if renameto != ''
-		call OmniSharp#RenameTo(renameto)
-	endif
+    let renameto = inputdialog("Rename to:", expand('<cword>'))
+    if renameto != ''
+        call OmniSharp#RenameTo(renameto)
+    endif
 endfunction
 
 function! OmniSharp#RenameTo(renameto)
-	let qf_taglist = []
-	python renameTo()
+    let qf_taglist = []
+    python renameTo()
 endfunction
 
 function! OmniSharp#Build()
     let qf_taglist = pyeval("build()")
 
-	" Place the tags in the quickfix window, if possible
-	if len(qf_taglist) > 0
-		call setqflist(qf_taglist)
-		copen 4
-	endif
+    " Place the tags in the quickfix window, if possible
+    if len(qf_taglist) > 0
+        call setqflist(qf_taglist)
+        copen 4
+    endif
 endfunction
 
 function! OmniSharp#BuildAsync()
     python buildcommand()
     let &l:makeprg=b:buildcommand
-	setlocal errorformat=\ %#%f(%l\\\,%c):\ %m
-	Make
+    setlocal errorformat=\ %#%f(%l\\\,%c):\ %m
+    Make
 endfunction
 
 function! OmniSharp#RunTests(mode)
-	wall 
-	python buildcommand()
+    wall
+    python buildcommand()
 
-	if a:mode != 'last'
-		python getTestCommand()
-	endif
+    if a:mode != 'last'
+        python getTestCommand()
+    endif
 
     let s:cmdheight=&cmdheight
-    set cmdheight=5 
+    set cmdheight=5
     let b:dispatch = b:buildcommand . " && " . s:testcommand
     if executable("sed")
         " don't match on <filename unknown>:0
@@ -281,241 +281,243 @@ function! OmniSharp#RunTests(mode)
     let &l:makeprg=b:dispatch
     "errorformat=msbuild,nunit stack trace
     setlocal errorformat=\ %#%f(%l\\\,%c):\ %m,%m\ in\ %#%f:%l
-	Make
+    Make
     let &cmdheight = s:cmdheight
 endfunction
 
 function! OmniSharp#EnableTypeHighlightingForBuffer()
-	hi link CSharpUserType Type
-	exec "syn keyword CSharpUserType " . s:allUserTypes
-	exec "syn keyword csInterfaceDeclaration " . s:allUserInterfaces
+    hi link CSharpUserType Type
+    exec "syn keyword CSharpUserType " . s:allUserTypes
+    exec "syn keyword csInterfaceDeclaration " . s:allUserInterfaces
 endfunction
 
 function! OmniSharp#EnableTypeHighlighting()
 
-	if !OmniSharp#ServerIsRunning() || !empty(s:allUserTypes)
-		return
-	endif
+    if !OmniSharp#ServerIsRunning() || !empty(s:allUserTypes)
+        return
+    endif
 
-	python lookupAllUserTypes()
+    python lookupAllUserTypes()
 
-	let startBuf = bufnr("%")
-	" Perform highlighting for existing buffers
-	bufdo if &ft == 'cs' | call OmniSharp#EnableTypeHighlightingForBuffer() | endif
-	exec "b ". startBuf
+    let startBuf = bufnr("%")
+    " Perform highlighting for existing buffers
+    bufdo if &ft == 'cs' | call OmniSharp#EnableTypeHighlightingForBuffer() | endif
+exec "b ". startBuf
 
-	call OmniSharp#EnableTypeHighlightingForBuffer()
+call OmniSharp#EnableTypeHighlightingForBuffer()
 
-	augroup _omnisharp
-		au!
-		autocmd BufRead *.cs call OmniSharp#EnableTypeHighlightingForBuffer()
-	augroup END
+augroup _omnisharp
+    au!
+    autocmd BufRead *.cs call OmniSharp#EnableTypeHighlightingForBuffer()
+augroup END
 endfunction
 
 function! OmniSharp#ReloadSolution()
-	python getResponse("/reloadsolution")
+    python getResponse("/reloadsolution")
 endfunction
 
 function! OmniSharp#UpdateBuffer()
-	if OmniSharp#BufferHasChanged() == 1
+    if OmniSharp#BufferHasChanged() == 1
         python getResponse("/updatebuffer")
     endif
 endfunction
 
 function! OmniSharp#BufferHasChanged()
-	if g:serverSeenRunning == 1
+    if g:serverSeenRunning == 1
         if b:changedtick != get(b:, "Omnisharp_UpdateChangeTick", -1)
             let b:Omnisharp_UpdateChangeTick = b:changedtick
             return 1
             echoerr 'wtf'
         endif
-	endif
+    endif
     return 0
 endfunction
 
 function! OmniSharp#CodeFormat()
-	python codeFormat()
+    python codeFormat()
 endfunction
 
 function! OmniSharp#FixUsings()
-	let qf_taglist = pyeval('fix_usings()')
+    let qf_taglist = pyeval('fix_usings()')
 
-	if len(qf_taglist) > 0
-		call setqflist(qf_taglist)
-		copen
-	endif
+    if len(qf_taglist) > 0
+        call setqflist(qf_taglist)
+        copen
+    endif
 endfunction
 
 function! OmniSharp#ServerIsRunning()
-	try
-		python vim.command("let s:alive = '" + getResponse("/checkalivestatus", None, 0.2) + "'");
-		return s:alive == 'true'
-	catch
-		return 0
-	endtry
+    try
+        python vim.command("let s:alive = '" + getResponse("/checkalivestatus", None, 0.2) + "'");
+        return s:alive == 'true'
+    catch
+        return 0
+    endtry
 endfunction
 
 function! OmniSharp#StartServerIfNotRunning()
-	if !OmniSharp#ServerIsRunning()
-		call OmniSharp#StartServer()
-		if g:Omnisharp_stop_server==2
-			au VimLeavePre * call OmniSharp#StopServer()
-		endif
-	endif
+    if !OmniSharp#ServerIsRunning()
+        call OmniSharp#StartServer()
+        if g:Omnisharp_stop_server==2
+            au VimLeavePre * call OmniSharp#StopServer()
+        endif
+    endif
 endfunction
 
 function! OmniSharp#FugitiveCheck()
-	if match( expand( '<afile>:p' ), "fugitive:///" ) == 0
-		return 1
-	else
-	   return 0
-	endif
+    if match( expand( '<afile>:p' ), "fugitive:///" ) == 0
+        return 1
+    else
+        return 0
+    endif
 endfunction
 
 function! OmniSharp#StartServer()
-	if OmniSharp#FugitiveCheck()
-		return
-	endif
+    if OmniSharp#FugitiveCheck()
+        return
+    endif
 
-	"get the path for the current buffer
-	let folder = expand('%:p:h')
-	let solutionfiles = globpath(folder, "*.sln", 1)
+    "get the path for the current buffer
+    let folder = expand('%:p:h')
+    let solutionfiles = globpath(folder, "*.sln", 1)
 
-	while (solutionfiles == '')
-		let lastfolder = folder
-		"traverse up a level
+    while (solutionfiles == '')
+        let lastfolder = folder
+        "traverse up a level
 
-		let folder = fnamemodify(folder, ':p:h:h')
-		if folder == lastfolder
-			break
-		endif
-		let solutionfiles = globpath(folder , "*.sln", 1)
-		if isdirectory(solutionfiles)
-			let solutionfiles = ''
-		endif
-	endwhile
+        let folder = fnamemodify(folder, ':p:h:h')
+        if folder == lastfolder
+            break
+        endif
+        let solutionfiles = globpath(folder , "*.sln", 1)
+        if isdirectory(solutionfiles)
+            let solutionfiles = ''
+        endif
+    endwhile
 
-	if solutionfiles != ''
-		let array = split(solutionfiles, '\n')
-		if len(array) == 1
-			call OmniSharp#StartServerSolution(array[0])
-		elseif g:OmniSharp_sln_list_name != ""
-			echom "Started with sln: " . g:OmniSharp_sln_list_name
-			call OmniSharp#StartServerSolution( g:OmniSharp_sln_list_name )
-		elseif g:OmniSharp_sln_list_index > -1 && g:OmniSharp_sln_list_index < len(array)
-			echom "Started with sln: " . array[g:OmniSharp_sln_list_index]
-			call OmniSharp#StartServerSolution( array[g:OmniSharp_sln_list_index]  )
-		else
-			echom "sln: " . g:OmniSharp_sln_list_name
-			let index = 1
-			if g:OmniSharp_autoselect_existing_sln
-				for solutionfile in array
-					if index( g:OmniSharp_running_slns, solutionfile ) >= 0
-						return
-					endif
-				endfor
-			endif
+    if solutionfiles != ''
+        let array = split(solutionfiles, '\n')
+        if len(array) == 1
+            call OmniSharp#StartServerSolution(array[0])
+        elseif g:OmniSharp_sln_list_name != ""
+            echom "Started with sln: " . g:OmniSharp_sln_list_name
+            call OmniSharp#StartServerSolution( g:OmniSharp_sln_list_name )
+        elseif g:OmniSharp_sln_list_index > -1 && g:OmniSharp_sln_list_index < len(array)
+            echom "Started with sln: " . array[g:OmniSharp_sln_list_index]
+            call OmniSharp#StartServerSolution( array[g:OmniSharp_sln_list_index]  )
+        else
+            echom "sln: " . g:OmniSharp_sln_list_name
+            let index = 1
+            if g:OmniSharp_autoselect_existing_sln
+                for solutionfile in array
+                    if index( g:OmniSharp_running_slns, solutionfile ) >= 0
+                        return
+                    endif
+                endfor
+            endif
 
-			for solutionfile in array
-				echo index . ' - '. solutionfile
-				let index = index + 1
-			endfor
+            for solutionfile in array
+                echo index . ' - '. solutionfile
+                let index = index + 1
+            endfor
 
-			let option = 0
-			let optionstring = input('Choose a solution file and press enter ')
-			let len = strlen(optionstring) - 1
-			let i = 0
-			while i <= len
-				let c = strpart(optionstring, len-i, 1)
-				if (c < '0' && c > '9')
-					return
-				endif
-				let option += c * float2nr(pow(10, i))
-				let i += 1
-			endwhile
+            let option = 0
+            let optionstring = input('Choose a solution file and press enter ')
+            let len = strlen(optionstring) - 1
+            let i = 0
+            while i <= len
+                let c = strpart(optionstring, len-i, 1)
+                if (c < '0' && c > '9')
+                    return
+                endif
+                let option += c * float2nr(pow(10, i))
+                let i += 1
+            endwhile
 
-			if (option == 0 || option > len(array))
-				return
-			endif
+            if (option == 0 || option > len(array))
+                return
+            endif
 
-			call OmniSharp#StartServerSolution(array[option - 1])
-		endif
-	else
-		echoerr "Did not find a solution file "
-	endif
+            call OmniSharp#StartServerSolution(array[option - 1])
+        endif
+    else
+        echoerr "Did not find a solution file "
+    endif
 endfunction
 
 function! OmniSharp#StartServerSolution(solutionPath)
 
-	let g:OmniSharp_running_slns += [a:solutionPath]
-	let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
-	let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . shellescape(a:solutionPath, 1)
-	if !has('win32') && !has('win32unix')
-		let command = 'mono ' . command
-	endif
-	call OmniSharp#RunAsyncCommand(command)
+    let g:OmniSharp_running_slns += [a:solutionPath]
+    let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
+    let command = shellescape(s:omnisharp_server,1) . ' -p ' . port . ' -s ' . shellescape(a:solutionPath, 1)
+    if !has('win32') && !has('win32unix')
+        let command = 'mono ' . command
+    endif
+    call OmniSharp#RunAsyncCommand(command)
 endfunction
 
 function! OmniSharp#RunAsyncCommand(command)
-	let is_vimproc = 0
-	silent! let is_vimproc = vimproc#version()
-	if exists(':Make')
-		call dispatch#start(a:command, {'background': 1})
-	else
-		if is_vimproc
-			call vimproc#system_gui(substitute(a:command, '\\', '\/', 'g'))
-		else
-			echoerr 'Please install either vim-dispatch or vimproc plugin to use this feature'
-		endif
-	endif
+    let is_vimproc = 0
+    silent! let is_vimproc = vimproc#version()
+    if exists(':Make')
+        call dispatch#start(a:command, {'background': 1})
+    else
+        if is_vimproc
+            call vimproc#system_gui(substitute(a:command, '\\', '\/', 'g'))
+        else
+            echoerr 'Please install either vim-dispatch or vimproc plugin to use this feature'
+        endif
+    endif
 endfunction
 
 function! OmniSharp#AddToProject()
-	python getResponse("/addtoproject")
+    python getResponse("/addtoproject")
 endfunction
 
 function! OmniSharp#AskStopServerIfRunning()
-	if OmniSharp#ServerIsRunning()
-		call inputsave()
-		let choice = input('Do you want to stop the OmniSharp server? (Y/n): ')
-		call inputrestore()
-		if choice != "n"
-			call OmniSharp#StopServer(1)
-		endif
-	endif
+    if OmniSharp#ServerIsRunning()
+        call inputsave()
+        let choice = input('Do you want to stop the OmniSharp server? (Y/n): ')
+        call inputrestore()
+        if choice != "n"
+            call OmniSharp#StopServer(1)
+        endif
+    endif
 endfunction
 
 function! OmniSharp#StopServer(...)
-	if a:0 > 0
-		let force = a:1
-	else
-		let force = 0
-	endif
+    if a:0 > 0
+        let force = a:1
+    else
+        let force = 0
+    endif
 
-	if force || OmniSharp#ServerIsRunning()
-		python getResponse("/stopserver")
-	endif
+    if force || OmniSharp#ServerIsRunning()
+        python getResponse("/stopserver")
+    endif
 endfunction
 
 function! OmniSharp#AddReference(reference)
-	if findfile(fnamemodify(a:reference, ':p')) != ''
-		let a:ref = fnamemodify(a:reference, ':p')
-	else
-		let a:ref = a:reference
-	endif
-	python addReference()
+    if findfile(fnamemodify(a:reference, ':p')) != ''
+        let a:ref = fnamemodify(a:reference, ':p')
+    else
+        let a:ref = a:reference
+    endif
+    python addReference()
 endfunction
 
 function! OmniSharp#AppendCtrlPExtensions()
-	" Don't override settings made elsewhere
-	if !exists("g:ctrlp_extensions")
-		let g:ctrlp_extensions = []
-	endif
-	if !exists("g:OmniSharp_ctrlp_extensions_added")
-		let g:OmniSharp_ctrlp_extensions_added = 1
-		let g:ctrlp_extensions += ['findtype', 'findsymbols', 'findcodeactions']
-	endif
+    " Don't override settings made elsewhere
+    if !exists("g:ctrlp_extensions")
+        let g:ctrlp_extensions = []
+    endif
+    if !exists("g:OmniSharp_ctrlp_extensions_added")
+        let g:OmniSharp_ctrlp_extensions_added = 1
+        let g:ctrlp_extensions += ['findtype', 'findsymbols', 'findcodeactions']
+    endif
 endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
+
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -36,14 +36,14 @@
 " + specinput: enable special inputs '..' and '@cd' (disabled by default)
 "
 call add(g:ctrlp_ext_vars, {
-	\ 'init': 'ctrlp#OmniSharp#findcodeactions#init()',
-	\ 'accept': 'ctrlp#OmniSharp#findcodeactions#accept',
-	\ 'exit': 'ctrlp#OmniSharp#findcodeactions#exit()',
-	\ 'lname': 'Find Code Actions',
-	\ 'sname': 'code actions',
-	\ 'type': 'line',
-	\ 'sort': 1,
-	\ })
+      \ 'init': 'ctrlp#OmniSharp#findcodeactions#init()',
+      \ 'accept': 'ctrlp#OmniSharp#findcodeactions#accept',
+      \ 'exit': 'ctrlp#OmniSharp#findcodeactions#exit()',
+      \ 'lname': 'Find Code Actions',
+      \ 'sname': 'code actions',
+      \ 'type': 'line',
+      \ 'sort': 1,
+      \ })
 
 
 function! ctrlp#OmniSharp#findcodeactions#setactions(mode, actions)
@@ -86,7 +86,7 @@ let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
 
 " Allow it to be called later
 function! ctrlp#OmniSharp#findcodeactions#id()
-	return s:id
+  return s:id
 endfunction
 
-" vim:nofen:fdl=0:ts=2:sw=2:sts=2
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -1,8 +1,8 @@
 
 " Load guard
 if ( exists('g:OmniSharp_loaded_ctrlp_findsymbols') && g:OmniSharp_loaded_ctrlp_findsymbols )
-	\ || v:version < 700 || &cp
-	finish
+      \ || v:version < 700 || &cp
+  finish
 endif
 let g:loaded_ctrlp_OmniSharp_findsymbols = 1
 
@@ -37,13 +37,13 @@ let g:loaded_ctrlp_OmniSharp_findsymbols = 1
 " + specinput: enable special inputs '..' and '@cd' (disabled by default)
 "
 call add(g:ctrlp_ext_vars, {
-	\ 'init': 'ctrlp#OmniSharp#findsymbols#init()',
-	\ 'accept': 'ctrlp#OmniSharp#findsymbols#accept',
-	\ 'lname': 'Find Symbols',
-	\ 'sname': 'symbols',
-	\ 'type': 'tabs',
-	\ 'sort': 1,
-	\ })
+      \ 'init': 'ctrlp#OmniSharp#findsymbols#init()',
+      \ 'accept': 'ctrlp#OmniSharp#findsymbols#accept',
+      \ 'lname': 'Find Symbols',
+      \ 'sname': 'symbols',
+      \ 'type': 'tabs',
+      \ 'sort': 1,
+      \ })
 
 
 " Provide a list of strings to search in
@@ -51,16 +51,16 @@ call add(g:ctrlp_ext_vars, {
 " Return: a Vim's List
 "
 function! ctrlp#OmniSharp#findsymbols#init()
-	if !OmniSharp#ServerIsRunning() 
-		return
-	endif
+  if !OmniSharp#ServerIsRunning()
+    return
+  endif
 
-	let s:quickfixes = pyeval("findSymbols()")
-	let symbols = []
-	for quickfix in s:quickfixes
-		call add(symbols, quickfix.text)
-	endfor
-	return symbols
+  let s:quickfixes = pyeval("findSymbols()")
+  let symbols = []
+  for quickfix in s:quickfixes
+    call add(symbols, quickfix.text)
+  endfor
+  return symbols
 endfunction
 
 
@@ -73,13 +73,13 @@ endfunction
 "
 function! ctrlp#OmniSharp#findsymbols#accept(mode, str)
   call ctrlp#exit()
-	for quickfix in s:quickfixes
-		if quickfix.text == a:str
-			break
-		endif
-	endfor
+  for quickfix in s:quickfixes
+    if quickfix.text == a:str
+      break
+    endif
+  endfor
   echo quickfix.filename
-	call  OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col)
+  call  OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col)
 endfunction
 
 " Give the extension an ID
@@ -87,7 +87,7 @@ let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
 
 " Allow it to be called later
 function! ctrlp#OmniSharp#findsymbols#id()
-	return s:id
+  return s:id
 endfunction
 
-" vim:nofen:fdl=0:ts=2:sw=2:sts=2
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/OmniSharp/findtype.vim
+++ b/autoload/ctrlp/OmniSharp/findtype.vim
@@ -1,7 +1,7 @@
 " Load guard
 if ( exists('g:loaded_ctrlp_OmniSharp_findtype') && g:loaded_ctrlp_OmniSharp_findtype )
-	\ || v:version < 700 || &cp
-	finish
+      \ || v:version < 700 || &cp
+  finish
 endif
 let g:loaded_ctrlp_OmniSharp_findtype = 1
 
@@ -36,13 +36,13 @@ let g:loaded_ctrlp_OmniSharp_findtype = 1
 " + specinput: enable special inputs '..' and '@cd' (disabled by default)
 "
 call add(g:ctrlp_ext_vars, {
-	\ 'init': 'ctrlp#OmniSharp#findtype#init()',
-	\ 'accept': 'ctrlp#OmniSharp#findtype#accept',
-	\ 'lname': 'Find Types',
-	\ 'sname': 'types',
-	\ 'type': 'tabs',
-	\ 'sort': 1,
-	\ })
+      \ 'init': 'ctrlp#OmniSharp#findtype#init()',
+      \ 'accept': 'ctrlp#OmniSharp#findtype#accept',
+      \ 'lname': 'Find Types',
+      \ 'sname': 'types',
+      \ 'type': 'tabs',
+      \ 'sort': 1,
+      \ })
 
 
 " Provide a list of strings to search in
@@ -50,16 +50,16 @@ call add(g:ctrlp_ext_vars, {
 " Return: a Vim's List
 "
 function! ctrlp#OmniSharp#findtype#init()
-	if !OmniSharp#ServerIsRunning() 
-		return
-	endif
+  if !OmniSharp#ServerIsRunning()
+    return
+  endif
 
-	let s:quickfixes = pyeval("findTypes()")
-	let types = []
-	for quickfix in s:quickfixes
-		call add(types, quickfix.text)
-	endfor
-	return types
+  let s:quickfixes = pyeval("findTypes()")
+  let types = []
+  for quickfix in s:quickfixes
+    call add(types, quickfix.text)
+  endfor
+  return types
 endfunction
 
 
@@ -71,12 +71,12 @@ endfunction
 "  a:str    the selected string
 "
 function! ctrlp#OmniSharp#findtype#accept(mode, str)
-	call ctrlp#OmniSharp#findtype#exit()
-	for quickfix in s:quickfixes
-		if quickfix.text == a:str
-			break
-		endif
-	endfor
+  call ctrlp#OmniSharp#findtype#exit()
+  for quickfix in s:quickfixes
+    if quickfix.text == a:str
+      break
+    endif
+  endfor
   call  OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col)
 endfunction
 
@@ -101,7 +101,7 @@ let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
 
 " Allow it to be called later
 function! ctrlp#OmniSharp#findtype#id()
-	return s:id
+  return s:id
 endfunction
 
-" vim:nofen:fdl=0:ts=2:sw=2:sts=2
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/ftplugin/cs.vim
+++ b/ftplugin/cs.vim
@@ -4,19 +4,19 @@ if !exists('g:omnicomplete_fetch_full_documentation')
 endif
 
 augroup plugin-OmniSharp
-	autocmd! * <buffer>
+    autocmd! * <buffer>
 
-	autocmd BufLeave <buffer>
-	\ 	if !pumvisible()
-	\|		call OmniSharp#UpdateBuffer()
-	\|	endif	
-	
+    autocmd BufLeave <buffer>
+                \ 	if !pumvisible()
+                \|		call OmniSharp#UpdateBuffer()
+                \|	endif
+
 augroup END
 
 call OmniSharp#AppendCtrlPExtensions()
 
 if get(g:, 'Omnisharp_start_server', 0) == 1
-	call OmniSharp#StartServerIfNotRunning()
+    call OmniSharp#StartServerIfNotRunning()
 endif
 
 " Commands
@@ -50,50 +50,52 @@ command! -buffer -bar OmniSharpTypeLookup          call OmniSharp#TypeLookupWith
 
 
 command! -buffer -nargs=1 OmniSharpRenameTo
-\	call OmniSharp#RenameTo(<q-args>)
+            \	call OmniSharp#RenameTo(<q-args>)
 
 command! -buffer -nargs=1 -complete=file
-\	OmniSharpStartServerSolution
-\	call OmniSharp#StartServerSolution(<q-args>)
+            \	OmniSharpStartServerSolution
+            \	call OmniSharp#StartServerSolution(<q-args>)
 
-command! -buffer -nargs=1 -complete=file OmniSharpAddReference         
-\   call OmniSharp#AddReference(<q-args>)
+command! -buffer -nargs=1 -complete=file OmniSharpAddReference
+            \   call OmniSharp#AddReference(<q-args>)
 
 
 if exists('b:undo_ftplugin')
-	let b:undo_ftplugin .= ' | '
+    let b:undo_ftplugin .= ' | '
 else
-	let b:undo_ftplugin = ''
+    let b:undo_ftplugin = ''
 endif
 let b:undo_ftplugin .= '
-\	execute "autocmd! plugin-OmniSharp * <buffer>"
-\
-\|	delcommand OmniSharpAddReference
-\|	delcommand OmniSharpAddToProject
-\|	delcommand OmniSharpBuild
-\|	delcommand OmniSharpBuildAsync
-\|	delcommand OmniSharpCodeFormat
-\|	delcommand OmniSharpFindImplementations
-\|	delcommand OmniSharpFindSymbol
-\|	delcommand OmniSharpFindSyntaxErrors
-\|	delcommand OmniSharpFindType
-\|	delcommand OmniSharpFindUsages
-\|	delcommand OmniSharpFixIssue
-\|	delcommand OmniSharpFixUsings
-\|	delcommand OmniSharpGetCodeActions
-\|	delcommand OmniSharpGotoDefinition
-\|	delcommand OmniSharpNavigateUp
-\|	delcommand OmniSharpNavigateDown
-\|	delcommand OmniSharpReloadSolution
-\|	delcommand OmniSharpRename
-\|	delcommand OmniSharpRenameTo
-\|	delcommand OmniSharpStartServer
-\|	delcommand OmniSharpStartServerSolution
-\|	delcommand OmniSharpStopServer
-\|	delcommand OmniSharpTypeLookup
-\|  delcommand OmniSharpRunAllTests
-\|  delcommand OmniSharpRunLastTests
-\|  delcommand OmniSharpRunTestFixture
-\|  delcommand OmniSharpRunTests
-\
-\|	setlocal omnifunc< errorformat< makeprg<'
+            \	execute "autocmd! plugin-OmniSharp * <buffer>"
+            \
+            \|	delcommand OmniSharpAddReference
+            \|	delcommand OmniSharpAddToProject
+            \|	delcommand OmniSharpBuild
+            \|	delcommand OmniSharpBuildAsync
+            \|	delcommand OmniSharpCodeFormat
+            \|	delcommand OmniSharpFindImplementations
+            \|	delcommand OmniSharpFindSymbol
+            \|	delcommand OmniSharpFindSyntaxErrors
+            \|	delcommand OmniSharpFindType
+            \|	delcommand OmniSharpFindUsages
+            \|	delcommand OmniSharpFixIssue
+            \|	delcommand OmniSharpFixUsings
+            \|	delcommand OmniSharpGetCodeActions
+            \|	delcommand OmniSharpGotoDefinition
+            \|	delcommand OmniSharpNavigateUp
+            \|	delcommand OmniSharpNavigateDown
+            \|	delcommand OmniSharpReloadSolution
+            \|	delcommand OmniSharpRename
+            \|	delcommand OmniSharpRenameTo
+            \|	delcommand OmniSharpStartServer
+            \|	delcommand OmniSharpStartServerSolution
+            \|	delcommand OmniSharpStopServer
+            \|	delcommand OmniSharpTypeLookup
+            \|  delcommand OmniSharpRunAllTests
+            \|  delcommand OmniSharpRunLastTests
+            \|  delcommand OmniSharpRunTestFixture
+            \|  delcommand OmniSharpRunTests
+            \
+            \|	setlocal omnifunc< errorformat< makeprg<'
+
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -5,7 +5,7 @@
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
-   finish
+    finish
 endif
 let b:did_indent = 1
 
@@ -15,20 +15,22 @@ setlocal indentexpr=GetCSIndent(v:lnum)
 
 function! GetCSIndent(lnum)
 
-  let this_line = getline(a:lnum)
-  let previous_line = getline(a:lnum - 1)
+    let this_line = getline(a:lnum)
+    let previous_line = getline(a:lnum - 1)
 
-  " Hit the start of the file, use zero indent.
-  if a:lnum == 0
-    return 0
-  endif
+    " Hit the start of the file, use zero indent.
+    if a:lnum == 0
+        return 0
+    endif
 
-  " If previous_line is an attribute line:
-  if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
-    let ind = indent(a:lnum - 1)
-    return ind
-  else
-    return cindent(a:lnum)
-  endif
+    " If previous_line is an attribute line:
+    if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+        let ind = indent(a:lnum - 1)
+        return ind
+    else
+        return cindent(a:lnum)
+    endif
 
 endfunction
+
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,5 +1,5 @@
 if exists("g:OmniSharp_loaded")
-	finish
+    finish
 endif
 
 let g:OmniSharp_loaded = 1
@@ -34,19 +34,19 @@ let g:OmniSharp_BufWritePreSyntaxCheck = get(g:, "OmniSharp_BufWritePreSyntaxChe
 let g:OmniSharp_CursorHoldSyntaxCheck = get(g:, "OmniSharp_CursorHoldSyntaxCheck", 0)
 
 let g:OmniSharp_sln_list_index =
-	\ get( g:, "OmniSharp_sln_list_index", -1 )
+            \ get( g:, "OmniSharp_sln_list_index", -1 )
 
 let g:OmniSharp_sln_list_name =
-	\get( g:, "OmniSharp_sln_list_name", "" )
+            \get( g:, "OmniSharp_sln_list_name", "" )
 
 let g:OmniSharp_autoselect_existing_sln =
-	\ get( g:, "OmniSharp_autoselect_existing_sln", 1 )
+            \ get( g:, "OmniSharp_autoselect_existing_sln", 1 )
 
 let g:OmniSharp_running_slns = []
 
 " Automatically start server
 if !exists("g:Omnisharp_start_server")
-	let g:Omnisharp_start_server = 1
+    let g:Omnisharp_start_server = 1
 endif
 
 " Automatically stop server
@@ -54,13 +54,15 @@ endif
 " g:Omnisharp_stop_server == 1  :: always ask
 " g:Omnisharp_stop_server == 2  :: stop if this vim started
 if !exists("g:Omnisharp_stop_server")
-	let g:Omnisharp_stop_server = 2
+    let g:Omnisharp_stop_server = 2
 endif
 
 if g:Omnisharp_stop_server==1
-	au VimLeavePre * call OmniSharp#AskStopServerIfRunning()
+    au VimLeavePre * call OmniSharp#AskStopServerIfRunning()
 endif
 
 if !exists("g:Omnisharp_highlight_user_types")
-	let g:Omnisharp_highlight_user_types = 0
+    let g:Omnisharp_highlight_user_types = 0
 endif
+
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -20,14 +20,14 @@ set cpo&vim
 func! SummaryFolds()
     let firstLine = getline(v:foldstart)
     if firstLine =~ "<summary>"
-	let line = getline(v:foldstart + 1)
-	let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
-	return "+--" . " Summary: " . sub
+        let line = getline(v:foldstart + 1)
+        let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
+        return "+--" . " Summary: " . sub
     elseif firstLine =~ "# region"
-	let sub = substitute(firstLine, '\s*\# region ', '', 'g')
-	return "+-- Region: " . sub
+        let sub = substitute(firstLine, '\s*\# region ', '', 'g')
+        return "+-- Region: " . sub
     else
-	return "+-- " . firstLine
+        return "+-- " . firstLine
     endif
 endfunc
 
@@ -107,10 +107,10 @@ hi def link xmlRegion Comment
 
 " [1] 9.5 Pre-processing directives
 syn region	csPreCondit
-    \ start="^\s*#\s*\(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\)"
-    \ skip="\\$" end="$" contains=csComment keepend
+            \ start="^\s*#\s*\(define\|undef\|if\|elif\|else\|endif\|line\|error\|warning\)"
+                \ skip="\\$" end="$" contains=csComment keepend
 syn region csRegion matchgroup=csPreCondit start="^\s*#\s*region.*$"
-    \ end="^\s*#\s*endregion" transparent fold contains=TOP
+            \ end="^\s*#\s*endregion" transparent fold contains=TOP
 syn region csSummary start="^\s*/// <summary" end="^\(\s*///\)\@!" transparent fold keepend
 
 
@@ -192,4 +192,4 @@ let b:current_syntax = "cs"
 let &cpo = s:cs_cpo_save
 unlet s:cs_cpo_save
 
-" vim: ts=8
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/syntax_checkers/cs/issues.vim
+++ b/syntax_checkers/cs/issues.vim
@@ -21,10 +21,10 @@ function! SyntaxCheckers_cs_issues_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-    \ 'filetype': 'cs',
-    \ 'name': 'issues'})
+            \ 'filetype': 'cs',
+            \ 'name': 'issues'})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
-" vim: set et sts=4 sw=4:
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/syntax_checkers/cs/semantic.vim
+++ b/syntax_checkers/cs/semantic.vim
@@ -20,10 +20,10 @@ function! SyntaxCheckers_cs_semantic_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-    \ 'filetype': 'cs',
-    \ 'name': 'semantic'})
+            \ 'filetype': 'cs',
+            \ 'name': 'semantic'})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
-" vim: set et sts=4 sw=4:
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2

--- a/syntax_checkers/cs/syntax.vim
+++ b/syntax_checkers/cs/syntax.vim
@@ -20,10 +20,10 @@ function! SyntaxCheckers_cs_syntax_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
-    \ 'filetype': 'cs',
-    \ 'name': 'syntax'})
+            \ 'filetype': 'cs',
+            \ 'name': 'syntax'})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
-" vim: set et sts=4 sw=4:
+" vim:nofen:fdl=0:et:ts=2:sw=2:sts=2


### PR DESCRIPTION
Per our discussion in the last PR, I've used the modeline found in the CtrlP plugins with the addition of `et` (`expandtab`). Only a couple other files had modelines that were inconsistent and didn't contain all typical formatting options.