### PR TITLE
Initial support for omnisharp-roslyn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "server"]
 	path = server
 	url = https://github.com/nosami/OmniSharpServer.git
+[submodule "omnisharp-roslyn"]
+	path = omnisharp-roslyn
+	url = https://github.com/OmniSharp/omnisharp-roslyn.git

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -1,7 +1,12 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+"Set g:omnisharp_server_type to 'roslyn' or 'v1'
+let g:omnisharp_server_type = 'roslyn'
 let s:omnisharp_server = join([expand('<sfile>:p:h:h'), 'server', 'OmniSharp', 'bin', 'Debug', 'OmniSharp.exe'], '/')
+let s:omnisharp_roslyn_server = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'scripts', 'Omnisharp'], '/')
+let s:server_files = '*.sln'
+let s:roslyn_server_files = 'project.json'
 let s:allUserTypes = ''
 let s:allUserInterfaces = ''
 let g:serverSeenRunning = 0
@@ -380,6 +385,9 @@ function! OmniSharp#StartServer()
 	"get the path for the current buffer
 	let folder = expand('%:p:h')
 	let solutionfiles = globpath(folder, "*.sln", 1)
+	if g:omnisharp_server_type == 'roslyn'
+		let solutionfiles = globpath(folder, "project.json", 1)
+	endif
 
 	while (solutionfiles == '')
 		let lastfolder = folder
@@ -390,6 +398,10 @@ function! OmniSharp#StartServer()
 			break
 		endif
 		let solutionfiles = globpath(folder , "*.sln", 1)
+		if g:omnisharp_server_type == 'roslyn'
+			let solutionfiles = globpath(folder, "project.json", 1)
+		endif
+
 		if isdirectory(solutionfiles)
 			let solutionfiles = ''
 		endif
@@ -458,15 +470,23 @@ function! OmniSharp#ResolveLocalConfig(solutionPath)
 endfunction
 
 function! OmniSharp#StartServerSolution(solutionPath)
-
-	let g:OmniSharp_running_slns += [a:solutionPath]
+	if g:omnisharp_server_type == 'roslyn'
+		let g:OmniSharp_running_slns += [fnamemodify(a:solutionPath, ':h')]
+	else
+		let g:OmniSharp_running_slns += [a:solutionPath]
+	endif
 	let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
-	let command = shellescape(s:omnisharp_server,1)
+	if g:omnisharp_server_type == 'roslyn'
+		let command = shellescape(s:omnisharp_roslyn_server,1) . ' -p ' . port . ' -s ' . shellescape(fnamemodify(a:solutionPath, ':h'), 1)
+	else
+		let command = shellescape(s:omnisharp_server,1)
 					\ . ' -p ' . port
 					\ . ' -s ' . shellescape(a:solutionPath, 1)
 					\ . OmniSharp#ResolveLocalConfig(a:solutionPath)
 
-	if !has('win32') && !has('win32unix')
+
+        endif
+	if !has('win32') && !has('win32unix') && g:omnisharp_server_type != 'roslyn'
 		let command = 'mono ' . command
 	endif
 	call OmniSharp#RunAsyncCommand(command)
@@ -509,7 +529,17 @@ function! OmniSharp#StopServer(...)
 	endif
 
 	if force || OmniSharp#ServerIsRunning()
-		python getResponse("/stopserver")
+		if g:omnisharp_server_type == 'roslyn'
+			"Kill process - temporary hack till /stop is
+                        "implemented in the roslyn server
+			if !has('win32') && !has('win32unix')
+				call system('pkill -f omnisharp-roslyn')
+			else
+				call system('taskkill /IM /f Omnisharp')
+			endif
+ 		else
+			python getResponse("/stopserver")
+		endif
 	endif
 endfunction
 


### PR DESCRIPTION
Added omnisharp-roslyn as a module and starting it up by pointing it to directory containing project.json. To switch - set variable in autoload/Omnisharp.vim. Stopserver for roslyn a hack. Generally the code can be cleaned up once roslyn server has more command support.