### PR TITLE
#183 Add checks before exporting functionality that requires python

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -1,3 +1,7 @@
+if !has('python')
+  finish
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -1,3 +1,7 @@
+if !has('python')
+  finish
+endif
+
 "Set a default value for the server address
 if !exists('g:omnicomplete_fetch_full_documentation')
     let g:omnicomplete_fetch_full_documentation = 0

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,3 +1,8 @@
+if !has('python')
+  echoerr 'Error: OmniSharp requires Vim compiled with +python'
+  finish
+endif
+
 if exists('g:OmniSharp_loaded')
   finish
 endif

--- a/syntax_checkers/cs/codecheck.vim
+++ b/syntax_checkers/cs/codecheck.vim
@@ -1,3 +1,7 @@
+if !has('python')
+  finish
+endif
+
 if exists("g:loaded_syntastic_cs_code_checker")
     finish
 endif

--- a/syntax_checkers/cs/issues.vim
+++ b/syntax_checkers/cs/issues.vim
@@ -1,3 +1,7 @@
+if !has('python')
+  finish
+endif
+
 if exists("g:loaded_syntastic_cs_issues_checker")
     finish
 endif

--- a/syntax_checkers/cs/semantic.vim
+++ b/syntax_checkers/cs/semantic.vim
@@ -1,6 +1,11 @@
+if !has('python')
+  finish
+endif
+
 if exists("g:loaded_syntastic_cs_semantic_checker")
     finish
 endif
+
 let g:loaded_syntastic_cs_semantic_checker = 1
 
 let s:save_cpo = &cpo

--- a/syntax_checkers/cs/syntax.vim
+++ b/syntax_checkers/cs/syntax.vim
@@ -1,3 +1,7 @@
+if !has('python')
+  finish
+endif
+
 if exists("g:loaded_syntastic_cs_syntax_checker")
     finish
 endif


### PR DESCRIPTION
I have no idea what I'm doing when it comes to VimScript. I just know that I wanted to contribute something to a plugin that I'm using every single day. Issue #183 looked like something simple. 

I've added functionality to not register functions reliant on python if Vim is not compiled with +python.

To plugin/OmniSharp.vim I've also added a friendly error indicating that OmniSharp requires Vim with +python. 

If I've done something obviously foolish please let me know and I'll try and sort it out. 

Thanks everyone for creating and maintaining this plugin. 