### PR TITLE
#206 Support for on the fly generation and expansion of snippets during completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Omnisharp-vim can now be run with the [omnisharp-roslyn server](https://github.c
     * Exact start match (case insensitive)
     * CamelCase completions
     * Subsequence match completions
+  * Completion snippets are supported. e.g. Console.WriteLine(TAB) (ENTER) will complete to Console.WriteLine(string value) and expand a dynamic snippet, this will place you in SELECT mode and the first method argument will be selected. 
+    * Requires [UltiSnips](https://github.com/SirVer/ultisnips) and supports standard C-x C-o completion, [Supertab](https://github.com/ervandew/supertab) and [Neocomplete](https://github.com/Shougo/neocomplete.vim).
+    * Requires `set completeopt-=preview` when using [Neocomplete](https://github.com/Shougo/neocomplete.vim) because of a compatibility issue with [UltiSnips](https://github.com/SirVer/ultisnips). 
+    * This functionality requires a recent version of Vim, you can check if your version is supported by running `:echo has("patch-7.3-598")`, it should output 1.
 
 * Jump to the definition of a type/variable/method
 * Find types/symbols interactively (requires [CtrlP](https://github.com/kien/ctrlp.vim) plugin or [unite.vim](https://github.com/Shougo/unite.vim) plugin)
@@ -317,6 +321,9 @@ nnoremap <leader>sp :OmniSharpStopServer<cr>
 nnoremap <leader>th :OmniSharpHighlightTypes<cr>
 "Don't ask to save when changing buffers (i.e. when jumping to a type definition)
 set hidden
+
+" Enable snippet completion, requires completeopt-=preview
+let g:OmniSharp_want_snippet=1
 ```
 
 

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -29,7 +29,10 @@ function! OmniSharp#Complete(findstart, base) abort
     return start
   else
     let omnisharp_last_completion_result =  pyeval('Completion().get_completions("s:column", "a:base")')
-    let s:omnisharp_last_completion_dictionary = pyeval('Completion().to_dictionary_keyed_by("word", "omnisharp_last_completion_result")')
+    let s:omnisharp_last_completion_dictionary = {}
+    for completion in omnisharp_last_completion_result
+        let s:omnisharp_last_completion_dictionary[get(completion, 'word')] = completion
+    endfor
     return omnisharp_last_completion_result
   endif
 endfunction

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -11,7 +11,7 @@ let s:server_files = '*.sln'
 let s:roslyn_server_files = 'project.json'
 let s:allUserTypes = ''
 let s:allUserInterfaces = ''
-let s:generated_snippets = []
+let s:generated_snippets = {}
 let g:serverSeenRunning = 0
 
 function! OmniSharp#Complete(findstart, base) abort
@@ -636,9 +636,9 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
 
     if has_key(s:omnisharp_last_completion_dictionary, completion)
       let snippet = get(get(s:omnisharp_last_completion_dictionary, completion, ''), 'snip','')
-      if index(s:generated_snippets, completion) == -1
+      if !has_key(s:generated_snippets, completion)
         call UltiSnips#AddSnippetWithPriority(completion, snippet, completion, 'iw', 'cs', 1)
-        call add(s:generated_snippets, completion)
+        let s:generated_snippets[completion] = snippet
       endif
       call UltiSnips#CursorMoved()
       call UltiSnips#ExpandSnippetOrJump()

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -613,12 +613,12 @@ function! OmniSharp#AppendCtrlPExtensions() abort
 endfunction
 
 function! OmniSharp#ExpandAutoCompleteSnippet()
-  if !g:omnicomplete_want_snippet
+  if !g:OmniSharp_want_snippet
     return
   endif
 
   if !exists("*UltiSnips#AddSnippetWithPriority")
-    echoerr "g:omnicomplete_want_snippet is enabled but this requires the UltiSnips plugin and it is not installed."
+    echoerr "g:OmniSharp_want_snippet is enabled but this requires the UltiSnips plugin and it is not installed."
     return
   endif
  

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -625,7 +625,7 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
   let line = strpart(getline('.'), 0, col('.')-1)
   let remove_whitespace_regex = '^\s*\(.\{-}\)\s*$'
  
-  let completion = matchstr(line, '.*\zs\s\W.\+(.\+)')
+  let completion = matchstr(line, '.*\zs\s\W.\+(.*)')
   let completion = substitute(completion, remove_whitespace_regex, '\1', '')
  
   let should_expand_completion = len(completion) != 0

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -11,8 +11,8 @@ let s:server_files = '*.sln'
 let s:roslyn_server_files = 'project.json'
 let s:allUserTypes = ''
 let s:allUserInterfaces = ''
+let s:generated_snippets = []
 let g:serverSeenRunning = 0
-let g:generated_snippets = []
 
 function! OmniSharp#Complete(findstart, base) abort
   if a:findstart
@@ -28,9 +28,9 @@ function! OmniSharp#Complete(findstart, base) abort
 
     return start
   else
-    let g:omnisharp_last_completion_result =  pyeval('Completion().get_completions("s:column", "a:base")')
-    let g:omnisharp_last_completion_dictionary = pyeval('Completion().to_dictionary_keyed_by("word", "g:omnisharp_last_completion_result")')
-    return g:omnisharp_last_completion_result
+    let omnisharp_last_completion_result =  pyeval('Completion().get_completions("s:column", "a:base")')
+    let s:omnisharp_last_completion_dictionary = pyeval('Completion().to_dictionary_keyed_by("word", "omnisharp_last_completion_result")')
+    return omnisharp_last_completion_result
   endif
 endfunction
 
@@ -634,11 +634,11 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
     let completion = split(completion, '\.')[-1]
     let completion = split(completion, 'new ')[-1]
 
-    if has_key(g:omnisharp_last_completion_dictionary, completion)
-      let snippet = get(get(g:omnisharp_last_completion_dictionary, completion, ''), 'snip','')
-      if index(g:generated_snippets, completion) == -1
+    if has_key(s:omnisharp_last_completion_dictionary, completion)
+      let snippet = get(get(s:omnisharp_last_completion_dictionary, completion, ''), 'snip','')
+      if index(s:generated_snippets, completion) == -1
         call UltiSnips#AddSnippetWithPriority(completion, snippet, completion, 'iw', 'cs', 1)
-        call add(g:generated_snippets, completion)
+        call add(s:generated_snippets, completion)
       endif
       call UltiSnips#CursorMoved()
       call UltiSnips#ExpandSnippetOrJump()

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -618,8 +618,8 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
   endif
 
   if !exists("*UltiSnips#AddSnippetWithPriority")
-      echoerr "g:omnicomplete_want_snippet is enabled but this requires the UltiSnips plugin and it is not installed."
-      return
+    echoerr "g:omnicomplete_want_snippet is enabled but this requires the UltiSnips plugin and it is not installed."
+    return
   endif
  
   let line = strpart(getline('.'), 0, col('.')-1)

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -15,6 +15,8 @@ augroup plugin-OmniSharp
   \|    call OmniSharp#UpdateBuffer()
   \|  endif
 
+  autocmd CompleteDone <buffer> call OmniSharp#ExpandAutoCompleteSnippet()
+
 augroup END
 
 setlocal omnifunc=OmniSharp#Complete

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -89,5 +89,3 @@ let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'v1')
 
 " Set default for snippet based completions
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
-let g:OmniSharp_want_method_header = get(g:, 'OmniSharp_want_method_header', 0)
-let g:OmniSharp_want_return_type = get(g:, 'OmniSharp_want_return_type', 0)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -86,3 +86,8 @@ endif
 
 " Set g:OmniSharp_server_type to 'roslyn' or 'v1'
 let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'v1')
+
+" Set default for snippet based completions
+let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
+let g:OmniSharp_want_method_header = get(g:, 'OmniSharp_want_method_header', 0)
+let g:OmniSharp_want_return_type = get(g:, 'OmniSharp_want_return_type', 0)

--- a/python/Completion.py
+++ b/python/Completion.py
@@ -9,13 +9,13 @@ class Completion:
             bool(int(vim.eval('g:omnicomplete_fetch_full_documentation')))
 
         want_snippet = \
-            bool(int(vim.eval('g:omnicomplete_want_snippet')))
+            bool(int(vim.eval('g:OmniSharp_want_snippet')))
 
         want_method_header = \
-            bool(int(vim.eval('g:omnicomplete_want_method_header')))
+            bool(int(vim.eval('g:OmniSharp_want_method_header')))
 
         want_return_type = \
-            bool(int(vim.eval('g:omnicomplete_want_return_type')))
+            bool(int(vim.eval('g:OmniSharp_want_return_type')))
 
         parameters['WantSnippet'] = want_snippet
         parameters['WantMethodHeader'] = want_method_header

--- a/python/Completion.py
+++ b/python/Completion.py
@@ -34,10 +34,3 @@ class Completion:
                 vim_completions.append(complete)
 
         return vim_completions
-    def to_dictionary_keyed_by(self, key_by, completions):
-        completion_dictionary = {}
-        if completions is not None:
-            for completion in vim.eval(completions):
-                completion_dictionary[completion.get(key_by)] = completion
-
-        return completion_dictionary

--- a/python/Completion.py
+++ b/python/Completion.py
@@ -24,10 +24,10 @@ class Completion:
         if response is not None:
             for completion in response:
                 complete = {
-                    'snip': completion['Snippet'] if completion['Snippet'] is not None else '',
-                    'word': completion['MethodHeader'] if completion['MethodHeader'] is not None else completion['CompletionText'],
-                    'menu': completion['ReturnType'] if completion['ReturnType'] is not None else completion['DisplayText'],
-                    'info': completion['Description'].replace('\r\n', '\n') if completion['Description'] is not None else '',
+                    'snip': completion['Snippet'] or '',
+                    'word': completion['MethodHeader'] or completion['CompletionText'],
+                    'menu': completion['ReturnType'] or completion['DisplayText'],
+                    'info': completion['Description'].replace('\r\n', '\n') or '',
                     'icase': 1,
                     'dup':1
                 }

--- a/python/Completion.py
+++ b/python/Completion.py
@@ -8,18 +8,31 @@ class Completion:
         parameters['WantDocumentationForEveryCompletionResult'] = \
             bool(int(vim.eval('g:omnicomplete_fetch_full_documentation')))
 
+        want_snippet = \
+            bool(int(vim.eval('g:omnicomplete_want_snippet')))
+
+        want_method_header = \
+            bool(int(vim.eval('g:omnicomplete_want_method_header')))
+
+        want_return_type = \
+            bool(int(vim.eval('g:omnicomplete_want_return_type')))
+
+        parameters['WantSnippet'] = want_snippet
+        parameters['WantMethodHeader'] = want_method_header
+        parameters['WantReturnType'] = want_return_type
+
         parameters['buffer'] = '\r\n'.join(vim.eval('s:textBuffer')[:])
 
         response = syncrequest.get_response('/autocomplete', parameters)
-
 
         enc = vim.eval('&encoding')
         vim_completions = []
         if response is not None:
             for completion in response:
                 complete = {
-                    'word': completion['CompletionText'],
-                    'menu' : completion['DisplayText'] if completion['DisplayText'] is not None else '',
+                    'snip': completion['Snippet'] if completion['Snippet'] is not None else '',
+                    'word': completion['MethodHeader'] if completion['MethodHeader'] is not None else completion['CompletionText'],
+                    'menu': completion['ReturnType'] if completion['ReturnType'] is not None else completion['DisplayText'],
                     'info': completion['Description'].replace('\r\n', '\n') if completion['Description'] is not None else '',
                     'icase': 1,
                     'dup':1
@@ -27,3 +40,10 @@ class Completion:
                 vim_completions.append(complete)
 
         return vim_completions
+    def to_dictionary_keyed_by(self, key_by, completions):
+        completion_dictionary = {}
+        if completions is not None:
+            for completion in vim.eval(completions):
+                completion_dictionary[completion.get(key_by)] = completion
+
+        return completion_dictionary

--- a/python/Completion.py
+++ b/python/Completion.py
@@ -11,15 +11,9 @@ class Completion:
         want_snippet = \
             bool(int(vim.eval('g:OmniSharp_want_snippet')))
 
-        want_method_header = \
-            bool(int(vim.eval('g:OmniSharp_want_method_header')))
-
-        want_return_type = \
-            bool(int(vim.eval('g:OmniSharp_want_return_type')))
-
         parameters['WantSnippet'] = want_snippet
-        parameters['WantMethodHeader'] = want_method_header
-        parameters['WantReturnType'] = want_return_type
+        parameters['WantMethodHeader'] = want_snippet
+        parameters['WantReturnType'] = want_snippet
 
         parameters['buffer'] = '\r\n'.join(vim.eval('s:textBuffer')[:])
 


### PR DESCRIPTION
I don't think I'm 100% complete with this pull request yet but I wanted to create it so that its gets some visibility. Even more so because I'm new to Vim and Vim Script development. 

This pull request adds support for #206, on the fly generation and expansion of snippets during code completion. 

There are some requirements:

1. UltiSnips is installed
2. set completeopt does not specify "preview". This causes known issues with UltiSnips since the preview temporary steals focus and breaks snippets
3. The user configures omnisharp completion to make use of snippets, return type and method header in their .vimrc
```
let g:omnicomplete_want_snippet=1
let g:omnicomplete_want_return_type=1
let g:omnicomplete_want_method_header=1
```
4. An autocmd to activate snippet expansion
```
autocmd CompleteDone *.cs call OmniSharp#ExpandAutoCompleteSnippet(). 
```
I'm not sure if it is preferable to hook this up automatically or let the user do it?

There are also some recommendations:

1. Neocomplete is installed
2. Neocomplete is configured to remove the "converter_remove_last_paren" from its converter list. For snippet completion and expansion we don't want to lose the last parentheses

The changes are pretty simple. I've exposed a dictionary of completions keyed by the completion "word" and containing the snippet "snip". When the CompleteDone event is triggered the "last completion" entered by the user is calculated and the matching snippet is looked up in the dictionary. If we've never generated a UltiSnips snippet for this completion word we generate one on the fly and add it to the list of generated UltiSnips snippets, then we expand it. 

I've tested a number of scenarios (with standard C-x C-o, SuperTab and Neocomplete) and everything has worked fine. I've also tested that completion behaves the same as it used to when the user has not configured snippet use in their .vimrc. There will no doubt be some issues though, I expected the way I am calculating the last entered completion could be improved. 

I'm really open to any suggestions about improvements that can be made, as I say, I'm new to this. 

Anyway, here are some tests I've done. 

Generics:

![generics](https://cloud.githubusercontent.com/assets/893173/7442954/77ff29c6-f120-11e4-9095-af234ab0a08a.gif)

Generics with no arguments:
![noargs-generic](https://cloud.githubusercontent.com/assets/893173/7446331/91ce2ad0-f1cc-11e4-8bcf-fe01e7737d85.gif)

Method Chaining
![method-chaining](https://cloud.githubusercontent.com/assets/893173/7442957/817c6630-f120-11e4-87e5-6395e1b4618f.gif)

Method Chaining Across Lines
![method-chaining-across0-lines](https://cloud.githubusercontent.com/assets/893173/7442958/900e74f4-f120-11e4-9b8d-14b293bdc344.gif)

None Dotted Method Access
![method-non-dotted](https://cloud.githubusercontent.com/assets/893173/7442959/971d6e8a-f120-11e4-87cb-a16c8efd9abb.gif)

Nested Snippet Expansion
![nested](https://cloud.githubusercontent.com/assets/893173/7442961/a12ed5c6-f120-11e4-92e2-f96d0cd0d87c.gif)

Nested Snippet Expansion - In a manually expanded UltiSnips snippet
![nested-ulti](https://cloud.githubusercontent.com/assets/893173/7442962/b907561e-f120-11e4-9d92-fd33b9b43e15.gif)

Other
![other](https://cloud.githubusercontent.com/assets/893173/7442963/be314938-f120-11e4-820f-405b11d5c7e4.gif)



 