### PR TITLE
Fixed OmniSharpBuild function which was not parsing result correctly

### DIFF
--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -166,16 +166,16 @@ def setBuffer(buffer):
     lines = [line.encode('utf-8') for line in lines]
     vim.current.buffer[:] = lines
 
-def build(ret):
-    response = json.loads(getResponse('/build', {}, 60))
+def build():
+    js = json.loads(getResponse('/build', {}, 60))
 
-    success = response["Success"]
+    success = js["Success"]
     if success:
         print "Build succeeded"
     else:
         print "Build failed"
 
-    return get_quickfix_list(js, 'QuickFixes')
+    return quickfixes_from_js(js, 'QuickFixes')
 
 def buildcommand():
     vim.command("let b:buildcommand = '%s'" % getResponse('/buildcommand')) 
@@ -227,8 +227,12 @@ def findSymbols():
 def get_quickfix_list(js, key):
     if js != '':
         response = json.loads(js)
-        if response[key] is not None:
-            return quickfixes_from_response(response[key])
+        return quickfixes_from_js(response, key)
+    return [];
+
+def quickfixes_from_js(js, key):
+    if js[key] is not None:
+        return quickfixes_from_response(js[key])
     return [];
 
 def quickfixes_from_response(response):


### PR DESCRIPTION
This is the first part of a patch to fix building the solution via the server.
The client was not parsing the result correctly.

The second part will contain fixes on the server to correctly parse errors/warnings, which it doesn't at the moment as it always returns a failed build.
