### PR TITLE
Fixed issue where server could not start after manually stopping it

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -586,6 +586,7 @@ function! OmniSharp#StopServer(...) abort
     else
       python getResponse("/stopserver")
     endif
+    let g:OmniSharp_running_slns = []
   endif
 endfunction
 


### PR DESCRIPTION
##### Steps to reproduce:
* Open csharp file foo.cs associated with multiple solution files
_ foo.cs
_ foo.sln
_ foo2.sln

* Server will then be started (provided autostart flag is set to 1)
* Stop server (:OmniSharpStopServer)
* Try starting server again :OmniSharpStartServer

##### Observed result:

Prompt will be empty :
    > sln:
Server is **not started**

##### Causes:
See https://github.com/OmniSharp/omnisharp-vim/blob/69a43ce9db692bc7d11fcac54df4c0c518c559c6/autoload/OmniSharp.vim#L476

It is checking variable g:OmniSharp_running_slns which is not cleared when server is stopped.

##### Solution:

Clear g:OmniSharp_running_slns when server is stopped.