### PR TITLE
called shellescape with configPath

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -513,7 +513,7 @@ function! OmniSharp#ResolveLocalConfig(solutionPath) abort
   \ . g:OmniSharp_server_config_name
 
   if filereadable(configPath)
-    let result = ' -config ' . configPath
+    let result = ' -config ' . shellescape(configPath, 1)
   endif
   return result
 endfunction


### PR DESCRIPTION
When building a "-config" parameters, Fixed a bug that path to the configuration file is not escape.