### PR TITLE
corrected addition to array when searching for solution files.

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -576,9 +576,9 @@ function! s:find_solution_files() abort
   let solution_files = []
 
   while empty(solution_files)
-    let solution_files += globpath(dir , '*.sln', 1, 1)
+    let solution_files = add(solution_files, globpath(dir , '*.sln', 1))
     if g:OmniSharp_server_type ==# 'roslyn'
-      let solution_files += globpath(dir, 'project.json', 1, 1)
+      let solution_files = add(solution_files, globpath(dir, 'project.json', 1)
     endif
 
     call filter(solution_files, 'filereadable(v:val)')


### PR DESCRIPTION
http://learnvimscriptthehardway.stevelosh.com/chapters/35.html states that the way to add to arrays in vim is by using the add() method

Also, globpath() takes 3 arguments, not 4.