### PR TITLE
Add support for expanding snippets if the calculated completion start…

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -610,6 +610,7 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
   if should_expand_completion
     let completion = split(completion, '\.')[-1]
     let completion = split(completion, 'new ')[-1]
+    let completion = split(completion, '= ')[-1]
 
     if has_key(s:omnisharp_last_completion_dictionary, completion)
       let snippet = get(get(s:omnisharp_last_completion_dictionary, completion, ''), 'snip','')


### PR DESCRIPTION
…s with "=". This is for instances where we might not be using dot notation on the existing line and we are not completing a new() call.

For example:

![example](https://cloud.githubusercontent.com/assets/893173/15958798/8ff466c8-2eef-11e6-8d1e-7924e80b0dcd.gif)
