### PR TITLE
Fix error when Description of autocomplete response is null

### DIFF
--- a/python/Completion.py
+++ b/python/Completion.py
@@ -27,7 +27,7 @@ class Completion:
                     'snip': completion['Snippet'] or '',
                     'word': completion['MethodHeader'] or completion['CompletionText'],
                     'menu': completion['ReturnType'] or completion['DisplayText'],
-                    'info': completion['Description'].replace('\r\n', '\n') or '',
+                    'info': (completion['Description'] or '').replace('\r\n', '\n'),
                     'icase': 1,
                     'dup':1
                 }


### PR DESCRIPTION
While testing omnisharp-vim with the latest roslyn server I got an error on autocomplete when Description is null. This PR should fix the problem.