### PR TITLE
Add support for global.json when looking for sln files.

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -638,11 +638,19 @@ endfunction
 function! s:find_solution_files() abort
   "get the path for the current buffer
   let dir = expand('%:p:h')
+  let lastfolder = ''
   let solution_files = []
 
-  while empty(solution_files)
-    let solution_files += s:globpath(dir , '*.sln')
+  while dir !=# lastfolder
+    let solution_files += s:globpath(dir, '*.sln')
     if g:OmniSharp_server_type ==# 'roslyn'
+      if g:OmniSharp_prefer_global_sln
+        let global_solution_files = s:globpath(dir, 'global.json')
+	if !empty(global_solution_files)
+          let solution_files = [dir]
+          break
+	endif
+      endif
       let solution_files += s:globpath(dir, 'project.json')
     endif
 
@@ -650,9 +658,6 @@ function! s:find_solution_files() abort
 
     let lastfolder = dir
     let dir = fnamemodify(dir, ':h')
-    if dir ==# lastfolder
-      break
-    endif
   endwhile
 
   if empty(solution_files) && g:OmniSharp_start_without_solution

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -642,19 +642,23 @@ function! s:find_solution_files() abort
   let solution_files = []
 
   while dir !=# lastfolder
-    let solution_files += s:globpath(dir, '*.sln')
-    if g:OmniSharp_server_type ==# 'roslyn'
-      if g:OmniSharp_prefer_global_sln
-        let global_solution_files = s:globpath(dir, 'global.json')
-	if !empty(global_solution_files)
-          let solution_files = [dir]
-          break
-	endif
+    if empty(solution_files)
+      let solution_files += s:globpath(dir, '*.sln')
+      if g:OmniSharp_server_type ==# 'roslyn'
+        let solution_files += s:globpath(dir, 'project.json')
       endif
-      let solution_files += s:globpath(dir, 'project.json')
+
+      call filter(solution_files, 'filereadable(v:val)')
     endif
 
-    call filter(solution_files, 'filereadable(v:val)')
+    if g:OmniSharp_server_type ==# 'roslyn' && g:OmniSharp_prefer_global_sln
+      let global_solution_files = s:globpath(dir, 'global.json')
+      call filter(global_solution_files, 'filereadable(v:val)')
+      if !empty(global_solution_files)
+        let solution_files = [dir]
+        break
+      endif
+    endif
 
     let lastfolder = dir
     let dir = fnamemodify(dir, ':h')

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -97,3 +97,7 @@ if !exists('g:OmniSharp_server_path')
     let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'artifacts', 'scripts', 'Omnisharp'], '/')
   endif
 endif
+
+if !exists('g:OmniSharp_prefer_global_sln')
+  let g:OmniSharp_prefer_global_sln = 0
+endif


### PR DESCRIPTION
This pull request is useful when working with multiple projects in this structure:
```
/unit-testing-using-dotnet-test
|__global.json
|__/src
   |__/PrimeService
      |__Source Files
      |__project.json
|__/test
   |__/PrimeService.Tests
      |__Test Files
      |__project.json
```
If we tell omnisharp to use the same directory that `global.json` is in for the solution, it will provide completion for all contained `project.json` files, instead of just one.

First, it adds the variable `g:OmniSharp_prefer_global_sln` with a default of 0.

If a user sets this to 1, then when omnisharp-vim is looking for sln files, it will also look for a `global.json` file. If it finds one, it will start the server using `global.json`'s directory as the solution.

When `g:OmniSharp_prefer_global_sln` is set to 0, there is no difference in behavior, except that we now scan all the way up to the root.