### PR TITLE
Provide more information when server returns empty/invalid JSON

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -672,8 +672,16 @@ function! s:find_solution_files() abort
 endfunction
 
 function! s:json_decode(json) abort
+  if !a:json
+    throw "Empty JSON response from server"
+  endif
+
   let [null, true, false] = [0, 1, 0]
-  sandbox return eval(a:json)
+  try
+    sandbox return eval(a:json)
+  catch
+    throw "Invalid JSON response from server: " . a:json
+  endtry
 endfunction
 
 if has('patch-7.4.279')


### PR DESCRIPTION
Following up on https://github.com/OmniSharp/omnisharp-vim/issues/244 - omnisharp-vim does not work in my environment, so I thought I'd at least add some information about what happened when JSON parsing fails. It simply says whether there was a response or not, and if the response is invalid, print it.