### PR TITLE
Move check for python to happen after OmniSharp_loaded check

### DIFF
--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,13 +1,13 @@
-if !has('python')
-  echoerr 'Error: OmniSharp requires Vim compiled with +python'
-  finish
-endif
-
 if exists('g:OmniSharp_loaded')
   finish
 endif
 
 let g:OmniSharp_loaded = 1
+
+if !has('python')
+  echoerr 'Error: OmniSharp requires Vim compiled with +python'
+  finish
+endif
 
 "Load python/OmniSharp.py
 let s:py_path = join([expand('<sfile>:p:h:h'), 'python'], '/')


### PR DESCRIPTION
Doing this makes sure that someone can do something like 
the following in their .vimrc to automatically disable omnisharp
if vim is loaded without seeing error messages:

if !has("python")
	let g:OmniSharp_loaded = 1
endif