### PR TITLE
Guard Highlighting to prevent errors in Neovim

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -378,8 +378,12 @@ endfunction
 
 function! OmniSharp#EnableTypeHighlightingForBuffer() abort
   hi link CSharpUserType Type
-  exec 'syn keyword CSharpUserType ' . s:allUserTypes
-  exec 'syn keyword csInterfaceDeclaration ' . s:allUserInterfaces
+  if !empty(s:allUserTypes)
+    exec 'syn keyword CSharpUserType ' . s:allUserTypes
+  endif
+  if !empty(s:allUserInterfaces)
+    exec 'syn keyword csInterfaceDeclaration ' . s:allUserInterfaces
+  endif
 endfunction
 
 function! OmniSharp#EnableTypeHighlighting() abort


### PR DESCRIPTION
I'm not sure if I messed something up to cause these to be empty but Neovim is complaining about these calls when they are.

I'm using the roslyn server if that makes a difference.