### PR TITLE
Fix command name on Windows

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -531,12 +531,17 @@ function! OmniSharp#StartServerSolution(solutionPath) abort
   if fnamemodify(solutionPath, ':t') ==? s:roslyn_server_files
     let solutionPath = fnamemodify(solutionPath, ':h')
   endif
-  let g:OmniSharp_running_slns += [solutionPath]
-  let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
+
   let cmd = g:OmniSharp_server_path
-  if has('win32') && &shell =~ 'cmd' && !s:is_vimproc
+  if s:is_vimproc
+    let cmd = substitute(cmd, '\\', '/', 'g')
+    let solutionPath = substitute(solutionPath, '\\', '/', 'g')
+  elseif has('win32') && &shell =~ 'cmd'
     let cmd = substitute(cmd, '/', '\\', 'g')
   endif
+
+  let g:OmniSharp_running_slns += [solutionPath]
+  let port = exists('b:OmniSharp_port') ? b:OmniSharp_port : g:OmniSharp_port
   let command = shellescape(cmd, 1)
   \ . ' -p ' . port
   \ . ' -s ' . shellescape(solutionPath, 1)
@@ -553,7 +558,7 @@ function! OmniSharp#RunAsyncCommand(command) abort
   if exists(':Dispatch') == 2
     call dispatch#start(a:command, {'background': 1})
   elseif s:is_vimproc
-    call vimproc#system_gui(substitute(a:command, '\\', '\/', 'g'))
+    call vimproc#system_gui(a:command)
   else
     echoerr 'Please install either vim-dispatch or vimproc plugin to use this feature'
   endif

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -94,7 +94,7 @@ if !exists('g:OmniSharp_server_path')
   if g:OmniSharp_server_type ==# 'v1'
     let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'server', 'OmniSharp', 'bin', 'Debug', 'OmniSharp.exe'], '/')
   else
-    let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'artifacts', 'scripts', 'OmniSharp'], '/')
+    let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'artifacts', 'scripts', 'OmniSharp' . (has('win32') ? '.cmd' : '')], '/')
   endif
 endif
 


### PR DESCRIPTION
Currently, roslyn server doesn't work on Windows since command name contains slashs. Also `.cmd` is missing.
