### PR TITLE
Check for cygwin when adding .cmd to path

### DIFF
--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -94,7 +94,7 @@ if !exists('g:OmniSharp_server_path')
   if g:OmniSharp_server_type ==# 'v1'
     let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'server', 'OmniSharp', 'bin', 'Debug', 'OmniSharp.exe'], '/')
   else
-    let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'artifacts', 'scripts', 'OmniSharp' . (has('win32') ? '.cmd' : '')], '/')
+    let g:OmniSharp_server_path = join([expand('<sfile>:p:h:h'), 'omnisharp-roslyn', 'artifacts', 'scripts', 'OmniSharp' . (has('win32') || has('win32unix') ? '.cmd' : '')], '/')
   endif
 endif
 


### PR DESCRIPTION
This is a tiny addon to @mattn's previous PR - it just includes cygwin (`has('win32unix')`) when adding `.cmd` to the executable path