### PR TITLE
Warn when server not started on running host

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -454,7 +454,9 @@ function! OmniSharp#ServerIsRunning() abort
 endfunction
 
 function! OmniSharp#StartServerIfNotRunning() abort
-  if !OmniSharp#ServerIsRunning()
+  if OmniSharp#ServerIsRunning()
+    echohl ErrorMsg | echom 'A server is already running on host ' . g:OmniSharp_host | echohl NONE
+  else
     call OmniSharp#StartServer()
     if g:Omnisharp_stop_server==2
       au VimLeavePre * call OmniSharp#StopServer()


### PR DESCRIPTION
If an attempt is made to start a server on a host port that is already running, echo a useful warning:
 "A server is already running on host " . g:OmniSharp_host