### PR TITLE
[RFC] Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
 install: pip install tox-travis
 script: cd ${TRAVIS_BUILD_DIR}/python; tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,4 +4,4 @@ install:
   - C:\Python36\python -m pip install tox
 build: false  # Not a C# project, build stuff at the test step instead.
 test_script:
-  - C:\Python36\python -m tox -c python/tox.ini
+  - C:\Python36\python -m tox -c python\tox.ini

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -133,7 +133,7 @@ function! OmniSharp#NavigateDown() abort
 endfunction
 
 function! OmniSharp#GotoDefinition() abort
-  OmniSharp#py#eval('gotoDefinition()')
+  call OmniSharp#py#eval('gotoDefinition()')
 endfunction
 
 function! OmniSharp#JumpToLocation(filename, line, column) abort
@@ -277,7 +277,7 @@ function! OmniSharp#GetIssues() abort
 endfunction
 
 function! OmniSharp#FixIssue() abort
-  OmniSharp#py#eval('fixCodeIssue()')
+  call OmniSharp#py#eval('fixCodeIssue()')
 endfunction
 
 function! OmniSharp#FindSyntaxErrors() abort
@@ -332,7 +332,7 @@ function! OmniSharp#TypeLookup(includeDocumentation) abort
 
   if g:OmniSharp_typeLookupInPreview || a:includeDocumentation ==# 'True'
     let s:documentation = ''
-    OmniSharp#py#eval('typeLookup("type")')
+    call OmniSharp#py#eval('typeLookup("type")')
     let doc = get(s:, 'documentation', '')
     if len(doc) > 0
       let doc = "\n\n" . doc
@@ -352,7 +352,7 @@ function! OmniSharp#TypeLookup(includeDocumentation) abort
       endfor
     endif
     if found_line_in_loc_list == 0
-      OmniSharp#py#eval('typeLookup("type")')
+      call OmniSharp#py#eval('typeLookup("type")')
       call OmniSharp#Echo(type)
     endif
   endif
@@ -412,7 +412,7 @@ function! OmniSharp#Build() abort
 endfunction
 
 function! OmniSharp#BuildAsync() abort
-  OmniSharp#py#eval('buildcommand()')
+  call OmniSharp#py#eval('buildcommand()')
   let &l:makeprg=b:buildcommand
   setlocal errorformat=\ %#%f(%l\\\,%c):\ %m
   Make
@@ -420,10 +420,10 @@ endfunction
 
 function! OmniSharp#RunTests(mode) abort
   wall
-  OmniSharp#py#eval('buildcommand()')
+  call OmniSharp#py#eval('buildcommand()')
 
   if a:mode !=# 'last'
-    OmniSharp#py#eval('getTestCommand()')
+    call OmniSharp#py#eval('getTestCommand()')
   endif
 
   let s:cmdheight=&cmdheight
@@ -461,9 +461,9 @@ function! OmniSharp#EnableTypeHighlighting() abort
   endif
 
   if g:OmniSharp_server_type ==# 'roslyn'
-    OmniSharp#py#eval('lookupAllUserTypes()')
+    call OmniSharp#py#eval('lookupAllUserTypes()')
   else
-    OmniSharp#py#eval('lookupAllUserTypesLegacy()')
+    call OmniSharp#py#eval('lookupAllUserTypesLegacy()')
   endif
 
   let startBuf = bufnr('%')
@@ -480,12 +480,12 @@ function! OmniSharp#EnableTypeHighlighting() abort
 endfunction
 
 function! OmniSharp#ReloadSolution() abort
-  OmniSharp#py#eval('getResponse("/reloadsolution")')
+  call OmniSharp#py#eval('getResponse("/reloadsolution")')
 endfunction
 
 function! OmniSharp#UpdateBuffer() abort
   if OmniSharp#BufferHasChanged() == 1
-    OmniSharp#py#eval('getResponse("/updatebuffer")')
+    call OmniSharp#py#eval('getResponse("/updatebuffer")')
   endif
 endfunction
 
@@ -501,7 +501,7 @@ function! OmniSharp#BufferHasChanged() abort
 endfunction
 
 function! OmniSharp#CodeFormat() abort
-  OmniSharp#py#eval('codeFormat()')
+  call OmniSharp#py#eval('codeFormat()')
 endfunction
 
 function! OmniSharp#FixUsings() abort
@@ -515,7 +515,7 @@ endfunction
 
 function! OmniSharp#ServerIsRunning() abort
   try
-    OmniSharp#py#eval('vim.command("let s:alive = \"%s\"" % getResponse("/checkalivestatus", None, 0.2))')
+    call OmniSharp#py#eval('vim.command("let s:alive = \"%s\"" % getResponse("/checkalivestatus", None, 0.2))')
     return s:alive ==# 'true'
   catch
     return 0
@@ -594,7 +594,7 @@ function! OmniSharp#StartServer() abort
 endfunction
 
 function! OmniSharp#AddToProject() abort
-  OmniSharp#py#eval('getResponse("/addtoproject")')
+  call OmniSharp#py#eval('getResponse("/addtoproject")')
 endfunction
 
 function! OmniSharp#AskStopServerIfRunning() abort
@@ -616,7 +616,7 @@ function! OmniSharp#StopServer(...) abort
   endif
 
   if force || OmniSharp#ServerIsRunning()
-    OmniSharp#py#eval('getResponse("/stopserver")')
+    call OmniSharp#py#eval('getResponse("/stopserver")')
     call OmniSharp#proc#StopJob()
     let g:OmniSharp_running_slns = []
   endif
@@ -628,7 +628,7 @@ function! OmniSharp#AddReference(reference) abort
   else
     let a:ref = a:reference
   endif
-  OmniSharp#py#eval('addReference()')
+  call OmniSharp#py#eval('addReference()')
 endfunction
 
 function! OmniSharp#AppendCtrlPExtensions() abort

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -1,4 +1,4 @@
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   finish
 endif
 
@@ -6,7 +6,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Load python/omnisharp/OmniSharp.py
-call OmniSharp#lib#py#load('/OmniSharp.py')
+call OmniSharp#py#load('/OmniSharp.py')
 
 let s:server_files = '*.sln'
 let s:allUserTypes = ''
@@ -19,7 +19,7 @@ let s:is_vimproc = 0
 silent! let s:is_vimproc = vimproc#version()
 
 function! OmniSharp#GetCompletions(partial, ...) abort
-  let completions = OmniSharp#lib#py#eval(printf('getCompletions(%s)', string(a:partial)))
+  let completions = OmniSharp#py#eval(printf('getCompletions(%s)', string(a:partial)))
   let s:last_completion_dictionary = {}
   for completion in completions
     let s:last_completion_dictionary[get(completion, 'word')] = completion
@@ -49,7 +49,7 @@ function! OmniSharp#Complete(findstart, base) abort
 endfunction
 
 function! OmniSharp#FindUsages() abort
-  let qf_taglist = OmniSharp#lib#py#eval('findUsages()')
+  let qf_taglist = OmniSharp#py#eval('findUsages()')
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
@@ -61,7 +61,7 @@ function! OmniSharp#FindUsages() abort
 endfunction
 
 function! OmniSharp#FindImplementations() abort
-  let qf_taglist = OmniSharp#lib#py#eval('findImplementations()')
+  let qf_taglist = OmniSharp#py#eval('findImplementations()')
 
   if len(qf_taglist) == 0
     echo 'No implementations found'
@@ -79,7 +79,7 @@ function! OmniSharp#FindImplementations() abort
 endfunction
 
 function! OmniSharp#FindMembers() abort
-  let qf_taglist = OmniSharp#lib#py#eval('findMembers()')
+  let qf_taglist = OmniSharp#py#eval('findMembers()')
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 1
@@ -90,10 +90,10 @@ endfunction
 
 function! OmniSharp#NavigateUp() abort
   if g:OmniSharp_server_type ==# 'roslyn'
-    let qf_tag = OmniSharp#lib#py#eval('navigateUp()')
+    let qf_tag = OmniSharp#py#eval('navigateUp()')
     call cursor(qf_tag.Line, qf_tag.Column)
   else
-    let qf_taglist = OmniSharp#lib#py#eval('findMembers()')
+    let qf_taglist = OmniSharp#py#eval('findMembers()')
     let column = col('.')
     let line = line('.')
     let l = len(qf_taglist) - 1
@@ -114,10 +114,10 @@ endfunction
 
 function! OmniSharp#NavigateDown() abort
   if g:OmniSharp_server_type ==# 'roslyn'
-    let qf_tag = OmniSharp#lib#py#eval('navigateDown()')
+    let qf_tag = OmniSharp#py#eval('navigateDown()')
     call cursor(qf_tag.Line, qf_tag.Column)
   else
-    let qf_taglist = OmniSharp#lib#py#eval('findMembers()')
+    let qf_taglist = OmniSharp#py#eval('findMembers()')
     let column = col('.')
     let line = line('.')
     for l in range(0, len(qf_taglist) - 1)
@@ -133,7 +133,7 @@ function! OmniSharp#NavigateDown() abort
 endfunction
 
 function! OmniSharp#GotoDefinition() abort
-  OmniSharp#lib#py#eval('gotoDefinition()')
+  OmniSharp#py#eval('gotoDefinition()')
 endfunction
 
 function! OmniSharp#JumpToLocation(filename, line, column) abort
@@ -156,7 +156,7 @@ function! OmniSharp#FindSymbol(...) abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let quickfixes = OmniSharp#lib#py#eval(printf('findSymbols(%s)', string(filter)))
+  let quickfixes = OmniSharp#py#eval(printf('findSymbols(%s)', string(filter)))
   if empty(quickfixes)
     echo 'No symbols found'
     return
@@ -197,7 +197,7 @@ endfunction
 " callback function can be used to clear the flag.
 function! OmniSharp#CountCodeActions(...) abort
   let v = g:OmniSharp_server_type ==# 'roslyn' ? 'v2' : 'v1'
-  let s:actions = OmniSharp#lib#py#eval(printf('getCodeActions("normal", %s)', string(v)))
+  let s:actions = OmniSharp#py#eval(printf('getCodeActions("normal", %s)', string(v)))
 
   " v:t_func was added in vim8 - this form is backwards-compatible
   if a:0 && type(a:1) == type(function("tr"))
@@ -228,7 +228,7 @@ function! OmniSharp#GetCodeActions(mode) range abort
   if exists('s:actions')
     let actions = s:actions
   else
-    let actions = OmniSharp#lib#py#eval(printf('getCodeActions(%s, %s)', string(a:mode), string(v)))
+    let actions = OmniSharp#py#eval(printf('getCodeActions(%s, %s)', string(a:mode), string(v)))
   endif
   if empty(actions)
     echo 'No code actions found'
@@ -259,7 +259,7 @@ function! OmniSharp#GetCodeActions(mode) range abort
         let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
         let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', a:mode, command)
       endif
-      if !OmniSharp#lib#py#eval(command)
+      if !OmniSharp#py#eval(command)
         echo 'No action taken'
       endif
     endif
@@ -271,13 +271,13 @@ function! OmniSharp#GetIssues() abort
     return get(b:, 'issues', [])
   endif
   if g:serverSeenRunning == 1
-    let b:issues = OmniSharp#lib#py#eval('getCodeIssues()')
+    let b:issues = OmniSharp#py#eval('getCodeIssues()')
   endif
   return get(b:, 'issues', [])
 endfunction
 
 function! OmniSharp#FixIssue() abort
-  OmniSharp#lib#py#eval('fixCodeIssue()')
+  OmniSharp#py#eval('fixCodeIssue()')
 endfunction
 
 function! OmniSharp#FindSyntaxErrors() abort
@@ -288,7 +288,7 @@ function! OmniSharp#FindSyntaxErrors() abort
     return []
   endif
   if g:serverSeenRunning == 1
-    let b:syntaxerrors = OmniSharp#lib#py#eval('findSyntaxErrors()')
+    let b:syntaxerrors = OmniSharp#py#eval('findSyntaxErrors()')
   endif
   return get(b:, 'syntaxerrors', [])
 endfunction
@@ -301,7 +301,7 @@ function! OmniSharp#FindSemanticErrors() abort
     return []
   endif
   if g:serverSeenRunning == 1
-    let b:semanticerrors = OmniSharp#lib#py#eval('findSemanticErrors()')
+    let b:semanticerrors = OmniSharp#py#eval('findSemanticErrors()')
   endif
   return get(b:, 'semanticerrors', [])
 endfunction
@@ -314,7 +314,7 @@ function! OmniSharp#CodeCheck() abort
     return []
   endif
   if g:serverSeenRunning == 1
-    let b:codecheck = OmniSharp#lib#py#eval('codeCheck()')
+    let b:codecheck = OmniSharp#py#eval('codeCheck()')
   endif
   return get(b:, 'codecheck', [])
 endfunction
@@ -332,7 +332,7 @@ function! OmniSharp#TypeLookup(includeDocumentation) abort
 
   if g:OmniSharp_typeLookupInPreview || a:includeDocumentation ==# 'True'
     let s:documentation = ''
-    OmniSharp#lib#py#eval('typeLookup("type")')
+    OmniSharp#py#eval('typeLookup("type")')
     let doc = get(s:, 'documentation', '')
     if len(doc) > 0
       let doc = "\n\n" . doc
@@ -352,7 +352,7 @@ function! OmniSharp#TypeLookup(includeDocumentation) abort
       endfor
     endif
     if found_line_in_loc_list == 0
-      OmniSharp#lib#py#eval('typeLookup("type")')
+      OmniSharp#py#eval('typeLookup("type")')
       call OmniSharp#Echo(type)
     endif
   endif
@@ -370,7 +370,7 @@ function! OmniSharp#Rename() abort
 endfunction
 
 function! OmniSharp#RenameTo(renameto) abort
-  let result = s:json_decode(OmniSharp#lib#py#eval('renameTo()'))
+  let result = s:json_decode(OmniSharp#py#eval('renameTo()'))
 
   let save_lazyredraw = &lazyredraw
   let save_eventignore = &eventignore
@@ -402,7 +402,7 @@ function! OmniSharp#RenameTo(renameto) abort
 endfunction
 
 function! OmniSharp#Build() abort
-  let qf_taglist = OmniSharp#lib#py#eval('build()')
+  let qf_taglist = OmniSharp#py#eval('build()')
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
@@ -412,7 +412,7 @@ function! OmniSharp#Build() abort
 endfunction
 
 function! OmniSharp#BuildAsync() abort
-  OmniSharp#lib#py#eval('buildcommand()')
+  OmniSharp#py#eval('buildcommand()')
   let &l:makeprg=b:buildcommand
   setlocal errorformat=\ %#%f(%l\\\,%c):\ %m
   Make
@@ -420,10 +420,10 @@ endfunction
 
 function! OmniSharp#RunTests(mode) abort
   wall
-  OmniSharp#lib#py#eval('buildcommand()')
+  OmniSharp#py#eval('buildcommand()')
 
   if a:mode !=# 'last'
-    OmniSharp#lib#py#eval('getTestCommand()')
+    OmniSharp#py#eval('getTestCommand()')
   endif
 
   let s:cmdheight=&cmdheight
@@ -461,9 +461,9 @@ function! OmniSharp#EnableTypeHighlighting() abort
   endif
 
   if g:OmniSharp_server_type ==# 'roslyn'
-    OmniSharp#lib#py#eval('lookupAllUserTypes()')
+    OmniSharp#py#eval('lookupAllUserTypes()')
   else
-    OmniSharp#lib#py#eval('lookupAllUserTypesLegacy()')
+    OmniSharp#py#eval('lookupAllUserTypesLegacy()')
   endif
 
   let startBuf = bufnr('%')
@@ -480,12 +480,12 @@ function! OmniSharp#EnableTypeHighlighting() abort
 endfunction
 
 function! OmniSharp#ReloadSolution() abort
-  OmniSharp#lib#py#eval('getResponse("/reloadsolution")')
+  OmniSharp#py#eval('getResponse("/reloadsolution")')
 endfunction
 
 function! OmniSharp#UpdateBuffer() abort
   if OmniSharp#BufferHasChanged() == 1
-    OmniSharp#lib#py#eval('getResponse("/updatebuffer")')
+    OmniSharp#py#eval('getResponse("/updatebuffer")')
   endif
 endfunction
 
@@ -501,11 +501,11 @@ function! OmniSharp#BufferHasChanged() abort
 endfunction
 
 function! OmniSharp#CodeFormat() abort
-  OmniSharp#lib#py#eval('codeFormat()')
+  OmniSharp#py#eval('codeFormat()')
 endfunction
 
 function! OmniSharp#FixUsings() abort
-  let qf_taglist = OmniSharp#lib#py#eval('fix_usings()')
+  let qf_taglist = OmniSharp#py#eval('fix_usings()')
 
   if len(qf_taglist) > 0
     call setqflist(qf_taglist)
@@ -515,7 +515,7 @@ endfunction
 
 function! OmniSharp#ServerIsRunning() abort
   try
-    OmniSharp#lib#py#eval('vim.command("let s:alive = \"%s\"" % getResponse("/checkalivestatus", None, 0.2))')
+    OmniSharp#py#eval('vim.command("let s:alive = \"%s\"" % getResponse("/checkalivestatus", None, 0.2))')
     return s:alive ==# 'true'
   catch
     return 0
@@ -594,7 +594,7 @@ function! OmniSharp#StartServer() abort
 endfunction
 
 function! OmniSharp#AddToProject() abort
-  OmniSharp#lib#py#eval('getResponse("/addtoproject")')
+  OmniSharp#py#eval('getResponse("/addtoproject")')
 endfunction
 
 function! OmniSharp#AskStopServerIfRunning() abort
@@ -616,7 +616,7 @@ function! OmniSharp#StopServer(...) abort
   endif
 
   if force || OmniSharp#ServerIsRunning()
-    OmniSharp#lib#py#eval('getResponse("/stopserver")')
+    OmniSharp#py#eval('getResponse("/stopserver")')
     call OmniSharp#proc#StopJob()
     let g:OmniSharp_running_slns = []
   endif
@@ -628,7 +628,7 @@ function! OmniSharp#AddReference(reference) abort
   else
     let a:ref = a:reference
   endif
-  OmniSharp#lib#py#eval('addReference()')
+  OmniSharp#py#eval('addReference()')
 endfunction
 
 function! OmniSharp#AppendCtrlPExtensions() abort

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -6,7 +6,15 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " Load python/omnisharp/OmniSharp.py
-call OmniSharp#py#load('/OmniSharp.py')
+call OmniSharp#py#load('OmniSharp.py')
+
+let g:OmniSharp_use_random_port = get(g:, 'OmniSharp_use_random_port', 0)
+let s:OmniSharp_default_port = g:OmniSharp_use_random_port ? pyeval('find_free_port()') : 2000
+let g:OmniSharp_port = get(g:, 'OmniSharp_port', s:OmniSharp_default_port)
+
+"Setup variable defaults
+"Default value for the server address
+let g:OmniSharp_host = get(g:, 'OmniSharp_host', 'http://localhost:' . g:OmniSharp_port)
 
 let s:server_files = '*.sln'
 let s:allUserTypes = ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -523,7 +523,7 @@ endfunction
 
 function! OmniSharp#ServerIsRunning() abort
   try
-    let s:alive = OmniSharp#py#eval('\"%s\"" % getResponse("/checkalivestatus", None, 0.2)')
+    let s:alive = OmniSharp#py#eval('getResponse("/checkalivestatus", None, 0.2)')
     return s:alive ==# 'true'
   catch
     return 0

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -515,7 +515,7 @@ endfunction
 
 function! OmniSharp#ServerIsRunning() abort
   try
-    call OmniSharp#py#eval('vim.command("let s:alive = \"%s\"" % getResponse("/checkalivestatus", None, 0.2))')
+    let s:alive = OmniSharp#py#eval('\"%s\"" % getResponse("/checkalivestatus", None, 0.2)')
     return s:alive ==# 'true'
   catch
     return 0

--- a/autoload/OmniSharp/lib/py.vim
+++ b/autoload/OmniSharp/lib/py.vim
@@ -1,0 +1,41 @@
+if !(has('python') || has('python3'))
+  finish
+endif
+
+let s:pycmd = has('python3') ? 'python3' : 'python'
+let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
+let s:module_path_added = 0
+let g:omnisharp_python_path = OmniSharp#util#path_join(['python', 'omnisharp'])
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+if exists('*py3eval')
+  let s:pyeval = function('py3eval')
+elseif exists('*pyeval')
+  let s:pyeval = function('pyeval')
+else
+  exec s:pycmd 'import json, vim'
+  function! s:pyeval(e)
+    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
+  endfunction
+endif
+
+function! OmniSharp#lib#py#load(filename)
+  if s:module_path_added == 0
+    exec s:pycmd "sys.path.append(r'" . g:omnisharp_python_path . "')"
+    let s:module_path_added = 1
+  endif
+  exec s:pyfile fnameescape(g:omnisharp_python_path . a:filename)
+endfunction
+
+function! OmniSharp#lib#py#eval(tmp, ...)
+  return s:pyeval(printf(tmp, a:000))
+endfunction
+
+function! OmniSharp#lib#py#exists()
+  return has('python') || has('python3')
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/autoload/OmniSharp/py.vim
+++ b/autoload/OmniSharp/py.vim
@@ -26,12 +26,10 @@ function! OmniSharp#py#load(filename)
     exec s:pycmd "sys.path.append(r'" . g:omnisharp_python_path . "')"
     let s:module_path_added = 1
   endif
-  exec s:pyfile fnameescape(g:omnisharp_python_path . a:filename)
+  exec s:pyfile fnameescape(OmniSharp#util#path_join(['python', 'omnisharp', a:filename]))
 endfunction
 
-function! OmniSharp#py#eval(cmd)
-  return s:pyeval(a:cmd)
-endfunction
+let g:OmniSharp#py#eval = s:pyeval
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/OmniSharp/py.vim
+++ b/autoload/OmniSharp/py.vim
@@ -29,8 +29,8 @@ function! OmniSharp#py#load(filename)
   exec s:pyfile fnameescape(g:omnisharp_python_path . a:filename)
 endfunction
 
-function! OmniSharp#py#eval(tmp, ...)
-  return s:pyeval(printf(tmp, a:000))
+function! OmniSharp#py#eval(cmd)
+  return s:pyeval(a:cmd)
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/OmniSharp/py.vim
+++ b/autoload/OmniSharp/py.vim
@@ -21,7 +21,7 @@ else
   endfunction
 endif
 
-function! OmniSharp#lib#py#load(filename)
+function! OmniSharp#py#load(filename)
   if s:module_path_added == 0
     exec s:pycmd "sys.path.append(r'" . g:omnisharp_python_path . "')"
     let s:module_path_added = 1
@@ -29,12 +29,8 @@ function! OmniSharp#lib#py#load(filename)
   exec s:pyfile fnameescape(g:omnisharp_python_path . a:filename)
 endfunction
 
-function! OmniSharp#lib#py#eval(tmp, ...)
+function! OmniSharp#py#eval(tmp, ...)
   return s:pyeval(printf(tmp, a:000))
-endfunction
-
-function! OmniSharp#lib#py#exists()
-  return has('python') || has('python3')
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -5,6 +5,23 @@
 "endif
 "let g:loaded_ctrlp_findsymbols = 1
 
+if !(has('python') || has('python3'))
+  finish
+endif
+
+let s:pycmd = has('python3') ? 'python3' : 'python'
+let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
+if exists('*py3eval')
+  let s:pyeval = function('py3eval')
+elseif exists('*pyeval')
+  let s:pyeval = function('pyeval')
+else
+  exec s:pycmd 'import json, vim'
+  function! s:pyeval(e)
+    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
+  endfunction
+endif
+
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "
@@ -83,7 +100,7 @@ function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !pyeval(command)
+  if !s:pyeval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -5,9 +5,10 @@
 "endif
 "let g:loaded_ctrlp_findsymbols = 1
 
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   finish
 endif
+
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "
@@ -86,7 +87,7 @@ function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#lib#py#eval(command)
+  if !OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -87,7 +87,7 @@ function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#py#eval(command)
+  if !g:OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -5,23 +5,9 @@
 "endif
 "let g:loaded_ctrlp_findsymbols = 1
 
-if !(has('python') || has('python3'))
+if !OmniSharp#lib#py#exists()
   finish
 endif
-
-let s:pycmd = has('python3') ? 'python3' : 'python'
-let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
-if exists('*py3eval')
-  let s:pyeval = function('py3eval')
-elseif exists('*pyeval')
-  let s:pyeval = function('pyeval')
-else
-  exec s:pycmd 'import json, vim'
-  function! s:pyeval(e)
-    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
-  endfunction
-endif
-
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "
@@ -100,7 +86,7 @@ function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !s:pyeval(command)
+  if !OmniSharp#lib#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -6,10 +6,6 @@ if ( exists('g:OmniSharp_loaded_ctrlp_findsymbols') && g:OmniSharp_loaded_ctrlp_
 endif
 let g:loaded_ctrlp_OmniSharp_findsymbols = 1
 
-if !(has('python') || has('python3'))
-  finish
-endif
-
 " Add this extension's settings to g:ctrlp_ext_vars
 "
 " Required:

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -59,7 +59,20 @@ endfunction
 " Return: a Vim's List
 "
 function! ctrlp#OmniSharp#findsymbols#init() abort
+<<<<<<< HEAD
   return s:symbols
+=======
+  if !OmniSharp#ServerIsRunning()
+    return
+  endif
+
+  let s:quickfixes = OmniSharp#py#eval('findSymbols()')
+  let symbols = []
+  for quickfix in s:quickfixes
+    call add(symbols, quickfix.text)
+  endfor
+  return symbols
+>>>>>>> 1eb03cb... Remove #py#exists and fixup the new util function
 endfunction
 
 

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -59,20 +59,7 @@ endfunction
 " Return: a Vim's List
 "
 function! ctrlp#OmniSharp#findsymbols#init() abort
-<<<<<<< HEAD
   return s:symbols
-=======
-  if !OmniSharp#ServerIsRunning()
-    return
-  endif
-
-  let s:quickfixes = OmniSharp#py#eval('findSymbols()')
-  let symbols = []
-  for quickfix in s:quickfixes
-    call add(symbols, quickfix.text)
-  endfor
-  return symbols
->>>>>>> 1eb03cb... Remove #py#exists and fixup the new util function
 endfunction
 
 

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -6,6 +6,9 @@ if ( exists('g:OmniSharp_loaded_ctrlp_findsymbols') && g:OmniSharp_loaded_ctrlp_
 endif
 let g:loaded_ctrlp_OmniSharp_findsymbols = 1
 
+if !(has('python') || has('python3'))
+  finish
+endif
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "

--- a/autoload/ctrlp/OmniSharp/findtype.vim
+++ b/autoload/ctrlp/OmniSharp/findtype.vim
@@ -5,7 +5,7 @@ if ( exists('g:loaded_ctrlp_OmniSharp_findtype') && g:loaded_ctrlp_OmniSharp_fin
 endif
 let g:loaded_ctrlp_OmniSharp_findtype = 1
 
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   finish
 endif
 
@@ -58,7 +58,7 @@ function! ctrlp#OmniSharp#findtype#init() abort
     return
   endif
 
-  let s:quickfixes = OmniSharp#lib#py#eval('findTypes()')
+  let s:quickfixes = OmniSharp#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)

--- a/autoload/ctrlp/OmniSharp/findtype.vim
+++ b/autoload/ctrlp/OmniSharp/findtype.vim
@@ -5,6 +5,23 @@ if ( exists('g:loaded_ctrlp_OmniSharp_findtype') && g:loaded_ctrlp_OmniSharp_fin
 endif
 let g:loaded_ctrlp_OmniSharp_findtype = 1
 
+if !(has('python') || has('python3'))
+  finish
+endif
+
+let s:pycmd = has('python3') ? 'python3' : 'python'
+let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
+if exists('*py3eval')
+  let s:pyeval = function('py3eval')
+elseif exists('*pyeval')
+  let s:pyeval = function('pyeval')
+else
+  exec s:pycmd 'import json, vim'
+  function! s:pyeval(e)
+    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
+  endfunction
+endif
+
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "
@@ -55,7 +72,7 @@ function! ctrlp#OmniSharp#findtype#init() abort
     return
   endif
 
-  let s:quickfixes = pyeval('findTypes()')
+  let s:quickfixes = s:pyeval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)

--- a/autoload/ctrlp/OmniSharp/findtype.vim
+++ b/autoload/ctrlp/OmniSharp/findtype.vim
@@ -5,23 +5,9 @@ if ( exists('g:loaded_ctrlp_OmniSharp_findtype') && g:loaded_ctrlp_OmniSharp_fin
 endif
 let g:loaded_ctrlp_OmniSharp_findtype = 1
 
-if !(has('python') || has('python3'))
+if !OmniSharp#lib#py#exists()
   finish
 endif
-
-let s:pycmd = has('python3') ? 'python3' : 'python'
-let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
-if exists('*py3eval')
-  let s:pyeval = function('py3eval')
-elseif exists('*pyeval')
-  let s:pyeval = function('pyeval')
-else
-  exec s:pycmd 'import json, vim'
-  function! s:pyeval(e)
-    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
-  endfunction
-endif
-
 
 " Add this extension's settings to g:ctrlp_ext_vars
 "
@@ -72,7 +58,7 @@ function! ctrlp#OmniSharp#findtype#init() abort
     return
   endif
 
-  let s:quickfixes = s:pyeval('findTypes()')
+  let s:quickfixes = OmniSharp#lib#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)

--- a/autoload/ctrlp/OmniSharp/findtype.vim
+++ b/autoload/ctrlp/OmniSharp/findtype.vim
@@ -58,7 +58,7 @@ function! ctrlp#OmniSharp#findtype#init() abort
     return
   endif
 
-  let s:quickfixes = OmniSharp#py#eval('findTypes()')
+  let s:quickfixes = g:OmniSharp#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -1,5 +1,18 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
+endif
+
+let s:pycmd = has('python3') ? 'python3' : 'python'
+let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
+if exists('*py3eval')
+  let s:pyeval = function('py3eval')
+elseif exists('*pyeval')
+  let s:pyeval = function('pyeval')
+else
+  exec s:pycmd 'import json, vim'
+  function! s:pyeval(e)
+    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
+  endfunction
 endif
 
 let s:save_cpo = &cpoptions
@@ -19,7 +32,7 @@ function! fzf#OmniSharp#findtypes() abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let s:quickfixes = pyeval('findTypes()')
+  let s:quickfixes = s:pyeval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)
@@ -51,7 +64,7 @@ function! s:action_sink(str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !pyeval(command)
+  if !s:pyeval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -1,4 +1,4 @@
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   finish
 endif
 
@@ -19,7 +19,7 @@ function! fzf#OmniSharp#findtypes() abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let s:quickfixes = OmniSharp#lib#py#eval('findTypes()')
+  let s:quickfixes = OmniSharp#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)
@@ -51,7 +51,7 @@ function! s:action_sink(str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#lib#py#eval(command)
+  if !OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -19,7 +19,7 @@ function! fzf#OmniSharp#findtypes() abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let s:quickfixes = OmniSharp#py#eval('findTypes()')
+  let s:quickfixes = g:OmniSharp#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)
@@ -51,7 +51,7 @@ function! s:action_sink(str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#py#eval(command)
+  if !g:OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -1,18 +1,5 @@
-if !(has('python') || has('python3'))
+if !OmniSharp#lib#py#exists()
   finish
-endif
-
-let s:pycmd = has('python3') ? 'python3' : 'python'
-let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
-if exists('*py3eval')
-  let s:pyeval = function('py3eval')
-elseif exists('*pyeval')
-  let s:pyeval = function('pyeval')
-else
-  exec s:pycmd 'import json, vim'
-  function! s:pyeval(e)
-    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
-  endfunction
 endif
 
 let s:save_cpo = &cpoptions
@@ -32,7 +19,7 @@ function! fzf#OmniSharp#findtypes() abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let s:quickfixes = s:pyeval('findTypes()')
+  let s:quickfixes = OmniSharp#lib#py#eval('findTypes()')
   let types = []
   for quickfix in s:quickfixes
     call add(types, quickfix.text)
@@ -64,7 +51,7 @@ function! s:action_sink(str) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !s:pyeval(command)
+  if !OmniSharp#lib#py#eval(command)
     echo 'No action taken'
   endif
 endfunction

--- a/autoload/unite/sources/OmniSharp.vim
+++ b/autoload/unite/sources/OmniSharp.vim
@@ -1,18 +1,5 @@
-if !(has('python') || has('python3'))
+if !OmniSharp#lib#py#exists()
   finish
-endif
-
-let s:pycmd = has('python3') ? 'python3' : 'python'
-let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
-if exists('*py3eval')
-  let s:pyeval = function('py3eval')
-elseif exists('*pyeval')
-  let s:pyeval = function('pyeval')
-else
-  exec s:pycmd 'import json, vim'
-  function! s:pyeval(e)
-    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
-  endfunction
 endif
 
 let s:save_cpo = &cpoptions
@@ -60,7 +47,7 @@ function! s:findcodeactions_action_table.run.func(candidate) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !s:pyeval(command)
+  if !OmniSharp#lib#py#eval(command)
     echo 'No action taken'
   endif
 endfunction
@@ -93,7 +80,7 @@ function! s:findtype.gather_candidates(args, context) abort
   if !OmniSharp#ServerIsRunning()
     return []
   endif
-  let symbols = s:pyeval('findTypes()')
+  let symbols = OmniSharp#lib#py#eval('findTypes()')
   return map(symbols, '{
   \   "word": get(split(v:val.text, "\t"), 0),
   \   "abbr": v:val.text,

--- a/autoload/unite/sources/OmniSharp.vim
+++ b/autoload/unite/sources/OmniSharp.vim
@@ -1,3 +1,20 @@
+if !(has('python') || has('python3'))
+  finish
+endif
+
+let s:pycmd = has('python3') ? 'python3' : 'python'
+let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
+if exists('*py3eval')
+  let s:pyeval = function('py3eval')
+elseif exists('*pyeval')
+  let s:pyeval = function('pyeval')
+else
+  exec s:pycmd 'import json, vim'
+  function! s:pyeval(e)
+    exec s:pycmd 'vim.command("return " + json.dumps(eval(vim.eval("a:e"))))'
+  endfunction
+endif
+
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
@@ -43,7 +60,7 @@ function! s:findcodeactions_action_table.run.func(candidate) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !pyeval(command)
+  if !s:pyeval(command)
     echo 'No action taken'
   endif
 endfunction
@@ -76,7 +93,7 @@ function! s:findtype.gather_candidates(args, context) abort
   if !OmniSharp#ServerIsRunning()
     return []
   endif
-  let symbols = pyeval('findTypes()')
+  let symbols = s:pyeval('findTypes()')
   return map(symbols, '{
   \   "word": get(split(v:val.text, "\t"), 0),
   \   "abbr": v:val.text,

--- a/autoload/unite/sources/OmniSharp.vim
+++ b/autoload/unite/sources/OmniSharp.vim
@@ -1,4 +1,4 @@
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   finish
 endif
 
@@ -47,7 +47,7 @@ function! s:findcodeactions_action_table.run.func(candidate) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#lib#py#eval(command)
+  if !OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction
@@ -80,7 +80,7 @@ function! s:findtype.gather_candidates(args, context) abort
   if !OmniSharp#ServerIsRunning()
     return []
   endif
-  let symbols = OmniSharp#lib#py#eval('findTypes()')
+  let symbols = OmniSharp#py#eval('findTypes()')
   return map(symbols, '{
   \   "word": get(split(v:val.text, "\t"), 0),
   \   "abbr": v:val.text,

--- a/autoload/unite/sources/OmniSharp.vim
+++ b/autoload/unite/sources/OmniSharp.vim
@@ -47,7 +47,7 @@ function! s:findcodeactions_action_table.run.func(candidate) abort
     let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
     let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
-  if !OmniSharp#py#eval(command)
+  if !g:OmniSharp#py#eval(command)
     echo 'No action taken'
   endif
 endfunction
@@ -80,7 +80,7 @@ function! s:findtype.gather_candidates(args, context) abort
   if !OmniSharp#ServerIsRunning()
     return []
   endif
-  let symbols = OmniSharp#py#eval('findTypes()')
+  let symbols = g:OmniSharp#py#eval('findTypes()')
   return map(symbols, '{
   \   "word": get(split(v:val.text, "\t"), 0),
   \   "abbr": v:val.text,

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -22,7 +22,7 @@ CONTENTS                                                   *omnisharp-contents*
 DEPENDENCIES                                           *omnisharp-dependencies*
 
 Required:~
-    - Vim 7.3 or higher with Python 2 support
+    - Vim 7.4 or higher with Python 2 or Python 3 support
     - Mono OR .NET Framework
 
 Optional:~

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -1,4 +1,4 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
 endif
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -4,8 +4,8 @@ endif
 
 let g:OmniSharp_loaded = 1
 
-if !has('python')
-  echoerr 'Error: OmniSharp requires Vim compiled with +python'
+if !(has('python') || has('python3'))
+  echoerr 'Error: OmniSharp requires Vim compiled with +python or +python3'
   finish
 endif
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -4,7 +4,7 @@ endif
 
 let g:OmniSharp_loaded = 1
 
-if !(has('python') || has('python3'))
+if !OmniSharp#lib#py#exists()
   echoerr 'Error: OmniSharp requires Vim compiled with +python or +python3'
   finish
 endif

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -12,14 +12,6 @@ endif
 " Set default for translating cygwin/WSL unix paths to Windows paths
 let g:OmniSharp_translate_cygwin_wsl = get(g:, 'OmniSharp_translate_cygwin_wsl', 0)
 
-let g:OmniSharp_use_random_port = get(g:, 'OmniSharp_use_random_port', 0)
-let s:OmniSharp_default_port = g:OmniSharp_use_random_port ? pyeval('find_free_port()') : 2000
-let g:OmniSharp_port = get(g:, 'OmniSharp_port', s:OmniSharp_default_port)
-
-"Setup variable defaults
-"Default value for the server address
-let g:OmniSharp_host = get(g:, 'OmniSharp_host', 'http://localhost:' . g:OmniSharp_port)
-
 "Default value for the timeout value
 let g:OmniSharp_timeout = get(g:, 'OmniSharp_timeout', 1)
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -4,7 +4,7 @@ endif
 
 let g:OmniSharp_loaded = 1
 
-if !OmniSharp#lib#py#exists()
+if !(has('python') || has('python3'))
   echoerr 'Error: OmniSharp requires Vim compiled with +python or +python3'
   finish
 endif

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -226,7 +226,7 @@ contextmanager-decorators=contextlib.contextmanager
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,ex,Run,_,logger
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -291,10 +291,10 @@ class-rgx=[A-Z_][a-zA-Z0-9]+$
 class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=(test_[a-z_][a-z0-9_]{2,60}$|[a-z_][a-z0-9_]{2,30}$)
 
 # Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
+function-name-hint=(test_[a-z_][a-z0-9_]{2,60}$|[a-z_][a-z0-9_]{2,30}$)
 
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -8,6 +8,9 @@ import os.path
 import types
 import sys
 import platform
+import re
+import socket
+from contextlib import closing
 
 try:
     from urllib import parse as urlparse

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -6,6 +6,7 @@ import json
 import os
 import os.path
 import types
+import sys
 
 try:
     from urllib import parse as urlparse
@@ -89,6 +90,10 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
         response = opener.open(req, json.dumps(parameters), timeout)
         vim.command("let g:serverSeenRunning = 1")
         res = response.read()
+
+        if sys.version_info >= (3, 0):
+            res = res.decode('utf-8')
+
         if res.startswith("\xef\xbb\xbf"):  # Drop UTF-8 BOM
             res = res[3:]
         return res

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -429,6 +429,7 @@ def get_navigate_response(js):
         return {}
 
 def find_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with closing(s):
         s.bind(('', 0))
         return s.getsockname()[1]

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -95,7 +95,13 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
     req.add_header('Content-Type', 'application/json')
 
     try:
-        response = opener.open(req, json.dumps(parameters), timeout)
+
+        body = json.dumps(parameters)
+
+        if sys.version_info >= (3, 0):
+            body = body.encode('utf-8')
+
+        response = opener.open(req, body, timeout)
         vim.command("let g:serverSeenRunning = 1")
         res = response.read()
 

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -1,5 +1,20 @@
-import json, logging, os.path, platform, re, urllib2, urlparse, vim, socket
-from contextlib import closing
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import json
+import os
+import os.path
+import types
+
+try:
+    from urllib import parse as urlparse
+    from urllib import request
+except ImportError:
+    import urllib2 as request
+    import urlparse
+
+import vim  # pylint: disable=import-error
 
 logger = logging.getLogger('omnisharp')
 logger.setLevel(logging.WARNING)
@@ -65,9 +80,9 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
 
     target = urlparse.urljoin(host, endPoint)
 
-    proxy = urllib2.ProxyHandler({})
-    opener = urllib2.build_opener(proxy)
-    req = urllib2.Request(target)
+    proxy = request.ProxyHandler({})
+    opener = request.build_opener(proxy)
+    req = request.Request(target)
     req.add_header('Content-Type', 'application/json')
 
     try:

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -7,6 +7,7 @@ import os
 import os.path
 import types
 import sys
+import platform
 
 try:
     from urllib import parse as urlparse

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -20,7 +20,11 @@ import vim  # pylint: disable=import-error
 logger = logging.getLogger('omnisharp')
 logger.setLevel(logging.WARNING)
 
-log_dir = os.path.join(vim.eval('expand("<sfile>:p:h")'), '..', 'log')
+log_dir = os.path.join(
+    vim.eval('g:omnisharp_python_path'),
+    '..',
+    '..',
+    'log')
 if not os.path.exists(log_dir):
     os.makedirs(log_dir)
 hdlr = logging.FileHandler(os.path.join(log_dir, 'python.log'))

--- a/python/tests/mock_vim.py
+++ b/python/tests/mock_vim.py
@@ -26,6 +26,8 @@ def mock_eval(expr):
         return 0
     elif expr.startswith('g:OmniSharp'):
         return "some_global_setting"
+    elif expr.startswith('g:omnisharp_python_path'):
+        return "."
     elif expr == 'expand("<sfile>:p:h")':
         return os.path.dirname(__file__)
 

--- a/python/tests/test_vim.py
+++ b/python/tests/test_vim.py
@@ -2,22 +2,30 @@
 # -*- coding: utf-8 -*-
 
 import mock
+import sys
 import tests.mock_vim as vim
 from omnisharp import OmniSharp
 
 def test_get_response_no_server():
-    response = OmniSharp.getResponse("my_endpoint")
+    response = OmniSharp.getResponse("http://my_endpoint")
     expected_response = ''
     assert expected_response == response
 
-@mock.patch('urllib2.build_opener')
+if sys.version_info >= (3, 0):
+    BUILD_OPENER = 'urllib.request.build_opener'
+elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
+    BUILD_OPENER = 'urllib2.build_opener'
+else:
+    raise ImportError("Unsupported python version")
+
+@mock.patch(BUILD_OPENER)
 def test_get_response_mocked_server(build_opener):
     mocked_response = '\xef\xbb\xbfMocked response with UTF-8 BOM'
     build_opener \
         .return_value.open \
         .return_value.read \
         .return_value = mocked_response
-    response = OmniSharp.getResponse("my_endpoint")
+    response = OmniSharp.getResponse("http://my_endpoint")
 
     expected_response = mocked_response[3:]
     assert expected_response == response

--- a/python/tests/test_vim.py
+++ b/python/tests/test_vim.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import mock
-import sys
-import tests.mock_vim as vim
-from omnisharp import OmniSharp
+'''Simple tests'''
 
-def test_get_response_no_server():
-    response = OmniSharp.getResponse("http://my_endpoint")
-    expected_response = ''
-    assert expected_response == response
+import sys
+import json
+import mock
+
+import tests.mock_vim as vim  # pylint: disable=unused-import
+from omnisharp import OmniSharp
 
 if sys.version_info >= (3, 0):
     BUILD_OPENER = 'urllib.request.build_opener'
@@ -18,14 +17,48 @@ elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
 else:
     raise ImportError("Unsupported python version")
 
+
+def test_get_response_no_server():
+    '''Test that the response is empty when there is no server'''
+    response = OmniSharp.getResponse("http://my_endpoint")
+    expected_response = ''
+    assert expected_response == response
+
 @mock.patch(BUILD_OPENER)
 def test_get_response_mocked_server(build_opener):
-    mocked_response = '\xef\xbb\xbfMocked response with UTF-8 BOM'
+    '''Test that we can get a response the server'''
+    expected_response = 'Mocked response with UTF-8 BOM'
+    if sys.version_info >= (3, 0):
+        mocked_response = (
+            '\xef\xbb\xbf' + expected_response).encode('utf-8')
+    elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
+        mocked_response = '\xef\xbb\xbf' + expected_response
+
     build_opener \
         .return_value.open \
         .return_value.read \
         .return_value = mocked_response
+
     response = OmniSharp.getResponse("http://my_endpoint")
 
-    expected_response = mocked_response[3:]
     assert expected_response == response
+
+@mock.patch(BUILD_OPENER)
+def test_get_json_response_mocked_server(build_opener):
+    '''Test that we can get a response the server'''
+    expected_response = '{"foo": "bar"}'
+    if sys.version_info >= (3, 0):
+        mocked_response = (
+            '\xef\xbb\xbf' + expected_response).encode('utf-8')
+    elif sys.version_info < (3, 0) and sys.version_info >= (2, 5):
+        mocked_response = '\xef\xbb\xbf' + expected_response
+
+    build_opener \
+        .return_value.open \
+        .return_value.read \
+        .return_value = mocked_response
+
+    response = OmniSharp.getResponse("http://my_endpoint")
+
+    assert expected_response == response
+    assert {'foo': 'bar'} == json.loads(response)

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -6,7 +6,11 @@
 [tox]
 # In the future the plan is to support the following
 #envlist = py27, py34, py35, py36
-envlist = py{27,35}
+envlist =
+  py27,
+  py35,
+  lint2,
+  lint
 
 [testenv]
 commands = py.test tests
@@ -14,6 +18,14 @@ deps =
     pylint
     pytest
     mock
+
+[testenv:lint2]
+basepython=python2.7
+deps =
+    pylint
+    pytest
+    mock
+commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests
 
 [testenv:lint]
 basepython=python3.5

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -25,7 +25,7 @@ deps =
     pylint
     pytest
     mock
-commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests
+commands=pylint -E {envsitepackagesdir}/omnisharp {toxinidir}/tests
 
 [testenv:lint]
 basepython=python3.5
@@ -33,4 +33,4 @@ deps =
     pylint
     pytest
     mock
-commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests
+commands=pylint -E {envsitepackagesdir}/omnisharp {toxinidir}/tests

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -11,18 +11,11 @@ envlist = py{27,35}
 [testenv]
 commands = py.test tests
 deps =
-    pytest
-    mock
-
-[testenv:lint27]
-basepython=python2.7
-deps =
     pylint
     pytest
     mock
-commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests
 
-[testenv:lint35]
+[testenv:lint]
 basepython=python3.5
 deps =
     pylint

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -6,11 +6,26 @@
 [tox]
 # In the future the plan is to support the following
 #envlist = py27, py34, py35, py36
-envlist = py27
+envlist = py{27,35}
 
 [testenv]
 commands = py.test tests
 deps =
     pytest
-    pylint
     mock
+
+[testenv:lint27]
+basepython=python2.7
+deps =
+    pylint
+    pytest
+    mock
+commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests
+
+[testenv:lint35]
+basepython=python3.5
+deps =
+    pylint
+    pytest
+    mock
+commands=pylint -rn {envsitepackagesdir}/omnisharp {toxinidir}/tests

--- a/syntax_checkers/cs/codecheck.vim
+++ b/syntax_checkers/cs/codecheck.vim
@@ -1,4 +1,4 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
 endif
 

--- a/syntax_checkers/cs/issues.vim
+++ b/syntax_checkers/cs/issues.vim
@@ -1,4 +1,4 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
 endif
 

--- a/syntax_checkers/cs/semantic.vim
+++ b/syntax_checkers/cs/semantic.vim
@@ -1,4 +1,4 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
 endif
 

--- a/syntax_checkers/cs/syntax.vim
+++ b/syntax_checkers/cs/syntax.vim
@@ -1,4 +1,4 @@
-if !has('python')
+if !(has('python') || has('python3'))
   finish
 endif
 


### PR DESCRIPTION
I am trying to get this working again.

I am raising this PR as `omnisharp-vim` is the last plugin, that is requiring me to have python 2 installed.  This depends on #287 as #287 adds the necessary infrastructure to test the python mod
                                                                                                                                                                                                          
Features I'd like to see getting merged:
- [ ] Pylint setup
- [x] Tox setup
- [ ] Working code that is compatible with both Python versions.  It would be much easier to just use Python 3, but I do not know if this is desired.
                                                                                                                                                                                                          
It would be great to hear any feedback on whether we want to support both Python versions.
                                                                                                                                                                                                          
**NOTE**: Since #275 is quite big, I would prefer it to be merged before dealing with this and #287.
Currently rebased on `feature/pytest` for easier testing.