### PR TITLE
Add `OmniSharp_sln_finder` for situations where the solution file isn't in a parent folder of the current C# file.

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -599,6 +599,19 @@ function! OmniSharp#ExpandAutoCompleteSnippet()
 endfunction
 
 function! s:find_solution_files() abort
+  if g:OmniSharp_sln_finder != ''
+    let found = call(g:OmniSharp_sln_finder, [expand('%:p')])
+    if type(found) == type([])
+      return found
+    elseif type(found) == type('')
+      if found == ''
+        return []
+      else
+        return [found]
+      endif
+    endif
+  endif
+
   "get the path for the current buffer
   let dir = expand('%:p:h')
   let lastfolder = ''

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -92,3 +92,5 @@ let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
 if !exists('g:OmniSharp_prefer_global_sln')
   let g:OmniSharp_prefer_global_sln = 0
 endif
+
+let g:OmniSharp_sln_finder = get(g:, 'OmniSharp_sln_finder', '')


### PR DESCRIPTION
This can happen when either the solution file or the C# file are actually generated files and are in some temp folder apart from the source code checked into Git/Hg/P4/etc.