### PR TITLE
Interpret "null" FileName response as current file

### DIFF
--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -232,8 +232,12 @@ def quickfixes_from_response(response):
         if 'Message' in quickfix:
             text = quickfix['Message']
 
+        filename = quickfix['FileName']
+        if filename == None:
+            filename = vim.current.buffer.name
+
         item = {
-            'filename': quickfix['FileName'],
+            'filename': filename,
             'text': text,
             'lnum': quickfix['Line'],
             'col': quickfix['Column'],


### PR DESCRIPTION
The rolsyn server returns json containing "FileName": "null" from /currentfilemembersasflat in a call to OmniSharpFindMembers - presumably since this method only applies to the current file.

The "null" value can't be read by vim, so "null" filenames are replaced with the current buffer name.