### PR TITLE
Make fetch_full_documentation match README & help

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ set completeopt=longest,menuone,preview
 " There is a performance penalty with this (especially on Mono)
 " By default, only Type/Method signatures are fetched. Full documentation can still be fetched when
 " you need it with the :OmniSharpDocumentation command.
-" let g:omnicomplete_fetch_documentation=1
+" let g:omnicomplete_fetch_full_documentation=1
 
 "Move the preview window (code documentation) to the bottom of the screen, so it doesn't move the code!
 "You might also want to look at the echodoc plugin

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -101,12 +101,12 @@ server. Default: 1 >
     let g:OmniSharp_timeout=1
 <
 
-                                         *'g:omnicomplete_fetch_documentation'*
+                                         *'g:omnicomplete_fetch_full_documentation'*
 Use this option to specify whether OmniSharp will fetch full documentation on
 completion suggestions. By default, only type/method signatures are fetched for
 performance reasons. Full documentation can still be fetched when needed using
 the |:OmniSharpDocumentation| command. Default: 0 >
-    let g:omnicomplete_fetch_documentation=0
+    let g:omnicomplete_fetch_full_documentation=0
 <
 
                                                    *'g:OmniSharp_want_snippet'*

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -7,7 +7,6 @@ if get(b:, 'OmniSharp_ftplugin_loaded', 0)
 endif
 let b:OmniSharp_ftplugin_loaded = 1
 
-"Set a default value for the server address
 if !exists('g:omnicomplete_fetch_full_documentation')
     let g:omnicomplete_fetch_full_documentation = 0
 endif


### PR DESCRIPTION
The README and :help documentation describe variable `g:omnisharp_fetch_documentation` but in code it is actually called `g:omnisharp_fetch_full_documentation`.