### PR TITLE
Avoid to spawn server twice

### DIFF
--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -52,14 +52,20 @@ function! OmniSharp#proc#vimErrHandler(channel, message) abort
   echoerr printf('%s: %s', string(a:channel), string(a:message))
 endfunction
 
+let s:job = v:null
+
 function! OmniSharp#proc#vimJobStart(command) abort
   if OmniSharp#proc#supportsVimJobs()
     call s:debug('Using vim job_start to start the following command:')
     call s:debug(a:command)
-    return job_start(
-                \ a:command,
-                \ {'out_cb': 'OmniSharp#proc#vimOutHandler',
-                \  'err_cb': 'OmniSharp#proc#vimErrHandler'})
+    if type(s:job) !=# v:t_job || job_status(s:job) ==# 'dead'
+      let s:job = job_start(
+                  \ a:command,
+                  \ {'out_cb': 'OmniSharp#proc#vimOutHandler',
+                  \  'err_cb': 'OmniSharp#proc#vimErrHandler'})
+    else
+      call s:debug('Skip to start server since job still exists')
+    endif
   else
     echoerr 'Not using Vim 8.0+'
   endif

--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -52,13 +52,11 @@ function! OmniSharp#proc#vimErrHandler(channel, message) abort
   echoerr printf('%s: %s', string(a:channel), string(a:message))
 endfunction
 
-let s:job = v:null
-
 function! OmniSharp#proc#vimJobStart(command) abort
   if OmniSharp#proc#supportsVimJobs()
     call s:debug('Using vim job_start to start the following command:')
     call s:debug(a:command)
-    if type(s:job) !=# v:t_job || job_status(s:job) ==# 'dead'
+    if !exists('s:job') || job_status(s:job) ==# 'dead'
       let s:job = job_start(
                   \ a:command,
                   \ {'out_cb': 'OmniSharp#proc#vimOutHandler',


### PR DESCRIPTION
The case that set filetype immediately twice, for example, if I'm very fast to open the two C# files. Server will be spawned twice. And the second server throw exception `EADDRINUSE address already in use`. This change avoid to spawn the server if the job still exists.