### PR TITLE
Superficial: Remove incorrect version information from syntax

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -1,10 +1,8 @@
 " Vim syntax file
 " Language:	C#
-" Maintainer:	Anduin Withers <awithers@anduin.com>
+" Maintainer:	OmniSharp & Anduin Withers <awithers@anduin.com>
 " Former Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri Aug 14 13:56:37 PDT 2009
 " Filenames:	*.cs
-" $Id: cs.vim,v 1.4 2006/05/03 21:20:02 vimboss Exp $
 "
 " REFERENCES:
 " [1] ECMA TC39: C# Language Specification (WD13Oct01.doc)


### PR DESCRIPTION
The omnisharp syntax file was copied from the standard vimfiles, but
it's had some heavy modifications despite "last change" being 2009.

Add OmniSharp as a Maintainer and strip out the version lines to help
others find their way back to this repo and make it clearer that the
file isn't stock.

I was confused when looking through my C# syntax files: I had what appeared to be three identical ones because I had also copied the vimfiles one. But all three had different contents. This change hopes to prevent similar confusion for others.