### PR TITLE
Override folds

### DIFF
--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -101,7 +101,7 @@ server. Default: 1 >
     let g:OmniSharp_timeout=1
 <
 
-                                         *'g:omnicomplete_fetch_full_documentation'*
+                                    *'g:omnicomplete_fetch_full_documentation'*
 Use this option to specify whether OmniSharp will fetch full documentation on
 completion suggestions. By default, only type/method signatures are fetched for
 performance reasons. Full documentation can still be fetched when needed using
@@ -113,6 +113,12 @@ the |:OmniSharpDocumentation| command. Default: 0 >
 Use this option to enable snippet completion. Requires `completeopt-=preview`.
 Default: 0 >
     let g:OmniSharp_want_snippet=0
+<
+
+                                                 *'g:OmniSharp_override_folds'*
+Use a custom 'foldtext' for closed folds.
+Default: 1 >
+    let g:OmniSharp_override_folds=1
 <
 
 ===============================================================================

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -115,10 +115,10 @@ Default: 0 >
     let g:OmniSharp_want_snippet=0
 <
 
-                                                 *'g:OmniSharp_override_folds'*
+                                                   *'g:OmniSharp_set_foldtext'*
 Use a custom 'foldtext' for closed folds.
 Default: 1 >
-    let g:OmniSharp_override_folds=1
+    let g:OmniSharp_set_foldtext=1
 <
 
 ===============================================================================

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -30,6 +30,8 @@ let g:OmniSharp_quickFixLength = get(g:, 'OmniSharp_quickFixLength', 60)
 "Don't use the preview window by default
 let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0)
 
+let g:OmniSharp_override_folds = get(g:, 'OmniSharp_override_folds', 1)
+
 " Auto syntax-check options.
 " Default:
 " g:OmniSharp_BufWritePreSyntaxCheck = 1

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -30,6 +30,7 @@ let g:OmniSharp_quickFixLength = get(g:, 'OmniSharp_quickFixLength', 60)
 "Don't use the preview window by default
 let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0)
 
+"Override foldtext with a custom OmniSharp fold string
 let g:OmniSharp_override_folds = get(g:, 'OmniSharp_override_folds', 1)
 
 " Auto syntax-check options.

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -30,8 +30,8 @@ let g:OmniSharp_quickFixLength = get(g:, 'OmniSharp_quickFixLength', 60)
 "Don't use the preview window by default
 let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0)
 
-"Override foldtext with a custom OmniSharp fold string
-let g:OmniSharp_override_folds = get(g:, 'OmniSharp_override_folds', 1)
+"Set 'foldtext' to a custom OmniSharp fold string
+let g:OmniSharp_set_foldtext = get(g:, 'OmniSharp_set_foldtext', 1)
 
 " Auto syntax-check options.
 " Default:

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -16,22 +16,22 @@ endif
 let s:cs_cpo_save = &cpo
 set cpo&vim
 
-" Fold Message Function
-func! SummaryFolds()
-    let firstLine = getline(v:foldstart)
-    if firstLine =~ "<summary>"
-        let line = getline(v:foldstart + 1)
-        let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
-        return "+--" . " Summary: " . sub
-    elseif firstLine =~ "# region"
-        let sub = substitute(firstLine, '\s*\# region ', '', 'g')
-        return "+-- Region: " . sub
-    else
-        return "+-- " . firstLine
-    endif
-endfunc
+if g:OmniSharp_set_foldtext
+    " Fold Message Function
+    func! SummaryFolds()
+        let firstLine = getline(v:foldstart)
+        if firstLine =~ "<summary>"
+            let line = getline(v:foldstart + 1)
+            let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
+            return "+--" . " Summary: " . sub
+        elseif firstLine =~ "# region"
+            let sub = substitute(firstLine, '\s*\# region ', '', 'g')
+            return "+-- Region: " . sub
+        else
+            return "+-- " . firstLine
+        endif
+    endfunc
 
-if g:OmniSharp_override_folds
     augroup cs_folds
         autocmd!
         autocmd BufEnter *.cs setlocal foldtext=SummaryFolds()

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -20,14 +20,14 @@ set cpo&vim
 func! SummaryFolds()
     let firstLine = getline(v:foldstart)
     if firstLine =~ "<summary>"
-	let line = getline(v:foldstart + 1)
-	let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
-	return "+--" . " Summary: " . sub
+        let line = getline(v:foldstart + 1)
+        let sub = substitute(line, '\s*\/\/\/ ', '', 'g')
+        return "+--" . " Summary: " . sub
     elseif firstLine =~ "# region"
-	let sub = substitute(firstLine, '\s*\# region ', '', 'g')
-	return "+-- Region: " . sub
+        let sub = substitute(firstLine, '\s*\# region ', '', 'g')
+        return "+-- Region: " . sub
     else
-	return "+-- " . firstLine
+        return "+-- " . firstLine
     endif
 endfunc
 

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -31,10 +31,12 @@ func! SummaryFolds()
     endif
 endfunc
 
-augroup cs_folds
-    autocmd!
-    autocmd BufEnter *.cs setlocal foldtext=SummaryFolds()
-augroup END
+if g:OmniSharp_override_folds
+    augroup cs_folds
+        autocmd!
+        autocmd BufEnter *.cs setlocal foldtext=SummaryFolds()
+    augroup END
+endif
 
 " type
 syn keyword csType			bool byte char decimal double float int long object sbyte short string T uint ulong ushort var void dynamic


### PR DESCRIPTION
The syntax/cs.vim file contains an autocmd and function to set 'foldtext'. This PR wraps this functionality with an option so it can be disabled in vimrc, allowing users to use their own custom foldtext.

The new option defaults to `g:OmniSharp_set_foldtext = 1` so the current behaviour remains consistent.