### PR TITLE
Use roslyn /v2/getcodeactions

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -169,13 +169,9 @@ function! OmniSharp#GetCodeActions(mode) range abort
     let context = {'empty': 0, 'auto_resize': 1}
     call unite#start([['OmniSharp/findcodeactions', a:mode]], context)
   elseif g:OmniSharp_selector_ui ==? 'ctrlp'
-    let actions = pyeval(printf('getCodeActions(%s)', string(a:mode)))
-    if empty(actions)
-      echo 'No code actions found'
-      return
+    if ctrlp#OmniSharp#findcodeactions#setactions(a:mode)
+      call ctrlp#init(ctrlp#OmniSharp#findcodeactions#id())
     endif
-    call ctrlp#OmniSharp#findcodeactions#setactions(a:mode, actions)
-    call ctrlp#init(ctrlp#OmniSharp#findcodeactions#id())
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#getcodeactions(a:mode)
   else

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -46,19 +46,28 @@ call add(g:ctrlp_ext_vars, {
 \ })
 
 
-function! ctrlp#OmniSharp#findcodeactions#setactions(mode, actions) abort
-  let s:actions = a:actions
+function! ctrlp#OmniSharp#findcodeactions#setactions(mode) abort
+  " When using the roslyn server, use /v2/codeactions
+  let s:version = g:OmniSharp_server_type ==# 'roslyn' ? 'v2' : 'v1'
+  let s:actions = pyeval(printf('getCodeActions(%s, %s)', string(a:mode), string(s:version)))
   let s:mode = a:mode
+  if empty(s:actions)
+    echo 'No code actions found'
+    return 0
+  endif
+  return 1
 endfunction
 
 " Provide a list of strings to search in
 "
 " Return: a Vim's List
 "
-"
-
 function! ctrlp#OmniSharp#findcodeactions#init() abort
-  return s:actions
+  if s:version ==# 'v1'
+    return s:actions
+  else
+    return map(copy(s:actions), {i,v -> get(v, 'Name')})
+  endif
 endfunction
 
 
@@ -71,8 +80,17 @@ endfunction
 "
 function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
   call ctrlp#exit()
-  let action = index(s:actions, a:str)
-  call pyeval(printf('runCodeAction(%s, %d)', string(s:mode), action))
+  if s:version ==# 'v1'
+    let action = index(s:actions, a:str)
+    let command = printf('runCodeAction(%s, %d)', string(s:mode), action)
+  else
+    let action = filter(copy(s:actions), {i,v -> get(v, 'Name') ==# a:str})[0]
+    let command = get(action, 'Identifier')
+    let command = printf('runCodeAction(%s, %s, ''v2'')', string(s:mode), string(command))
+  endif
+  if !pyeval(command)
+    echo 'No action taken'
+  endif
 endfunction
 
 " Give the extension an ID

--- a/autoload/ctrlp/OmniSharp/findcodeactions.vim
+++ b/autoload/ctrlp/OmniSharp/findcodeactions.vim
@@ -85,8 +85,8 @@ function! ctrlp#OmniSharp#findcodeactions#accept(mode, str) abort
     let command = printf('runCodeAction(%s, %d)', string(s:mode), action)
   else
     let action = filter(copy(s:actions), {i,v -> get(v, 'Name') ==# a:str})[0]
-    let command = get(action, 'Identifier')
-    let command = printf('runCodeAction(%s, %s, ''v2'')', string(s:mode), string(command))
+    let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
+    let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
   if !pyeval(command)
     echo 'No action taken'

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -51,8 +51,8 @@ function! s:action_sink(str) abort
     let command = printf('runCodeAction(%s, %d)', string(s:mode), action)
   else
     let action = filter(copy(s:actions), {i,v -> get(v, 'Name') ==# a:str})[0]
-    let command = get(action, 'Identifier')
-    let command = printf('runCodeAction(%s, %s, ''v2'')', string(s:mode), string(command))
+    let command = substitute(get(action, 'Identifier'), '''', '\\''', 'g')
+    let command = printf('runCodeAction(''%s'', ''%s'', ''v2'')', s:mode, command)
   endif
   if !pyeval(command)
     echo 'No action taken'

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -59,7 +59,7 @@ function! s:action_sink(str) abort
   endif
 endfunction
 
-function! fzf#OmniSharp#getcodeactions(mode, actions) abort
+function! fzf#OmniSharp#getcodeactions(mode) abort
   " When using the roslyn server, use /v2/codeactions
   let s:version = g:OmniSharp_server_type ==# 'roslyn' ? 'v2' : 'v1'
   let s:actions = pyeval(printf('getCodeActions(%s, %s)', string(a:mode), string(s:version)))

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -59,7 +59,7 @@ function! s:action_sink(str) abort
   endif
 endfunction
 
-function! fzf#OmniSharp#getcodeactions(mode) abort
+function! fzf#OmniSharp#getcodeactions(mode, actions) abort
   " When using the roslyn server, use /v2/codeactions
   let s:version = g:OmniSharp_server_type ==# 'roslyn' ? 'v2' : 'v1'
   let s:actions = pyeval(printf('getCodeActions(%s, %s)', string(a:mode), string(s:version)))
@@ -68,11 +68,10 @@ function! fzf#OmniSharp#getcodeactions(mode) abort
     echo 'No code actions found'
     return
   endif
-  " rosyln endpoint /v2/getcodeactions returns dicts, not strings
-  if type(s:actions[0]) == v:t_dict
-    let acts = map(copy(s:actions), {i,v -> get(v, 'Name')})
-  else
+  if s:version ==# 'v1'
     let acts = s:actions
+  else
+    let acts = map(copy(s:actions), {i,v -> get(v, 'Name')})
   endif
 
   call fzf#run({


### PR DESCRIPTION
When using the roslyn server, use the `/v2/getcodeactions` endpoint instead of the old `/getcodeactions`.

I have only implemented this for fzf, but it would be trivial to implement for ctrlp and unite based on this PR. I can add CtrlP support but I don't have experience with unite so I'd prefer someone else do it?