### PR TITLE
Fix /findsymbols bug with roslyn server

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -149,7 +149,9 @@ function! OmniSharp#FindSymbol(...) abort
   if g:OmniSharp_selector_ui ==? 'unite'
     call unite#start([['OmniSharp/findsymbols']])
   elseif g:OmniSharp_selector_ui ==? 'ctrlp'
-    call ctrlp#init(ctrlp#OmniSharp#findsymbols#id())
+    if ctrlp#OmniSharp#findsymbols#findsymbols(filter)
+      call ctrlp#init(ctrlp#OmniSharp#findsymbols#id())
+    endif
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#findsymbols(filter)
   else

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -140,13 +140,18 @@ function! OmniSharp#SelectorPluginError()
   echoerr 'No selector plugin found.  Please install unite.vim, ctrlp.vim or fzf.vim'
 endfunction
 
-function! OmniSharp#FindSymbol() abort
+function! OmniSharp#FindSymbol(...) abort
+  if a:0 > 0
+    let filter = a:1
+  else
+    let filter = ''
+  endif
   if g:OmniSharp_selector_ui ==? 'unite'
     call unite#start([['OmniSharp/findsymbols']])
   elseif g:OmniSharp_selector_ui ==? 'ctrlp'
     call ctrlp#init(ctrlp#OmniSharp#findsymbols#id())
   elseif g:OmniSharp_selector_ui ==? 'fzf'
-    call fzf#OmniSharp#findsymbols()
+    call fzf#OmniSharp#findsymbols(filter)
   else
     call OmniSharp#SelectorPluginError()
   endif

--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -47,21 +47,28 @@ call add(g:ctrlp_ext_vars, {
 \ })
 
 
+function! ctrlp#OmniSharp#findsymbols#findsymbols(filter) abort
+  if !OmniSharp#ServerIsRunning()
+    return 0
+  endif
+  let s:quickfixes = pyeval(printf('findSymbols(%s)', string(a:filter)))
+  let s:symbols = []
+  for quickfix in s:quickfixes
+    call add(s:symbols, quickfix.text)
+  endfor
+  if empty(s:symbols)
+    echo 'No symbols found'
+    return 0
+  endif
+  return 1
+endfunction
+
 " Provide a list of strings to search in
 "
 " Return: a Vim's List
 "
 function! ctrlp#OmniSharp#findsymbols#init() abort
-  if !OmniSharp#ServerIsRunning()
-    return
-  endif
-
-  let s:quickfixes = pyeval('findSymbols()')
-  let symbols = []
-  for quickfix in s:quickfixes
-    call add(symbols, quickfix.text)
-  endfor
-  return symbols
+  return s:symbols
 endfunction
 
 

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -39,6 +39,10 @@ function! fzf#OmniSharp#findsymbols(filter) abort
   for quickfix in s:quickfixes
     call add(symbols, quickfix.text)
   endfor
+  if empty(symbols)
+    echo 'No symbols found'
+    return
+  endif
   call fzf#run({
   \ 'source': symbols,
   \ 'down': '40%',

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -30,11 +30,11 @@ function! fzf#OmniSharp#findtypes() abort
   \ 'sink': function('s:location_sink')})
 endfunction
 
-function! fzf#OmniSharp#findsymbols() abort
+function! fzf#OmniSharp#findsymbols(filter) abort
   if !OmniSharp#ServerIsRunning()
     return
   endif
-  let s:quickfixes = pyeval('findSymbols()')
+  let s:quickfixes = pyeval(printf('findSymbols(%s)', string(a:filter)))
   let symbols = []
   for quickfix in s:quickfixes
     call add(symbols, quickfix.text)

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -261,8 +261,10 @@ def findTypes():
     js = getResponse('/findtypes')
     return get_quickfix_list(js, 'QuickFixes')
 
-def findSymbols():
-    js = getResponse('/findsymbols')
+def findSymbols(filter=''):
+    parameters = {}
+    parameters["filter"] = filter
+    js = getResponse('/findsymbols', parameters)
     return get_quickfix_list(js, 'QuickFixes')
 
 def get_quickfix_list(js, key):


### PR DESCRIPTION
The roslyn /findsymbols endpoint requires a 'Filter' parameter, which may be an empty string.

This PR also adds the ability to add a filter, when using fzf, i.e. `:call OmniSharp#FindSymbol('IAbstract')` to filter the output. This is probably of limited value, but roslyn offers the functionality so we might as well use it.