### PR TITLE
Two Bug Fixes: NeoVim jobstart and absolute path for OmniSharp server -s option

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -628,7 +628,7 @@ function! s:find_solution_files() abort
   endwhile
 
   if empty(solution_files) && g:OmniSharp_start_without_solution
-    let solution_files = ['.']
+    let solution_files = [getcwd()]
   endif
 
   return solution_files

--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -30,7 +30,7 @@ function! OmniSharp#proc#neovimJobStart(command) abort
     call s:debug('Using Neovim jobstart to start the following command:')
     call s:debug(a:command)
     return jobstart(
-                \ a:command,
+                \ join(a:command, ' '),
                 \ {'on_stdout': 'OmniSharp#proc#neovimOutHandler',
                 \  'on_stderr': 'OmniSharp#proc#neovimErrHandler'})
   else


### PR DESCRIPTION
# Two Big Fixes

1. The jobstart function fails to execute if the first argument is a string on NeoVim 0.2.0.
2. OmniSharp-server (Roslyn 1.29.1) requires that the solution path (using the `-s` option) is an absolute path.