### PR TITLE
Add roslyn server OmniSharpHighlightTypes support

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -371,34 +371,42 @@ function! OmniSharp#RunTests(mode) abort
 endfunction
 
 function! OmniSharp#EnableTypeHighlightingForBuffer() abort
-  hi link CSharpUserType Type
+  highlight default link csUserType Type
   if !empty(s:allUserTypes)
-    exec 'syn keyword CSharpUserType ' . s:allUserTypes
+    exec 'syn keyword csUserType ' . s:allUserTypes
   endif
+  highlight default link csUserInterface Include
   if !empty(s:allUserInterfaces)
-    exec 'syn keyword csInterfaceDeclaration ' . s:allUserInterfaces
+    exec 'syn keyword csUserInterface ' . s:allUserInterfaces
+  endif
+  highlight default link csUserAttribute Include
+  if !empty(s:allUserAttributes)
+    exec 'syn keyword csUserAttribute ' . s:allUserAttributes
   endif
 endfunction
 
 function! OmniSharp#EnableTypeHighlighting() abort
-
-  if !OmniSharp#ServerIsRunning() || !empty(s:allUserTypes)
+  if !OmniSharp#ServerIsRunning()
     return
   endif
 
-  python lookupAllUserTypes()
+  if g:OmniSharp_server_type ==# 'roslyn'
+    python lookupAllUserTypes()
+  else
+    python lookupAllUserTypesLegacy()
+  endif
 
   let startBuf = bufnr('%')
   " Perform highlighting for existing buffers
   bufdo if &ft == 'cs' | call OmniSharp#EnableTypeHighlightingForBuffer() | endif
-exec 'b '. startBuf
+  exec 'b '. startBuf
 
-call OmniSharp#EnableTypeHighlightingForBuffer()
+  call OmniSharp#EnableTypeHighlightingForBuffer()
 
-augroup _omnisharp
-  au!
-  autocmd BufRead *.cs call OmniSharp#EnableTypeHighlightingForBuffer()
-augroup END
+  augroup _omnisharp
+    au!
+    autocmd BufRead *.cs call OmniSharp#EnableTypeHighlightingForBuffer()
+  augroup END
 endfunction
 
 function! OmniSharp#ReloadSolution() abort

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -308,6 +308,25 @@ def quickfixes_from_response(response):
     return items
 
 def lookupAllUserTypes():
+    js = getResponse('/findsymbols', {'filter': ''})
+    if js != '':
+        response = json.loads(js)
+        if response != None and response['QuickFixes'] != None:
+            slnTypes = []
+            slnInterfaces = []
+            slnAttributes = []
+            for symbol in response['QuickFixes']:
+                if symbol['Kind'] == 'Class':
+                    slnTypes.append(symbol['Text'])
+                    if symbol['Text'].endswith('Attribute'):
+                        slnAttributes.append(symbol['Text'][:-9])
+                elif symbol['Kind'] == 'Interface':
+                    slnInterfaces.append(symbol['Text'])
+            vim.command("let s:allUserTypes = '%s'" % ' '.join(slnTypes))
+            vim.command("let s:allUserInterfaces = '%s'" % ' '.join(slnInterfaces))
+            vim.command("let s:allUserAttributes = '%s'" % ' '.join(slnAttributes))
+
+def lookupAllUserTypesLegacy():
     js = getResponse('/lookupalltypes')
     if js != '':
         response = json.loads(js)


### PR DESCRIPTION
The roslyn server does not have the /lookupalltypes endpoint that the OmniSharpHighlightTypes functionality relies on. This change uses the /findsymbols endpoint instead.