### PR TITLE
Add option to start roslyn with mono on *nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ let g:OmniSharp_translate_cygwin_wsl = 1
 ```
 
 ### Mono
-OmniSharp-Roslyn requires Mono on Linux and OSX, see [The Mono Project](https://www.mono-project.com/download/stable/) for installation details.
+OmniSharp-Roslyn requires Mono on Linux and OSX. The roslyn server [releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) usually come with an embedded Mono, but this can be overridden to use the installed Mono by setting `g:OmniSharp_server_use_mono` in your vimrc. See [The Mono Project](https://www.mono-project.com/download/stable/) for installation details.
+
+```vim
+    let g:OmniSharp_server_use_mono = 1
+```
 
 ### Install Python
 Install last version of 2.7 series ([Python 2.7.14](https://www.python.org/downloads/release/python-2714/) at the time of this writing). Make sure that you pick correct version of Python to match the architecture of Vim.

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -73,13 +73,13 @@ function! OmniSharp#util#get_start_cmd(solution_path) abort
               \ '-p', port,
               \ '-s', solution_path]
 
-  if g:OmniSharp_server_type !=# 'roslyn'
+  if g:OmniSharp_server_type ==# 'v1'
     let l:config_file = s:resolve_local_config(solution_path)
     if l:config_file !=# ''
       let command = command + ['-config', l:config_file]
     endif
   endif
-  if !has('win32') && !has('win32unix') && g:OmniSharp_server_type !=# 'roslyn'
+  if !has('win32') && !has('win32unix') && (g:OmniSharp_server_use_mono || g:OmniSharp_server_type ==# 'v1')
     let command = insert(command, 'mono')
   endif
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -91,6 +91,14 @@ executable. >
     let g:OmniSharp_server_path='/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
 <
 
+                                                *'g:OmniSharp_server_use_mono'*
+The roslyn server must be run with mono on Linux and OSX. The roslyn server
+binaries usually come with an embedded mono, but this can be overridden to use
+the installed mono with this option. Note that mono must be in the $PATH.
+Default: 0 >
+    let g:OmniSharp_server_use_mono=1
+<
+
                                                            *'g:OmniSharp_host'*
 Use this option to specify the host address of the OmniSharp server.
 Default: 'http://localhost:2000' >

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -88,6 +88,9 @@ endif
 " Set g:OmniSharp_server_type to 'roslyn' or 'v1'
 let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'roslyn')
 
+" Use mono to start the roslyn server on *nix
+let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
+
 " Set default for snippet based completions
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
 


### PR DESCRIPTION
The roslyn server _usually_ does not need to be explicitly started with mono on Linux and OSX - it uses its own embedded mono so can be executed like a native binary. However, it may be desirable/necessary to prefix the command with mono in some circumstances, so this PR adds a new option to allow that.

Closes #347