### PR TITLE
allow use of a random port during omnisharp startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ let g:Omnisharp_stop_server = 1  " Ask whether to stop the server
 let g:Omnisharp_stop_server = 2  " Automatically stop the server
 ```
 
-OmniSharp listens to requests from Vim on port 2000 by default, so make sure that your firewall is configured to accept requests from localhost on this port.
+OmniSharp listens to requests from Vim on port 2000 by default, so make sure that your firewall is configured to accept requests from localhost on this port. This behavior can be changed by setting `let g:OmniSharp_use_random_port = 1` in your vimrc. When set, the OmniSharp server will run on a random port instead of using the default port.
 
 To get completions, open a C# file from your solution within Vim and press `<C-x><C-o>` (that is ctrl x followed by ctrl o) in Insert mode, or use an autocompletion plugin.
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -17,7 +17,9 @@ let s:py_path = OmniSharp#util#path_join('python')
 exec "python sys.path.append(r'" . s:py_path . "')"
 exec 'pyfile ' . fnameescape(OmniSharp#util#path_join(['python', 'OmniSharp.py']))
 
-let g:OmniSharp_port = get(g:, 'OmniSharp_port', 2000)
+let g:OmniSharp_use_random_port = get(g:, 'OmniSharp_use_random_port', 0)
+let s:OmniSharp_default_port = g:OmniSharp_use_random_port ? pyeval('find_free_port()') : 2000
+let g:OmniSharp_port = get(g:, 'OmniSharp_port', s:OmniSharp_default_port)
 
 "Setup variable defaults
 "Default value for the server address

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -1,4 +1,5 @@
-import json, logging, os.path, platform, re, urllib2, urlparse, vim
+import json, logging, os.path, platform, re, urllib2, urlparse, vim, socket
+from contextlib import closing
 
 logger = logging.getLogger('omnisharp')
 logger.setLevel(logging.WARNING)
@@ -372,3 +373,8 @@ def get_navigate_response(js):
         return {'Line': response['Line'], 'Column': response['Column']}
     else:
         return {}
+
+def find_free_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        return s.getsockname()[1]


### PR DESCRIPTION
i work with multiple projects open at the same time. having the default port set to 2000 causes conflicts - opening ProjectA works fine but opening ProjectB requires a bit of manual work to hook up omni.

this pr allows allows a new setting (g:OmniSharp_use_random_port) to be defined. if set to a truthy value, a random port will be used during OmniSharp startup.