### PR TITLE
handle code actions requiring a separate file than the current buffer

### DIFF
--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -174,8 +174,10 @@ def runCodeAction(mode, action, version='v1'):
         res = getResponse('/v2/runcodeaction', parameters)
         js = json.loads(res)
         if 'Changes' in js:
+            vim.command("let cursor_position = getcurpos()")
             for changeDefinition in js['Changes']:
                 __applyChange(changeDefinition)
+            vim.command("call setpos('.', cursor_position)")
             return True
     return False
 

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -146,6 +146,21 @@ def getCodeActions(mode, version='v1'):
     return []
 
 def runCodeAction(mode, action, version='v1'):
+    def __applyChange(changeDefinition):
+        filename = formatPathForClient(changeDefinition['FileName'])
+        openFile(filename, 1, 1)
+        if __isBufferChange(changeDefinition):
+            setBufferText(changeDefinition['Buffer'])
+        elif __isNewFile(changeDefinition):
+            for change in changeDefinition['Changes']:
+                setBufferText(change['NewText'])
+
+    def __isBufferChange(changeDefinition):
+        return 'Buffer' in changeDefinition and changeDefinition['Buffer'] != None
+
+    def __isNewFile(changeDefinition):
+        return 'Changes' in changeDefinition and changeDefinition['Changes'] != None
+
     parameters = codeActionParameters(mode, version)
     if version == 'v1':
         parameters['codeaction'] = action
@@ -163,21 +178,6 @@ def runCodeAction(mode, action, version='v1'):
                 __applyChange(changeDefinition)
             return True
     return False
-
-def __applyChange(changeDefinition):
-    filename = formatPathForClient(changeDefinition['FileName'])
-    openFile(filename, 1, 1)
-    if __isBufferChange(changeDefinition):
-        setBufferText(changeDefinition['Buffer'])
-    elif __isNewFile(changeDefinition):
-        for change in changeDefinition['Changes']:
-            setBufferText(change['NewText'])
-
-def __isBufferChange(changeDefinition):
-    return 'Buffer' in changeDefinition and changeDefinition['Buffer'] != None
-
-def __isNewFile(changeDefinition):
-    return 'Changes' in changeDefinition and changeDefinition['Changes'] != None
 
 def codeActionParameters(mode, version='v1'):
     parameters = {}

--- a/python/OmniSharp.py
+++ b/python/OmniSharp.py
@@ -165,12 +165,12 @@ def runCodeAction(mode, action, version='v1'):
     return False
 
 def __applyChange(changeDefinition):
+    filename = formatPathForClient(changeDefinition['FileName'])
+    openFile(filename, 1, 1)
     if __isBufferChange(changeDefinition):
         setBufferText(changeDefinition['Buffer'])
     elif __isNewFile(changeDefinition):
         for change in changeDefinition['Changes']:
-            filename = formatPathForClient(changeDefinition['FileName'])
-            openFile(filename, change['StartLine'], change['StartColumn'])
             setBufferText(change['NewText'])
 
 def __isBufferChange(changeDefinition):


### PR DESCRIPTION
when a code action does things in a file other than the current buffer, nothing happens. here's a fix for that ... seems to work as best i tested it.

a few things 

- is there a test suite to run ensuring i am not breaking anything?
- not sure what to do when a new file is opened. should the user be taken back to the buffer from where the code action was run? should the new file be saved automatically? right now the user is left in the new file that was created, the file is not saved.
- my python is non-existent so if there's a better way to accomplish this don't hesitate to let me know / change it.

thx