### PR TITLE
Option to open quickfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ It tries to detect your solution file (.sln) and starts the OmniSharp-roslyn ser
 In vim8 and neovim, the server is started invisibly by a vim job.
 In older versions of vim, the server will be started in different ways depending on whether you are using vim-dispatch in tmux, or are using vim-proc, gvim or running vim in a terminal.
 
-This behaviour can be disabled by setting `let g:Omnisharp_start_server = 0` in your vimrc. You can then start the server manually from within vim with `:OmniSharpStartServer`. Alternatively, the server can be manually started from outside vim:
+This behaviour can be disabled by setting `let g:OmniSharp_start_server = 0` in your vimrc. You can then start the server manually from within vim with `:OmniSharpStartServer`. Alternatively, the server can be manually started from outside vim:
 
 ```sh
 [mono] OmniSharp.exe -p (portnumber) -s (path/to/sln)
@@ -171,12 +171,12 @@ Add `-v Verbose` to get extra information from the server.
 
 
 When vim is closed and the OmniSharp server is running, vim will stop the server automatically.
-This behaviour can be altered with the `g:Omnisharp_stop_server` variable in your vimrc:
+This behaviour can be altered with the `g:OmniSharp_stop_server` variable in your vimrc:
 
 ```vim
-let g:Omnisharp_stop_server = 0  " Do not stop the server on exit
-let g:Omnisharp_stop_server = 1  " Ask whether to stop the server
-let g:Omnisharp_stop_server = 2  " Automatically stop the server
+let g:OmniSharp_stop_server = 0  " Do not stop the server on exit
+let g:OmniSharp_stop_server = 1  " Ask whether to stop the server
+let g:OmniSharp_stop_server = 2  " Automatically stop the server
 ```
 
 OmniSharp listens to requests from Vim on port 2000 by default, so make sure that your firewall is configured to accept requests from localhost on this port. This behavior can be changed by setting `let g:OmniSharp_use_random_port = 1` in your vimrc. When set, the OmniSharp server will run on a random port instead of using the default port.

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -82,6 +82,8 @@ function! OmniSharp#FindImplementations() abort
   if len(qf_taglist) > 1
     call s:set_quickfix(qf_taglist, 'Implementations: '.expand('<cword>'))
   endif
+
+  return len(qf_taglist)
 endfunction
 
 function! OmniSharp#FindMembers() abort

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -533,7 +533,7 @@ endfunction
 function! OmniSharp#StartServerIfNotRunning() abort
   if !OmniSharp#ServerIsRunning()
     call OmniSharp#StartServer()
-    if g:Omnisharp_stop_server==2
+    if g:OmniSharp_stop_server == 2
       au VimLeavePre * call OmniSharp#StopServer()
     endif
   endif

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -61,8 +61,7 @@ function! OmniSharp#FindUsages() abort
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
-    call setqflist(qf_taglist)
-    botright cwindow 4
+    call s:set_quickfix(qf_taglist)
   else
     echo 'No usages found'
   endif
@@ -81,8 +80,7 @@ function! OmniSharp#FindImplementations() abort
   endif
 
   if len(qf_taglist) > 1
-    call setqflist(qf_taglist)
-    botright cwindow 4
+    call s:set_quickfix(qf_taglist)
   endif
 endfunction
 
@@ -91,8 +89,7 @@ function! OmniSharp#FindMembers() abort
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 1
-    call setqflist(qf_taglist)
-    botright cwindow 4
+    call s:set_quickfix(qf_taglist)
   endif
 endfunction
 
@@ -177,8 +174,7 @@ function! OmniSharp#FindSymbol(...) abort
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#findsymbols(quickfixes)
   else
-    call setqflist(quickfixes)
-    botright cwindow 4
+    call s:set_quickfix(quickfixes)
   endif
 endfunction
 
@@ -190,8 +186,7 @@ function! OmniSharp#FindType() abort
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#findtypes()
   else
-    call setqflist(quickfixes)
-    botright cwindow 4
+    call s:set_quickfix(quickfixes)
   endif
 endfunction
 
@@ -414,8 +409,7 @@ function! OmniSharp#Build() abort
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
-    call setqflist(qf_taglist)
-    botright cwindow 4
+    call s:set_quickfix(qf_taglist)
   endif
 endfunction
 
@@ -516,8 +510,7 @@ function! OmniSharp#FixUsings() abort
   let qf_taglist = g:OmniSharp#py#eval('fix_usings()')
 
   if len(qf_taglist) > 0
-    call setqflist(qf_taglist)
-    botright cwindow
+    call s:set_quickfix(qf_taglist)
   endif
 endfunction
 
@@ -732,6 +725,13 @@ function! s:json_decode(json) abort
   catch
     throw 'Invalid JSON response from server: ' . a:json
   endtry
+endfunction
+
+function! s:set_quickfix(list)
+  call setqflist(a:list)
+  if g:OmniSharp_open_quickfix
+    botright cwindow 4
+  endif
 endfunction
 
 " Manually write content to the preview window.

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -61,7 +61,7 @@ function! OmniSharp#FindUsages() abort
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
-    call s:set_quickfix(qf_taglist)
+    call s:set_quickfix(qf_taglist, 'Usages: '.expand('<cword>'))
   else
     echo 'No usages found'
   endif
@@ -80,7 +80,7 @@ function! OmniSharp#FindImplementations() abort
   endif
 
   if len(qf_taglist) > 1
-    call s:set_quickfix(qf_taglist)
+    call s:set_quickfix(qf_taglist, 'Implementations: '.expand('<cword>'))
   endif
 endfunction
 
@@ -88,8 +88,10 @@ function! OmniSharp#FindMembers() abort
   let qf_taglist = g:OmniSharp#py#eval('findMembers()')
 
   " Place the tags in the quickfix window, if possible
+  " TODO: Should this use the location window instead, since it is
+  " buffer-specific?
   if len(qf_taglist) > 1
-    call s:set_quickfix(qf_taglist)
+    call s:set_quickfix(qf_taglist, 'Members')
   endif
 endfunction
 
@@ -157,7 +159,7 @@ function! OmniSharp#JumpToLocation(filename, line, column) abort
 endfunction
 
 function! OmniSharp#FindSymbol(...) abort
-  let filter = a:0 > 0 ? a:1 : ''
+  let filter = a:0 ? a:1 : ''
   if !OmniSharp#ServerIsRunning()
     return
   endif
@@ -174,7 +176,8 @@ function! OmniSharp#FindSymbol(...) abort
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#findsymbols(quickfixes)
   else
-    call s:set_quickfix(quickfixes)
+    let title = 'Symbols'.(len(filter) ? ': '.filter : '')
+    call s:set_quickfix(quickfixes, title)
   endif
 endfunction
 
@@ -186,7 +189,7 @@ function! OmniSharp#FindType() abort
   elseif g:OmniSharp_selector_ui ==? 'fzf'
     call fzf#OmniSharp#findtypes()
   else
-    call s:set_quickfix(quickfixes)
+    call s:set_quickfix(quickfixes, 'Types')
   endif
 endfunction
 
@@ -409,7 +412,7 @@ function! OmniSharp#Build() abort
 
   " Place the tags in the quickfix window, if possible
   if len(qf_taglist) > 0
-    call s:set_quickfix(qf_taglist)
+    call s:set_quickfix(qf_taglist, 'Build')
   endif
 endfunction
 
@@ -510,7 +513,7 @@ function! OmniSharp#FixUsings() abort
   let qf_taglist = g:OmniSharp#py#eval('fix_usings()')
 
   if len(qf_taglist) > 0
-    call s:set_quickfix(qf_taglist)
+    call s:set_quickfix(qf_taglist, 'Usings')
   endif
 endfunction
 
@@ -727,8 +730,8 @@ function! s:json_decode(json) abort
   endtry
 endfunction
 
-function! s:set_quickfix(list)
-  call setqflist(a:list)
+function! s:set_quickfix(list, title)
+  call setqflist([], ' ', {'nr': '$', 'items': a:list, 'title': a:title})
   if g:OmniSharp_open_quickfix
     botright cwindow 4
   endif

--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -1,10 +1,8 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let g:omnisharp_proc_debug = get(g:, 'omnisharp_proc_debug', 0)
-
 function! s:debug(message) abort
-  if g:omnisharp_proc_debug == 1
+  if g:OmniSharp_proc_debug == 1
     echom 'DEBUG: ' . string(a:message)
   endif
 endfunction
@@ -14,7 +12,7 @@ function! OmniSharp#proc#supportsNeovimJobs() abort
 endfunction
 
 function! OmniSharp#proc#neovimOutHandler(job_id, data, event) abort
-  if g:omnisharp_proc_debug == 1
+  if g:OmniSharp_proc_debug == 1
     let l:message = printf('%s: %s',a:event,string(a:data))
     echom l:message
   endif
@@ -43,8 +41,8 @@ function! OmniSharp#proc#supportsVimJobs() abort
 endfunction
 
 function! OmniSharp#proc#vimOutHandler(channel, message) abort
-  if g:omnisharp_proc_debug == 1
-      echom printf('%s: %s', string(a:channel), string(a:message))
+  if g:OmniSharp_proc_debug == 1
+    echom printf('%s: %s', string(a:channel), string(a:message))
   endif
 endfunction
 

--- a/autoload/OmniSharp/py.vim
+++ b/autoload/OmniSharp/py.vim
@@ -5,7 +5,7 @@ endif
 let s:pycmd = has('python3') ? 'python3' : 'python'
 let s:pyfile = has('python3') ? 'py3file' : 'pyfile'
 let s:module_path_added = 0
-let g:omnisharp_python_path = OmniSharp#util#path_join(['python', 'omnisharp'])
+let g:OmniSharp_python_path = OmniSharp#util#path_join(['python', 'omnisharp'])
 
 let s:save_cpo = &cpo
 set cpo&vim
@@ -23,7 +23,7 @@ endif
 
 function! OmniSharp#py#load(filename)
   if s:module_path_added == 0
-    exec s:pycmd "sys.path.append(r'" . g:omnisharp_python_path . "')"
+    exec s:pycmd "sys.path.append(r'" . g:OmniSharp_python_path . "')"
     let s:module_path_added = 1
   endif
   exec s:pyfile fnameescape(OmniSharp#util#path_join(['python', 'omnisharp', a:filename]))

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -94,6 +94,14 @@ Default: 0 >
     let g:OmniSharp_use_random_port = 0
 <
 
+                                                  *'g:OmniSharp_open_quickfix'*
+By default, OmniSharp-vim opens the quickfix window when it is populated, e.g.
+after find usages, implementations etc. Set this variable to 0 to prevent the
+quickfix window being opened automatically.
+Default: 1 >
+    let g:OmniSharp_open_quickfix = 0
+<
+
                                                         *'g:OmniSharp_timeout'*
 Use this option to specify the time (in seconds) to wait for a response from the
 server. Default: 1 >

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -42,11 +42,98 @@ Suggestion: Install a completer such as NeoComplete or SuperTab
 ===============================================================================
 OPTIONS                                                     *omnisharp-options*
 
+                                                   *'g:OmniSharp_start_server'*
+Use this option to specify whether OmniSharp will start automatically upon
+opening a `*.cs` file. Default: 1 >
+    let g:OmniSharp_start_server = 1
+<
+
+                                                    *'g:OmniSharp_stop_server'*
+Use this option to specify whether OmniSharp will stop automatically upon
+closing Vim. Default: 2 >
+    let g:OmniSharp_stop_server = 1
+<
+
+                                             *'g:OmniSharp_server_config_name'*
+Use this option to specify the OmniSharp server config filename.
+Default: 'omnisharp.json' >
+    let g:OmniSharp_server_config_name = 'omnisharp.json'
+<
+
+                                                    *'g:OmniSharp_server_type'*
+Use this option to specify which version of OmniSharp will be used.
+Default: 'roslyn' >
+    let g:OmniSharp_server_type = 'roslyn'
+    OR
+    let g:OmniSharp_server_type = 'v1'
+<
+
+                                                    *'g:OmniSharp_server_path'*
+Use this option to give the full path to the roslyn or v1 omnisharp server
+executable. >
+    let g:OmniSharp_server_path = '/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
+<
+
+                                                *'g:OmniSharp_server_use_mono'*
+The roslyn server must be run with mono on Linux and OSX. The roslyn server
+binaries usually come with an embedded mono, but this can be overridden to use
+the installed mono with this option. Note that mono must be in the $PATH.
+Default: 0 >
+    let g:OmniSharp_server_use_mono = 1
+<
+
+                                                           *'g:OmniSharp_host'*
+Use this option to specify the host address of the OmniSharp server.
+Default: 'http://localhost:2000' >
+    let g:OmniSharp_host = 'http://localhost:2000'
+<
+
+                                                *'g:OmniSharp_use_random_port'*
+Use this option to default to a random port when no port is selected.
+Default: 0 >
+    let g:OmniSharp_use_random_port = 0
+<
+
+                                                        *'g:OmniSharp_timeout'*
+Use this option to specify the time (in seconds) to wait for a response from the
+server. Default: 1 >
+    let g:OmniSharp_timeout = 1
+<
+
+                                           *'g:OmniSharp_translate_cygwin_wsl'*
+Use this option when vim is running in a Cygwin or Windows Subsystem for Linux
+environment on Windows, but the omnisharp server is a Windows binary. When set
+to 1, omnisharp-vim will translate the cygwin/WSL unix paths into Windows paths
+and back.
+Default: 0 >
+    let g:OmniSharp_translate_cygwin_wsl = 1
+<
+
+                                            *'g:OmniSharp_typeLookupInPreview'*
+Use this option to specify whether type lookups display in Vim's Preview Window.
+Type lookups will display in the status line if this is `0`. Default: 0 >
+    let g:OmniSharp_typeLookupInPreview = 0
+<
+
+                                                   *'g:OmniSharp_want_snippet'*
+Use this option to enable snippet completion. Requires `completeopt-=preview`.
+Default: 0 >
+    let g:OmniSharp_want_snippet = 0
+<
+
+                                    *'g:omnicomplete_fetch_full_documentation'*
+Use this option to specify whether OmniSharp will fetch full documentation on
+completion suggestions. By default, only type/method signatures are fetched for
+performance reasons. Full documentation can still be fetched when needed using
+the |:OmniSharpDocumentation| command. Default: 0 >
+    let g:omnicomplete_fetch_full_documentation = 0
+<
+
                                                     *'g:syntastic_cs_checkers'*
 Use this option to enable syntastic integration >
-    let g:syntastic_cs_checkers=['syntax', 'semantic', 'issues'] " v1 server
+    let g:syntastic_cs_checkers = ['code_checker']                 " roslyn
     OR
-    let g:syntastic_cs_checkers=['code_checker']                 " roslyn
+    let g:syntastic_cs_checkers = ['syntax', 'semantic', 'issues'] " v1 server
 <
 
                                                     *'g:OmniSharp_selector_ui'*
@@ -56,100 +143,13 @@ g:OmniSharp_selector_ui is set to '', then the vim command-line and quickfix
 window will be used instead.
 Default: Whichever of unite.vim, ctrlp.vim or fzf.vim is installed, or '' if
 none are. >
-    let g:OmniSharp_selector_ui='unite'
+    let g:OmniSharp_selector_ui = 'unite'
     OR
-    let g:OmniSharp_selector_ui='ctrlp'
+    let g:OmniSharp_selector_ui = 'ctrlp'
     OR
-    let g:OmniSharp_selector_ui='fzf'
+    let g:OmniSharp_selector_ui = 'fzf'
     OR
-    let g:OmniSharp_selector_ui=''
-<
-
-                                                   *'g:OmniSharp_start_server'*
-Use this option to specify whether OmniSharp will start automatically upon
-opening a `*.cs` file. Default: 1 >
-    let g:OmniSharp_start_server=1
-<
-
-                                                    *'g:OmniSharp_stop_server'*
-Use this option to specify whether OmniSharp will stop automatically upon
-closing Vim. Default: 2 >
-    let g:OmniSharp_stop_server=1
-<
-
-                                             *'g:OmniSharp_server_config_name'*
-Use this option to specify the OmniSharp server config filename.
-Default: 'omnisharp.json' >
-    let g:OmniSharp_server_config_name='omnisharp.json'
-<
-
-                                                    *'g:OmniSharp_server_type'*
-Use this option to specify which version of OmniSharp will be used.
-Default: 'roslyn' >
-    let g:OmniSharp_server_type='roslyn'
-    OR
-    let g:OmniSharp_server_type='v1'
-<
-
-                                                    *'g:OmniSharp_server_path'*
-Use this option to give the full path to the roslyn or v1 omnisharp server
-executable. >
-    let g:OmniSharp_server_path='/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
-<
-
-                                                *'g:OmniSharp_server_use_mono'*
-The roslyn server must be run with mono on Linux and OSX. The roslyn server
-binaries usually come with an embedded mono, but this can be overridden to use
-the installed mono with this option. Note that mono must be in the $PATH.
-Default: 0 >
-    let g:OmniSharp_server_use_mono=1
-<
-
-                                                           *'g:OmniSharp_host'*
-Use this option to specify the host address of the OmniSharp server.
-Default: 'http://localhost:2000' >
-    let g:OmniSharp_host='http://localhost:2000'
-<
-
-                                            *'g:OmniSharp_typeLookupInPreview'*
-Use this option to specify whether type lookups display in Vim's Preview Window.
-Type lookups will display in the status line if this is `0`. Default: 0 >
-    let g:OmniSharp_typeLookupInPreview=0
-<
-
-                                                        *'g:OmniSharp_timeout'*
-Use this option to specify the time (in seconds) to wait for a response from the
-server. Default: 1 >
-    let g:OmniSharp_timeout=1
-<
-
-                                    *'g:omnicomplete_fetch_full_documentation'*
-Use this option to specify whether OmniSharp will fetch full documentation on
-completion suggestions. By default, only type/method signatures are fetched for
-performance reasons. Full documentation can still be fetched when needed using
-the |:OmniSharpDocumentation| command. Default: 0 >
-    let g:omnicomplete_fetch_full_documentation=0
-<
-
-                                                   *'g:OmniSharp_want_snippet'*
-Use this option to enable snippet completion. Requires `completeopt-=preview`.
-Default: 0 >
-    let g:OmniSharp_want_snippet=0
-<
-
-                                           *'g:OmniSharp_translate_cygwin_wsl'*
-Use this option when vim is running in a Cygwin or Windows Subsystem for Linux
-environment on Windows, but the omnisharp server is a Windows binary. When set
-to 1, omnisharp-vim will translate the cygwin/WSL unix paths into Windows paths
-and back.
-Default: 0 >
-    let g:OmniSharp_translate_cygwin_wsl=1
-<
-
-                                                *'g:OmniSharp_use_random_port'*
-Use this option to default to a random port when no port is selected.
-Default: 0 >
-    let g:OmniSharp_use_random_port=0
+    let g:OmniSharp_selector_ui = ''
 <
 
 ===============================================================================

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -65,22 +65,22 @@ none are. >
     let g:OmniSharp_selector_ui=''
 <
 
-                                                   *'g:Omnisharp_start_server'*
+                                                   *'g:OmniSharp_start_server'*
 Use this option to specify whether OmniSharp will start automatically upon
 opening a `*.cs` file. Default: 1 >
-    let g:Omnisharp_start_server=1
+    let g:OmniSharp_start_server=1
 <
 
-                                                    *'g:Omnisharp_stop_server'*
+                                                    *'g:OmniSharp_stop_server'*
 Use this option to specify whether OmniSharp will stop automatically upon
 closing Vim. Default: 2 >
-    let g:Omnisharp_stop_server=1
+    let g:OmniSharp_stop_server=1
 <
 
-                                             *'g:Omnisharp_server_config_name'*
+                                             *'g:OmniSharp_server_config_name'*
 Use this option to specify the OmniSharp server config filename.
 Default: 'omnisharp.json' >
-    let g:Omnisharp_server_config_name='omnisharp.json'
+    let g:OmniSharp_server_config_name='omnisharp.json'
 <
 
                                                     *'g:OmniSharp_server_type'*

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -26,7 +26,7 @@ setlocal omnifunc=OmniSharp#Complete
 
 call OmniSharp#AppendCtrlPExtensions()
 
-if get(g:, 'Omnisharp_start_server', 0) == 1
+if get(g:, 'OmniSharp_start_server', 0) == 1
   call OmniSharp#StartServerIfNotRunning()
 endif
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -28,38 +28,30 @@ let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0
 let g:OmniSharp_BufWritePreSyntaxCheck = get(g:, 'OmniSharp_BufWritePreSyntaxCheck', 1)
 let g:OmniSharp_CursorHoldSyntaxCheck = get(g:, 'OmniSharp_CursorHoldSyntaxCheck', 0)
 
-let g:OmniSharp_sln_list_index =
-\ get( g:, 'OmniSharp_sln_list_index', -1 )
+let g:OmniSharp_sln_list_index = get(g:, 'OmniSharp_sln_list_index', -1)
 
-let g:OmniSharp_sln_list_name =
-\ get( g:, 'OmniSharp_sln_list_name', '' )
+let g:OmniSharp_sln_list_name = get(g:, 'OmniSharp_sln_list_name', '')
 
-let g:OmniSharp_autoselect_existing_sln =
-\ get( g:, 'OmniSharp_autoselect_existing_sln', 1 )
+let g:OmniSharp_autoselect_existing_sln = get(g:, 'OmniSharp_autoselect_existing_sln', 1)
 
 let g:OmniSharp_running_slns = []
 
 " Automatically start server
-if !exists('g:Omnisharp_start_server')
-  let g:Omnisharp_start_server = 1
-endif
+let g:OmniSharp_start_server = get(g:, 'OmniSharp_start_server', get(g:, 'Omnisharp_start_server', 1))
 
 " Automatically stop server
-" g:Omnisharp_stop_server == 0  :: never stop server
-" g:Omnisharp_stop_server == 1  :: always ask
-" g:Omnisharp_stop_server == 2  :: stop if this vim started
-if !exists('g:Omnisharp_stop_server')
-  let g:Omnisharp_stop_server = 2
-endif
+" g:OmniSharp_stop_server == 0  :: never stop server
+" g:OmniSharp_stop_server == 1  :: always ask
+" g:OmniSharp_stop_server == 2  :: stop if this vim started
+let g:OmniSharp_stop_server = get(g:, 'OmniSharp_stop_server', get(g:, 'Omnisharp_stop_server', 2))
 
 " Start server without solution file
 let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_solution', 0)
 
 " Provide custom server configuration file name
-let g:OmniSharp_server_config_name =
-\ get(g:, 'OmniSharp_server_config_name', 'omnisharp.json')
+let g:OmniSharp_server_config_name = get(g:, 'OmniSharp_server_config_name', 'omnisharp.json')
 
-if g:Omnisharp_stop_server == 1
+if g:OmniSharp_stop_server == 1
   autocmd VimLeavePre * call OmniSharp#AskStopServerIfRunning()
 endif
 
@@ -86,6 +78,6 @@ let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
 " Set default for snippet based completions
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
 
-if !exists('g:OmniSharp_prefer_global_sln')
-  let g:OmniSharp_prefer_global_sln = 0
-endif
+let g:OmniSharp_prefer_global_sln = get(g:, 'OmniSharp_prefer_global_sln', 0)
+
+let g:OmniSharp_proc_debug = get(g:, 'OmniSharp_proc_debug', get(g:, 'omnisharp_proc_debug', 0))

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -9,30 +9,29 @@ if !(has('python') || has('python3'))
   finish
 endif
 
-" Set default for translating cygwin/WSL unix paths to Windows paths
-let g:OmniSharp_translate_cygwin_wsl = get(g:, 'OmniSharp_translate_cygwin_wsl', 0)
+" Select a server: one of 'roslyn' or 'v1'
+let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'roslyn')
 
-"Default value for the timeout value
-let g:OmniSharp_timeout = get(g:, 'OmniSharp_timeout', 1)
+" Use mono to start the roslyn server on *nix
+let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
 
-"Default value for the timeout value
 let g:OmniSharp_quickFixLength = get(g:, 'OmniSharp_quickFixLength', 60)
 
-"Don't use the preview window by default
+let g:OmniSharp_timeout = get(g:, 'OmniSharp_timeout', 1)
+
+let g:OmniSharp_translate_cygwin_wsl = get(g:, 'OmniSharp_translate_cygwin_wsl', 0)
+
 let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0)
 
-" Auto syntax-check options.
-" Default:
-" g:OmniSharp_BufWritePreSyntaxCheck = 1
-" g:OmniSharp_CursorHoldSyntaxCheck  = 0
 let g:OmniSharp_BufWritePreSyntaxCheck = get(g:, 'OmniSharp_BufWritePreSyntaxCheck', 1)
 let g:OmniSharp_CursorHoldSyntaxCheck = get(g:, 'OmniSharp_CursorHoldSyntaxCheck', 0)
 
 let g:OmniSharp_sln_list_index = get(g:, 'OmniSharp_sln_list_index', -1)
-
 let g:OmniSharp_sln_list_name = get(g:, 'OmniSharp_sln_list_name', '')
 
 let g:OmniSharp_autoselect_existing_sln = get(g:, 'OmniSharp_autoselect_existing_sln', 1)
+let g:OmniSharp_prefer_global_sln = get(g:, 'OmniSharp_prefer_global_sln', 0)
+let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_solution', 0)
 
 let g:OmniSharp_running_slns = []
 
@@ -45,15 +44,12 @@ let g:OmniSharp_start_server = get(g:, 'OmniSharp_start_server', get(g:, 'Omnish
 " g:OmniSharp_stop_server == 2  :: stop if this vim started
 let g:OmniSharp_stop_server = get(g:, 'OmniSharp_stop_server', get(g:, 'Omnisharp_stop_server', 2))
 
-" Start server without solution file
-let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_solution', 0)
-
-" Provide custom server configuration file name
-let g:OmniSharp_server_config_name = get(g:, 'OmniSharp_server_config_name', 'omnisharp.json')
-
 if g:OmniSharp_stop_server == 1
   autocmd VimLeavePre * call OmniSharp#AskStopServerIfRunning()
 endif
+
+" Provide custom server configuration file name
+let g:OmniSharp_server_config_name = get(g:, 'OmniSharp_server_config_name', 'omnisharp.json')
 
 " Initialize OmniSharp as an asyncomplete source
 autocmd User asyncomplete_setup call asyncomplete#register_source({
@@ -69,15 +65,7 @@ if !exists('g:OmniSharp_selector_ui')
   \ ), 0, '')
 endif
 
-" Set g:OmniSharp_server_type to 'roslyn' or 'v1'
-let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'roslyn')
-
-" Use mono to start the roslyn server on *nix
-let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
-
-" Set default for snippet based completions
+" Set to 1 when ultisnips is installed
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
-
-let g:OmniSharp_prefer_global_sln = get(g:, 'OmniSharp_prefer_global_sln', 0)
 
 let g:OmniSharp_proc_debug = get(g:, 'OmniSharp_proc_debug', get(g:, 'omnisharp_proc_debug', 0))

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -15,6 +15,8 @@ let g:OmniSharp_server_type = get(g:, 'OmniSharp_server_type', 'roslyn')
 " Use mono to start the roslyn server on *nix
 let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
 
+let g:OmniSharp_open_quickfix = get(g:, 'OmniSharp_open_quickfix', 1)
+
 let g:OmniSharp_quickFixLength = get(g:, 'OmniSharp_quickFixLength', 60)
 
 let g:OmniSharp_timeout = get(g:, 'OmniSharp_timeout', 1)

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('omnisharp')
 logger.setLevel(logging.WARNING)
 
 log_dir = os.path.join(
-    vim.eval('g:omnisharp_python_path'),
+    vim.eval('g:OmniSharp_python_path'),
     '..',
     '..',
     'log')

--- a/python/tests/mock_vim.py
+++ b/python/tests/mock_vim.py
@@ -26,7 +26,7 @@ def mock_eval(expr):
         return 0
     elif expr.startswith('g:OmniSharp'):
         return "some_global_setting"
-    elif expr.startswith('g:omnisharp_python_path'):
+    elif expr.startswith('g:OmniSharp_python_path'):
         return "."
     elif expr == 'expand("<sfile>:p:h")':
         return os.path.dirname(__file__)

--- a/test/run-omnisharp-async.vader
+++ b/test/run-omnisharp-async.vader
@@ -21,7 +21,7 @@ Execute (Test start command construction):
 "     return OmniSharp#util#get_start_cmd(OmniSharp#util#path_join(['omnisharp-roslyn', 'src', 'OmniSharp', 'project.json']))
 "   endfunction
 "
-"   let g:omnisharp_proc_debug = 0
+"   let g:OmniSharp_proc_debug = 0
 "   let g:OmniSharp_port = get(g:, 'OmniSharp_port', 2000)
 "
 "   function! StartWait()


### PR DESCRIPTION
This PR adds a new variable to allow disabling automatically opening the quickfix window after FindUsages, FindImplementations etc.

There is also some minor refactoring, including renaming variables to make casing consistent throught the project - all variables called `g:Omnisharp_...` and `:g:omnisharp_...` have been renamed to `g:OmniSharp_...`