### PR TITLE
Shorten the filenames in quickfix

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -746,7 +746,10 @@ function! s:json_decode(json) abort
 endfunction
 
 function! s:set_quickfix(list, title)
-  call setqflist([], ' ', {'nr': '$', 'items': a:list, 'title': a:title})
+  if !has('patch-8.0.0657')
+  \ || setqflist([], ' ', {'nr': '$', 'items': a:list, 'title': a:title}) == -1
+    call setqflist(a:list)
+  endif
   if g:OmniSharp_open_quickfix
     botright cwindow 4
   endif

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -68,6 +68,10 @@ def formatPathForClient(filepath):
                 prefix = '/mnt/{0}/'
             return prefix.format(matchobj.group(1).lower())
         return re.sub(r'^([a-zA-Z]):\\', path_replace, filepath).replace('\\', '/')
+    # Shorten path names by checking if we can make them relative
+    cwd = vim.eval('getcwd()')
+    if os.path.commonprefix([cwd, filepath]) == cwd:
+        filepath = os.path.relpath(filepath, cwd)
     return filepath
 
 def getResponse(endPoint, additional_parameters=None, timeout=None):


### PR DESCRIPTION
Also, I had to change the call to `setqflist()`. The 'items' key is a [pretty recent addition](https://github.com/vim/vim/commit/6a8958db259d4444da6e6956e54a6513c1af8860) to vim and [even more recent](https://github.com/neovim/neovim/commit/d0c4bd23f78ee00943725ea77a63f2a223dba66b) in neovim. When it isn't supported, the set will silently fail.

There is another syntax where instead of providing a dict as the third argument you just pass in the title. Modern vim is backwards compatible with it, and it will throw if it fails which allows us to more easily support older versions (like 7.4)