### PR TITLE
Support running multiple OmniSharp servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,7 @@ This behaviour can be disabled by setting `let g:OmniSharp_start_server = 0` in 
 
 Add `-v Verbose` to get extra information from the server.
 
-
-When vim is closed and the OmniSharp server is running, vim will stop the server automatically.
-This behaviour can be altered with the `g:OmniSharp_stop_server` variable in your vimrc:
-
-```vim
-let g:OmniSharp_stop_server = 0  " Do not stop the server on exit
-let g:OmniSharp_stop_server = 1  " Ask whether to stop the server
-let g:OmniSharp_stop_server = 2  " Automatically stop the server
-```
-
-OmniSharp listens to requests from Vim on port 2000 by default, so make sure that your firewall is configured to accept requests from localhost on this port. This behavior can be changed by setting `let g:OmniSharp_use_random_port = 1` in your vimrc. When set, the OmniSharp server will run on a random port instead of using the default port.
+When vim starts an OmniSharp server, it will bind to a random port by default. If you need to run the server on a specific port (or you are running manually, as above) you can use `let g:OmniSharp_sln_ports = {'C:\path\to\project.sln': 2000}` to map solution files to specific ports, or you can `let g:OmniSharp_port = 2000` to always use a single port (though this will prevent you from running multiple OmniSharp servers).
 
 To get completions, open a C# file from your solution within Vim and press `<C-x><C-o>` (that is ctrl x followed by ctrl o) in Insert mode, or use a completion or autocompletion plugin.
 

--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -1,79 +1,86 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-function! s:debug(message) abort
-  if g:OmniSharp_proc_debug == 1
-    echom 'DEBUG: ' . string(a:message)
-  endif
-endfunction
+let s:jobs = {}
+
+" Neovim jobs {{{ "
 
 function! OmniSharp#proc#supportsNeovimJobs() abort
   return exists('*jobstart')
 endfunction
 
-function! OmniSharp#proc#neovimOutHandler(job_id, data, event) abort
-  if g:OmniSharp_proc_debug == 1
-    let l:message = printf('%s: %s',a:event,string(a:data))
-    echom l:message
-  endif
+function! OmniSharp#proc#neovimOutHandler(job_id, data, event) dict abort
+  let l:message = printf('%s: %s',a:event,string(a:data))
+  echom l:message
 endfunction
 
-function! OmniSharp#proc#neovimErrHandler(job_id, data, event) abort
+function! OmniSharp#proc#neovimErrHandler(job_id, data, event) dict abort
   let l:message = printf('%s: %s',a:event,string(a:data))
-  echoerr l:message
+  call OmniSharp#util#EchoErr(l:message)
+endfunction
+
+function! OmniSharp#proc#neovimExitHandler(job_id, data, event) dict abort
+  let jobkey = ''
+  for [key, id] in items(s:jobs)
+    if a:job_id == id
+      let jobkey = key
+      break
+    endif
+  endfor
+  if !empty(jobkey) && has_key(s:jobs, jobkey)
+    call remove(s:jobs, jobkey)
+  endif
 endfunction
 
 function! OmniSharp#proc#neovimJobStart(command) abort
-  if OmniSharp#proc#supportsNeovimJobs()
-    call s:debug('Using Neovim jobstart to start the following command:')
-    call s:debug(a:command)
-    return jobstart(
-                \ a:command,
-                \ {'on_stdout': 'OmniSharp#proc#neovimOutHandler',
-                \  'on_stderr': 'OmniSharp#proc#neovimErrHandler'})
-  else
-    echoerr 'Not using neovim'
+  if !OmniSharp#proc#supportsNeovimJobs()
+    call OmniSharp#util#EchoErr('Not using neovim')
+    return -1
   endif
+  call s:debug('Using Neovim jobstart to start the following command:')
+  call s:debug(a:command)
+  let opts = {'on_stderr': 'OmniSharp#proc#neovimErrHandler',
+              \  'on_exit': 'OmniSharp#proc#neovimExitHandler'}
+  if g:OmniSharp_proc_debug
+    let opts['on_stdout'] = 'OmniSharp#proc#neovimOutHandler'
+  endif
+  return jobstart(a:command, opts)
 endfunction
+
+" }}} Neovim jobs "
+
+" Vim jobs {{{ "
 
 function! OmniSharp#proc#supportsVimJobs() abort
   return exists('*job_start')
 endfunction
 
 function! OmniSharp#proc#vimOutHandler(channel, message) abort
-  if g:OmniSharp_proc_debug == 1
-    echom printf('%s: %s', string(a:channel), string(a:message))
-  endif
+  echom printf('%s: %s', string(a:channel), string(a:message))
 endfunction
 
 function! OmniSharp#proc#vimErrHandler(channel, message) abort
-  echoerr printf('%s: %s', string(a:channel), string(a:message))
+  let l:message = printf('%s: %s', string(a:channel), string(a:message))
+  call OmniSharp#util#EchoErr(l:message)
 endfunction
 
 function! OmniSharp#proc#vimJobStart(command) abort
-  if OmniSharp#proc#supportsVimJobs()
-    call s:debug('Using vim job_start to start the following command:')
-    call s:debug(a:command)
-    if !exists('s:job') || job_status(s:job) ==# 'dead'
-      let s:job = job_start(
-                  \ a:command,
-                  \ {'out_cb': 'OmniSharp#proc#vimOutHandler',
-                  \  'err_cb': 'OmniSharp#proc#vimErrHandler'})
-    else
-      echom 'OmniSharp server not started - job still exists'
-    endif
-  else
-    echoerr 'Not using Vim 8.0+'
+  if !OmniSharp#proc#supportsVimJobs()
+    call OmniSharp#util#EchoErr('Not using Vim 8.0+')
+    return -1
   endif
+  call s:debug('Using vim job_start to start the following command:')
+  call s:debug(a:command)
+  let opts = {'err_cb': 'OmniSharp#proc#vimErrHandler'}
+  if g:OmniSharp_proc_debug
+    let opts['out_cb'] = 'OmniSharp#proc#vimOutHandler'
+  endif
+  return job_start(a:command, opts)
 endfunction
 
-function! OmniSharp#proc#vimJobStop() abort
-  if OmniSharp#proc#supportsVimJobs()
-    if exists('s:job')
-      call job_stop(s:job)
-    endif
-  endif
-endfunction
+" }}} Vim jobs "
+
+" vim-dispatch {{{ "
 
 function! OmniSharp#proc#supportsVimDispatch() abort
   return exists(':Dispatch') == 2
@@ -85,9 +92,14 @@ function! OmniSharp#proc#dispatchStart(command) abort
           \ call('dispatch#shellescape', a:command),
           \ {'background': 1})
   else
-    echoerr 'vim-dispatch not found'
+    call OmniSharp#util#EchoErr('vim-dispatch not found')
+    return -1
   endif
 endfunction
+
+" }}} vim-dispatch "
+
+" vim-proc {{{ "
 
 function! OmniSharp#proc#supportsVimProc() abort
   let l:is_vimproc = 0
@@ -99,29 +111,91 @@ function! OmniSharp#proc#vimprocStart(command) abort
   if OmniSharp#proc#supportsVimProc()
     return vimproc#popen3(a:command)
   else
-    echoerr 'vimproc not found'
+    call OmniSharp#util#EchoErr('vimproc not found')
+    return -1
   endif
 endfunction
 
-function! OmniSharp#proc#RunAsyncCommand(command) abort
+" }}} vim-proc "
+
+" public functions {{{ "
+
+function! OmniSharp#proc#RunAsyncCommand(command, jobkey) abort
+  if OmniSharp#proc#IsJobRunning(a:jobkey)
+    return
+  endif
   if OmniSharp#proc#supportsNeovimJobs()
-    call OmniSharp#proc#neovimJobStart(a:command)
+    let job_id = OmniSharp#proc#neovimJobStart(a:command)
+    if job_id > 0
+      let s:jobs[a:jobkey] = job_id
+    endif
   elseif OmniSharp#proc#supportsVimJobs()
-    call OmniSharp#proc#vimJobStart(a:command)
+    let job_id = OmniSharp#proc#vimJobStart(a:command)
+    let s:jobs[a:jobkey] = job_id
   elseif OmniSharp#proc#supportsVimDispatch()
-    call OmniSharp#proc#dispatchStart(a:command)
+    let req = call OmniSharp#proc#dispatchStart(a:command)
+    let s:jobs[a:jobkey] = req
   elseif OmniSharp#proc#supportsVimProc()
-    call OmniSharp#proc#vimprocStart(a:command)
+    let proc = call OmniSharp#proc#vimprocStart(a:command)
+    let s:jobs[a:jobkey] = proc
   else
-    echoerr 'Please use neovim, or vim 8.0+ or install either vim-dispatch or vimproc.vim plugin to use this feature'
+    call OmniSharp#util#EchoErr('Please use neovim, or vim 8.0+ or install either vim-dispatch or vimproc.vim plugin to use this feature')
   endif
 endfunction
 
-function! OmniSharp#proc#StopJob() abort
-  if OmniSharp#proc#supportsVimJobs()
-    call OmniSharp#proc#vimJobStop()
+function! OmniSharp#proc#StopJob(jobkey) abort
+  if !OmniSharp#proc#IsJobRunning(a:jobkey)
+    return
+  endif
+  let job_id = s:jobs[a:jobkey]
+
+  if OmniSharp#proc#supportsNeovimJobs()
+    call jobstop(job_id)
+  elseif OmniSharp#proc#supportsVimJobs()
+    call job_stop(job_id)
+  elseif OmniSharp#proc#supportsVimDispatch()
+    call dispatch#abort_command(0, job_id.command)
+  elseif OmniSharp#proc#supportsVimProc()
+    call job_id.kill()
+  endif
+  if has_key(s:jobs, a:jobkey)
+    call remove(s:jobs, a:jobkey)
   endif
 endfunction
+
+function! OmniSharp#proc#ListRunningJobs() abort
+  return filter(keys(s:jobs), 'OmniSharp#proc#IsJobRunning(v:val)')
+endfunction
+
+function! OmniSharp#proc#IsJobRunning(jobkey) abort
+  if !has_key(s:jobs, a:jobkey)
+    return 0
+  endif
+  let job_id = get(s:jobs, a:jobkey)
+  if OmniSharp#proc#supportsNeovimJobs()
+    return 1
+  elseif OmniSharp#proc#supportsVimJobs()
+    let status = job_status(job_id)
+    return status ==# 'run'
+  elseif OmniSharp#proc#supportsVimDispatch()
+    return dispatch#completed(job_id)
+  elseif OmniSharp#proc#supportsVimProc()
+    let [cond, status] = call job_id.checkpid()
+    return status != 0
+  endif
+endfunction
+
+" }}} public functions "
+
+" private functions {{{ "
+
+function! s:debug(message) abort
+  if g:OmniSharp_proc_debug == 1
+    echom 'DEBUG: ' . string(a:message)
+  endif
+endfunction
+
+" }}} private functions "
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -42,16 +42,17 @@ Suggestion: Install a completer such as NeoComplete or SuperTab
 ===============================================================================
 OPTIONS                                                     *omnisharp-options*
 
+                                                           *'g:OmniSharp_port'*
+Always use this port when starting an OmniSharp server. Note that this means you
+will be unable to run more than one OmniSharp server at a time.
+Default: None >
+    let g:OmniSharp_port = 2000
+<
+
                                                    *'g:OmniSharp_start_server'*
 Use this option to specify whether OmniSharp will start automatically upon
 opening a `*.cs` file. Default: 1 >
     let g:OmniSharp_start_server = 1
-<
-
-                                                    *'g:OmniSharp_stop_server'*
-Use this option to specify whether OmniSharp will stop automatically upon
-closing Vim. Default: 2 >
-    let g:OmniSharp_stop_server = 1
 <
 
                                              *'g:OmniSharp_server_config_name'*
@@ -83,22 +84,18 @@ Default: 0 >
 <
 
                                                            *'g:OmniSharp_host'*
-Use this option to specify the host address of the OmniSharp server.
+Use this option to specify the host address of the OmniSharp server. Using this
+will not play well with the auto-start functionality, so you should probably set
+g:OmniSharp_start_server = 0
 Default: 'http://localhost:2000' >
     let g:OmniSharp_host = 'http://localhost:2000'
 <
 
-                                                *'g:OmniSharp_use_random_port'*
-Use this option to default to a random port when no port is selected.
-Default: 0 >
-    let g:OmniSharp_use_random_port = 0
-<
-
                                                        *'g:OmniSharp_loglevel'*
-Sets the log level for the python code. Possible values are debug, 'info',
+Sets the log level for the python code. Possible values are 'debug', 'info',
 'warning', 'error', and 'critical'.
 Default: warning >
-    let g:OmniSharp_loglevel = warning
+    let g:OmniSharp_loglevel = 'warning'
 <
 
                                                   *'g:OmniSharp_open_quickfix'*
@@ -107,6 +104,16 @@ after find usages, implementations etc. Set this variable to 0 to prevent the
 quickfix window being opened automatically.
 Default: 1 >
     let g:OmniSharp_open_quickfix = 0
+<
+
+                                                      *'g:OmniSharp_sln_ports'*
+Mapping of solution file to port. When auto-starting the OmniSharp server, it
+will bind to the port listed here if the solution file matches. If there is no
+match, the port will be chosen at random.
+Default: {} >
+    let g:OmniSharp_sln_ports = {
+      \ 'C:\path\to\myproject.sln': 2003,
+      \ }
 <
 
                                                         *'g:OmniSharp_timeout'*
@@ -262,9 +269,24 @@ COMMANDS                                                   *omnisharp-commands*
 :OmniSharpAddToProject
     Adds current file to closest `*.csproj`
 
+                                                  *:OmniSharpRestartAllServers*
+:OmniSharpRestartAllServers
+    Restarts all running OmniSharp servers
+    NOTE: Requires vim 8.0+, neovim or vim-dispatch
+
+                                                      *:OmniSharpRestartServer*
+:OmniSharpRestartServer
+    Restarts the OmniSharp server
+    NOTE: Requires vim 8.0+, neovim or vim-dispatch
+
                                                         *:OmniSharpStartServer*
 :OmniSharpStartServer
     Starts the OmniSharp server
+    NOTE: Requires vim 8.0+, neovim or vim-dispatch
+
+                                                     *:OmniSharpStopAllServers*
+:OmniSharpStopAllServers
+    Stops all running OmniSharp servers
     NOTE: Requires vim 8.0+, neovim or vim-dispatch
 
                                                          *:OmniSharpStopServer*

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -52,12 +52,15 @@ command! -buffer -bar OmniSharpNavigateDown        call OmniSharp#NavigateDown()
 command! -buffer -bar OmniSharpOpenPythonLog       call OmniSharp#OpenPythonLog()
 command! -buffer -bar OmniSharpReloadSolution      call OmniSharp#ReloadSolution()
 command! -buffer -bar OmniSharpRename              call OmniSharp#Rename()
+command! -buffer -bar OmniSharpRestartAllServers   call OmniSharp#RestartAllServers()
+command! -buffer -bar OmniSharpRestartServer       call OmniSharp#RestartServer()
 command! -buffer -bar OmniSharpRunAllTests         call OmniSharp#RunTests('all')
 command! -buffer -bar OmniSharpRunLastTests        call OmniSharp#RunTests('last')
 command! -buffer -bar OmniSharpRunTestFixture      call OmniSharp#RunTests('fixture')
 command! -buffer -bar OmniSharpRunTests            call OmniSharp#RunTests('single')
 command! -buffer -bar OmniSharpSignatureHelp       call OmniSharp#SignatureHelp()
 command! -buffer -bar OmniSharpStartServer         call OmniSharp#StartServer()
+command! -buffer -bar OmniSharpStopAllServers      call OmniSharp#StopAllServers()
 command! -buffer -bar OmniSharpStopServer          call OmniSharp#StopServer()
 command! -buffer -bar OmniSharpTypeLookup          call OmniSharp#TypeLookupWithoutDocumentation()
 
@@ -105,8 +108,11 @@ let b:undo_ftplugin .= '
 \|  delcommand OmniSharpReloadSolution
 \|  delcommand OmniSharpRename
 \|  delcommand OmniSharpRenameTo
+\|  delcommand OmniSharpRestartAllServers
+\|  delcommand OmniSharpRestartServer
 \|  delcommand OmniSharpStartServer
 \|  delcommand OmniSharpStartServerSolution
+\|  delcommand OmniSharpStopAllServers
 \|  delcommand OmniSharpStopServer
 \|  delcommand OmniSharpTypeLookup
 \|  delcommand OmniSharpRunAllTests

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -35,26 +35,17 @@ let g:OmniSharp_autoselect_existing_sln = get(g:, 'OmniSharp_autoselect_existing
 let g:OmniSharp_prefer_global_sln = get(g:, 'OmniSharp_prefer_global_sln', 0)
 let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_solution', 0)
 
-let g:OmniSharp_running_slns = []
-
 " Automatically start server
 let g:OmniSharp_start_server = get(g:, 'OmniSharp_start_server', get(g:, 'Omnisharp_start_server', 1))
-
-" Automatically stop server
-" g:OmniSharp_stop_server == 0  :: never stop server
-" g:OmniSharp_stop_server == 1  :: always ask
-" g:OmniSharp_stop_server == 2  :: stop if this vim started
-let g:OmniSharp_stop_server = get(g:, 'OmniSharp_stop_server', get(g:, 'Omnisharp_stop_server', 2))
-
-if g:OmniSharp_stop_server == 1
-  autocmd VimLeavePre * call OmniSharp#AskStopServerIfRunning()
-endif
 
 " Provide custom server configuration file name
 let g:OmniSharp_server_config_name = get(g:, 'OmniSharp_server_config_name', 'omnisharp.json')
 
 " Default value for python log level
 let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', 'warning')
+
+" Default map of solution file to port
+let g:OmniSharp_sln_ports = get(g:, 'OmniSharp_sln_ports', {})
 
 " Initialize OmniSharp as an asyncomplete source
 autocmd User asyncomplete_setup call asyncomplete#register_source({

--- a/python/omnisharp/OmniSharp.py
+++ b/python/omnisharp/OmniSharp.py
@@ -91,10 +91,7 @@ def getResponse(endPoint, additional_parameters=None, timeout=None):
     if timeout == None:
         timeout = int(vim.eval('g:OmniSharp_timeout'))
 
-    host = vim.eval('g:OmniSharp_host')
-
-    if vim.eval('exists("b:OmniSharp_host")') == '1':
-        host = vim.eval('b:OmniSharp_host')
+    host = vim.eval('OmniSharp#GetHost()')
 
     target = urlparse.urljoin(host, endPoint)
 
@@ -463,3 +460,9 @@ def find_free_port():
     with closing(s):
         s.bind(('', 0))
         return s.getsockname()[1]
+
+def checkAliveStatus():
+    try:
+        return getResponse("/checkalivestatus", timeout=0.2) == 'true'
+    except Exception as e:
+        return 0


### PR DESCRIPTION
I was doing a lot of work on projects with different solution files simultaneously, and omnisharp-vim wasn't handling it well.

The main focus of this change was making it so that instead of using a single omnisharp-roslyn server, we do everything on a per-solution-file basis. Servers are started per-solution. Ports are mapped per-solution.

A side effect of this change is that now servers are started on a random port by default, though this is configurable with `g:OmniSharp_sln_ports`.