### PR TITLE
Add ALE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The plugin relies on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisha
 * Find implementations/derived types
 * Find usages
 * Contextual code actions (unused usings, use var....etc.) (can use plugin: [fzf.vim](https://github.com/junegunn/fzf.vim), [CtrlP](https://github.com/ctrlpvim/ctrlp.vim) or [unite.vim](https://github.com/Shougo/unite.vim))
-* Find code issues (unused usings, use base type where possible....etc.) (requires plugin: [Syntastic](https://github.com/vim-syntastic/syntastic))
+* Find code issues (unused usings, use base type where possible....etc.) (requires plugin: [ALE](https://github.com/w0rp/ale) or [Syntastic](https://github.com/vim-syntastic/syntastic))
 * Fix using statements for the current buffer (sort, remove and add any missing using statements where possible)
 * Rename refactoring
 * Semantic type highlighting
@@ -118,8 +118,13 @@ OmniSharp-vim can start the server and run asynchronous builds only if any of th
 * [vim-dispatch](https://github.com/tpope/vim-dispatch) is installed
 * [vimproc.vim](https://github.com/Shougo/vimproc.vim) is installed
 
+### (optional) Install ALE
+
+If [ALE](https://github.com/w0rp/ale) is installed, it will automatically be
+used to asynchronously check your code for errors.
+
 ### (optional) Install syntastic
-The vim plugin [syntastic](https://github.com/vim-syntastic/syntastic) is needed for displaying code issues and syntax errors.
+The vim plugin [syntastic](https://github.com/vim-syntastic/syntastic) can be used if you don't have ALE.
 Configure it to work with OmniSharp with the following line in your vimrc.
 
 ```vim

--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -1,0 +1,38 @@
+function! ale_linters#cs#omnisharp#ProcessOutput(buffer, lines) abort
+  let list = []
+  for line in a:lines
+    let [filename, lnum, col, type, subtype, text] = split(line, '@@@')
+    let item = {
+          \ "filename": filename,
+          \ "lnum": lnum,
+          \ "col": col,
+          \ "type": type,
+          \ "text": text,
+          \}
+    if subtype ==? 'style'
+      let item['sub_type'] = 'style'
+    endif
+    call add(list, item)
+  endfor
+  return list
+endfunction
+
+function! ale_linters#cs#omnisharp#GetCommand(bufnum) abort
+  let linter = OmniSharp#util#path_join(['python', 'ale_lint.py'])
+  let host = OmniSharp#GetHost(a:bufnum)
+  let cmd = printf(
+        \ 'python %s --filename %%s --host %s --level %s --cwd %s --delimiter @@@',
+        \ ale#Escape(linter), ale#Escape(host), g:OmniSharp_loglevel, ale#Escape(getcwd()))
+  if g:OmniSharp_translate_cygwin_wsl
+    cmd = cmd . ' --translate'
+  endif
+  return cmd
+endfunction
+
+call ale#linter#Define('cs', {
+\   'name': 'omnisharp',
+\   'aliases': ['Omnisharp', 'OmniSharp'],
+\   'executable': 'python',
+\   'command_callback': 'ale_linters#cs#omnisharp#GetCommand',
+\   'callback': 'ale_linters#cs#omnisharp#ProcessOutput',
+\})

--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -1,7 +1,9 @@
+let s:delimiter = "@@@"
+
 function! ale_linters#cs#omnisharp#ProcessOutput(buffer, lines) abort
   let list = []
   for line in a:lines
-    let [filename, lnum, col, type, subtype, text] = split(line, '@@@')
+    let [filename, lnum, col, type, subtype, text] = split(line, s:delimiter)
     let item = {
           \ "filename": filename,
           \ "lnum": lnum,
@@ -21,10 +23,11 @@ function! ale_linters#cs#omnisharp#GetCommand(bufnum) abort
   let linter = OmniSharp#util#path_join(['python', 'ale_lint.py'])
   let host = OmniSharp#GetHost(a:bufnum)
   let cmd = printf(
-        \ 'python %s --filename %%s --host %s --level %s --cwd %s --delimiter @@@',
-        \ ale#Escape(linter), ale#Escape(host), g:OmniSharp_loglevel, ale#Escape(getcwd()))
+        \ '%%e %s --filename %%s --host %s --level %s --cwd %s --delimiter %s',
+        \ ale#Escape(linter), ale#Escape(host), ale#Escape(g:OmniSharp_loglevel),
+        \ ale#Escape(getcwd()), ale#Escape(s:delimiter))
   if g:OmniSharp_translate_cygwin_wsl
-    cmd = cmd . ' --translate'
+    let cmd = cmd . ' --translate'
   endif
   return cmd
 endfunction

--- a/python/ale_lint.py
+++ b/python/ale_lint.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import argparse
+import logging
+import os
+import sys
+from os.path import join, pardir, realpath
+
+from omnisharp.util import UtilCtx, getResponse, quickfixes_from_response
+
+
+def _setup_logging(level):
+    logger = logging.getLogger('omnisharp')
+    logger.setLevel(level)
+
+    log_dir = realpath(join(__file__, pardir, pardir, 'log'))
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+    log_file = os.path.join(log_dir, 'lint.log')
+    hdlr = logging.FileHandler(log_file)
+    logger.addHandler(hdlr)
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    hdlr.setFormatter(formatter)
+    return logger
+
+
+def main():
+    """ Run a /codecheck on a file """
+
+    log_levels = {
+        'debug': logging.DEBUG,
+        'info': logging.INFO,
+        'warning': logging.WARNING,
+        'error': logging.ERROR,
+        'critical': logging.CRITICAL,
+    }
+
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument('--host', required=True,
+                        help="Host and port of omnisharp server")
+    parser.add_argument('--filename', required=True,
+                        help="Path of the file being checked")
+    parser.add_argument('--cwd', help="Current working directory of vim",
+                        default='')
+    parser.add_argument('--delimiter', default=':',
+                        help="Delimiter for output (default %(default)s)")
+    parser.add_argument('--level', help="Log level (default %(default)s)",
+                        choices=log_levels.keys(), default='info')
+    parser.add_argument('--translate', action='store_true',
+                        help="If provided, translate cygwin/wsl paths")
+    args = parser.parse_args()
+    logger = _setup_logging(log_levels[args.level])
+    try:
+        do_codecheck(logger, args.filename.strip(), args.host, args.cwd,
+                     args.translate, args.delimiter)
+    except Exception as e:
+        logger.exception("Error doing codecheck")
+
+
+def do_codecheck(logger, filename, host, cwd, translate, delimiter):
+    ctx = UtilCtx(
+        buffer_name=filename,
+        translate_cygwin_wsl=translate,
+        cwd=cwd,
+        timeout=4,
+        host=host,
+        buffer=''.join(sys.stdin),
+    )
+
+    response = getResponse(ctx, '/codecheck', json=True)
+    quickfixes = quickfixes_from_response(ctx, response['QuickFixes'])
+
+    keys = ['filename', 'lnum', 'col', 'type', 'subtype', 'text']
+    for item in quickfixes:
+        print(delimiter.join([str(item.get(k, '')) for k in keys]))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Most of this is pretty straightforward. Just adding a standalone python script that can perform the lint, and the glue file that tells ALE how to use it.

I did some refactoring in `autoload/OmniSharp.vim` because ALE passes the buffer number as an argument. I don't know if that means that ALE might be called on buffers that aren't the current buffer...but I assumed that might be the case and changed some of the utility functions (like `OmniSharp#FindSolution()`) to optionally take a buffer number instead of always assuming the current buffer.