### PR TITLE
Set default path to server, and prompt to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install the vim plugin using your preferred plugin manager:
 | [Pathogen](https://github.com/tpope/vim-pathogen)    | `git clone git://github.com/OmniSharp/omnisharp-vim.git ~/.vim/bundle/omnisharp-vim` |
 
 ### Server
-OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. The first time OmniSharp-vim tries to open a C# file, it will check for the presence of the server, and if not found it will ask if it should be downloaded. Answer 'y' and the latest version will be downloaded and extracted to `~/.omnisharp/omnisharp-roslyn`, ready to use.
+OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. The first time OmniSharp-vim tries to open a C# file, it will check for the presence of the server, and if not found it will ask if it should be downloaded. Answer 'y' and the latest version will be downloaded and extracted to `~/.omnisharp/omnisharp-roslyn`, ready to use. *Note:* Requires curl.
 
 #### Manual installation, and Windows users
 The automatic installation script is currently only available in Linux and macOS, and to Windows users when vim is run in a Cygwin/WSL environment. To install the server manually, follow these steps:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ Install the vim plugin using your preferred plugin manager:
 | [Pathogen](https://github.com/tpope/vim-pathogen)    | `git clone git://github.com/OmniSharp/omnisharp-vim.git ~/.vim/bundle/omnisharp-vim` |
 
 ### Server
-OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. Download the latest **HTTP** release for your platform from the [releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page. OmniSharp-vim uses http to communicate with the server, so select the **HTTP** variant for your architecture. This means that for a 64-bit Windows system, the `omnisharp.http-win-x64.zip` package should be downloaded, whereas Mac users should select `omnisharp.http-osx.tar.gz`.
+OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. The first time OmniSharp-vim tries to open a C# file, it will check for the presence of the server, and if not found it will ask if it should be downloaded. Answer 'y' and the latest version will be downloaded and extracted to `~/.omnisharp/omnisharp-roslyn`, ready to use.
+
+#### Manual installation, and Windows users
+The automatic installation script is currently only available in Linux and macOS, and to Windows users when vim is run in a Cygwin/WSL environment. To install the server manually, follow these steps:
+
+Download the latest **HTTP** release for your platform from the [releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page. OmniSharp-vim uses http to communicate with the server, so select the **HTTP** variant for your architecture. This means that for a 64-bit Windows system, the `omnisharp.http-win-x64.zip` package should be downloaded, whereas Mac users should select `omnisharp.http-osx.tar.gz` etc.
 
 ##### Important! Download the HTTP release!
 _Please pay attention to the previous paragraph, and download the HTTP OmniSharp-Roslyn release (it has "http" in the download filename"). The non-HTTP version uses stdio instead of HTTP and OmniSharp-vim cannot communicate with it. This trips a lot of people up, hence the added emphasis!_
@@ -76,8 +81,12 @@ let g:OmniSharp_server_path = 'C:\OmniSharp\omnisharp.http-win-x64\OmniSharp.exe
 let g:OmniSharp_server_path = '/home/me/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
 ```
 
-#### Cygwin and WSL
-Windows users who wish to use OmniSharp-vim in a Cygwin or Windows Subsystem for Linux terminal vim, download the *Windows* OmniSharp-Rosyn release. Configure your vimrc to point to the `OmniSharp.exe` file, and let OmniSharp-vim know that you are operating in Cygwin/WSL mode (indicating that file paths need to be translated by OmniSharp-vim from Unix-Windows and back:
+#### Windows: Cygwin
+No special configuration is required for cygwin. The automatic installation script for cygwin downloads the *Windows* OmniSharp-roslyn release. OmniSharp-vim detects that it is running in a cygwin environment and automatically enables Windows/cygwin file path translations by setting the default value of `g:OmniSharp_translate_cygwin_wsl` to `1`.
+
+#### Windows Subsystem for Linux (WSL)
+OmniSharp-roslyn can function perfectly well in WSL using linux binaries, if the environment is correctly configured (see [OmniSharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn) for requirements).
+However, if you have the .NET Framework installed in Windows, you may have better results using the Windows binaries. To do this, follow the Manual installation instructions above, configure your vimrc to point to the `OmniSharp.exe` file, and let OmniSharp-vim know that you are operating in Cygwin/WSL mode (indicating that file paths need to be translated by OmniSharp-vim from Unix-Windows and back:
 
 ```vim
 let g:OmniSharp_server_path = '/mnt/c/OmniSharp/omnisharp.http-win-x64/OmniSharp.exe'
@@ -172,14 +181,11 @@ See the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki) for more custom 
 " OmniSharp won't work without this setting
 filetype plugin on
 
-" Set the path to the roslyn server
-let g:OmniSharp_server_path = '/home/me/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
-
 " Set the type lookup function to use the preview window instead of echoing it
 "let g:OmniSharp_typeLookupInPreview = 1
 
 " Timeout in seconds to wait for a response from the server
-let g:OmniSharp_timeout = 1
+let g:OmniSharp_timeout = 5
 
 " Don't autoselect first omnicomplete option, show options even if there is only
 " one (so the preview documentation is accessible). Remove 'preview' if you
@@ -195,9 +201,6 @@ set completeopt=longest,menuone,preview
 " Set desired preview window height for viewing documentation.
 " You might also want to look at the echodoc plugin.
 set previewheight=5
-
-" Get code issues and syntax errors
-let g:syntastic_cs_checkers = ['code_checker']
 
 augroup omnisharp_commands
     autocmd!

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -720,14 +720,8 @@ function! OmniSharp#Install() abort
   endif
   echo 'Installing OmniSharp Roslyn...'
   call OmniSharp#StopAllServers()
-  call system('sh '.s:script_location.' -Hl "$HOME/.omnisharp/vim/"')
-  echomsg "OmniSharp installed to: ~/.omnisharp/vim/"
-  echomsg "Place this in your Vim config:"
-  if has('win32unix')
-    echomsg "let g:OmniSharp_server_path = expand('~/.omnisharp/vim/OmniSharp.exe')"
-  else
-    echomsg "let g:OmniSharp_server_path = expand('~/.omnisharp/vim/run')"
-  endif
+  call system('sh '.s:script_location.' -Hl "$HOME/.omnisharp/omnisharp-roslyn/"')
+  echomsg 'OmniSharp installed to: ~/.omnisharp/omnisharp-roslyn/'
 endfunction
 
 function! s:find_solution_files(bufnum) abort

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -79,12 +79,10 @@ function! OmniSharp#util#get_start_cmd(solution_file) abort
     endif
     let s:server_path = join(parts, s:dir_separator)
     if !executable(s:server_path)
-      echohl Question
-      let yn = input('The OmniSharp server is missing. Download it now? [y/N] ')
-      echohl None
-      if yn ==? 'y'
-        echo '\n'
+      if confirm('The OmniSharp server does not appear to be installed. Would you like to install it?', "&Yes\n&No") == 1
         call OmniSharp#Install()
+      else
+        redraw
       endif
     endif
   else

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -27,8 +27,7 @@ Required:~
 
 Optional:~
     - CtrlP, unite.vim or fzf.vim (for fuzzy-search capabilities)
-    - Syntastic plugin (for syntax and type checking)
-    NOTE: Must be enabled (see |'g:syntastic_cs_checkers'|)
+    - ALE or Syntastic plugin (for syntax and type checking)
 
 ===============================================================================
 USAGE                                                         *omnisharp-usage*
@@ -63,7 +62,9 @@ Default: 'omnisharp.json' >
 
                                                     *'g:OmniSharp_server_path'*
 Use this option to give the full path to the roslyn omnisharp server
-executable. >
+executable. If not set, the |:OmniSharpInstall| location is used.
+Default: '/home/username/.omnisharp/omnisharp-roslyn/run'
+     or: 'C:\Users\username\.omnisharp\omnisharp-roslyn\OmniSharp.exe' >
     let g:OmniSharp_server_path = '/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
 <
 
@@ -261,5 +262,12 @@ COMMANDS                                                   *omnisharp-commands*
                                                      *:OmniSharpHighlightTypes*
 :OmniSharpHighlightTypes
     Enable advanced type highlighting for current file
+
+                                                            *:OmniSharpInstall*
+:OmniSharpInstall
+    Download the latest OmniSharp-roslyn binaries and extract them into
+    ~/.omnisharp/omnisharp-roslyn.
+    NOTE: This is currently only supported in Windows in Cygwin/WSL
+    environments
 
 ===============================================================================

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -266,8 +266,10 @@ COMMANDS                                                   *omnisharp-commands*
                                                             *:OmniSharpInstall*
 :OmniSharpInstall
     Download the latest OmniSharp-roslyn binaries and extract them into
-    ~/.omnisharp/omnisharp-roslyn.
-    NOTE: This is currently only supported in Windows in Cygwin/WSL
+    ~/.omnisharp/omnisharp-roslyn. This can be used to install OmniSharp-roslyn
+    initially, and to upgrade to the latest version at any time.
+    Requires "curl" to be installed.
+    NOTE: This is not currently supported in Windows, except in Cygwin/WSL
     environments
 
 ===============================================================================


### PR DESCRIPTION
This is a followup to #382, updating the default location for the OmniSharp-roslyn server when no `g:OmniSharp_server_path` is set, and prompting the user to download and extract the latest binaries when the server does not exist.