### PR TITLE
Allow users to disable omnisharp

### DIFF
--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -1,3 +1,7 @@
+if !get(g:, 'OmniSharp_loaded', 0)
+  finish
+endif
+
 let s:delimiter = "@@@"
 
 function! ale_linters#cs#omnisharp#ProcessOutput(buffer, lines) abort

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -1,3 +1,7 @@
+if !get(g:, 'OmniSharp_loaded', 0)
+  finish
+endif
+
 if !(has('python') || has('python3'))
   finish
 endif

--- a/syntax_checkers/cs/codecheck.vim
+++ b/syntax_checkers/cs/codecheck.vim
@@ -1,3 +1,7 @@
+if !get(g:, 'OmniSharp_loaded', 0)
+  finish
+endif
+
 if !(has('python') || has('python3'))
   finish
 endif


### PR DESCRIPTION
Support the common vim idiom for disabling a plugin:

    let g:OmniSharp_loaded = 0

Any vimscript that might execute on its own should ensure loaded is
greater than zero.

While omnisharp is generally great at silently failing if the server
doesn't exist, this allows users to easily turn it off when necessary.

Without this change, setting loaded to zero causes lots of errors when editing a .cs file. With this change,  no errors.