### PR TITLE
Fix :OmniSharpFindSymbols error when validating

### DIFF
--- a/autoload/ctrlp/OmniSharp/findsymbols.vim
+++ b/autoload/ctrlp/OmniSharp/findsymbols.vim
@@ -78,7 +78,7 @@ function! ctrlp#OmniSharp#findsymbols#accept(mode, str) abort
     endif
   endfor
   echo quickfix.filename
-  call  OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col)
+  call  OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col, 0)
 endfunction
 
 " Give the extension an ID

--- a/autoload/fzf/OmniSharp.vim
+++ b/autoload/fzf/OmniSharp.vim
@@ -12,7 +12,7 @@ function! s:location_sink(str) abort
     endif
   endfor
   echo quickfix.filename
-  call OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col)
+  call OmniSharp#JumpToLocation(quickfix.filename, quickfix.lnum, quickfix.col, 0)
 endfunction
 
 function! fzf#OmniSharp#findsymbols(quickfixes) abort


### PR DESCRIPTION
Fix an error after you validate an entry during a :OmniSharpFindSymbols.

Occurs only if g:OmniSharp_selector_ui is 'ctrlp' or 'fzf'.

Error message for fzf was:

Error detected while processing function OmniSharp#FindSymbol[17]..fzf#OmniSharp#findsymbols[6]..fzf#run[69]..<SNR>49_callback:
line   33:
Vim(call):E119: Not enough arguments for function: OmniSharp#JumpToLocation
Error detected while processing function OmniSharp#FindSymbol:
line   17:
E171: Missing :endif
Press ENTER or type command to continue