### PR TITLE
Mono installer & install specific versions

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -725,7 +725,8 @@ function! OmniSharp#Install() abort
     let l:location = expand('$HOME').'\.omnisharp\omnisharp-roslyn'
     call system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location.'"')
   else
-    call system('sh "'.s:script_location.'" -Hl "$HOME/.omnisharp/omnisharp-roslyn/"')
+    let l:mono = g:OmniSharp_server_use_mono ? " -M" : ""
+    call system('sh "'.s:script_location.'" -Hl "$HOME/.omnisharp/omnisharp-roslyn/"'.l:mono)
   endif
   echomsg 'OmniSharp installed to: ~/.omnisharp/omnisharp-roslyn/'
 endfunction

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -718,15 +718,20 @@ endfunction
 
 let s:extension = has('win32') ? '.ps1' : '.sh'
 let s:script_location = expand('<sfile>:p:h:h').'/installer/omnisharp-manager'.s:extension
-function! OmniSharp#Install() abort
+function! OmniSharp#Install(...) abort
   echo 'Installing OmniSharp Roslyn...'
   call OmniSharp#StopAllServers()
+
+  let l:version = a:000 != [] ? ' -v '.a:000[0] : ''
+
   if has('win32')
     let l:location = expand('$HOME').'\.omnisharp\omnisharp-roslyn'
-    call system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location.'"')
+    call system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location
+          \ .'"'.l:version)
   else
     let l:mono = g:OmniSharp_server_use_mono ? " -M" : ""
-    call system('sh "'.s:script_location.'" -Hl "$HOME/.omnisharp/omnisharp-roslyn/"'.l:mono)
+    call system('sh "'.s:script_location.'" -Hl "$HOME/.omnisharp/omnisharp-roslyn/"'
+          \ .l:mono.l:version)
   endif
   echomsg 'OmniSharp installed to: ~/.omnisharp/omnisharp-roslyn/'
 endfunction

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -72,14 +72,14 @@ function! OmniSharp#util#get_start_cmd(solution_file) abort
   let s:server_path = ''
   if !exists('g:OmniSharp_server_path')
     let parts = [expand('$HOME'), '.omnisharp', 'omnisharp-roslyn']
-    if has('win32') || s:is_cygwin()
+    if has('win32') || s:is_cygwin() || g:OmniSharp_server_use_mono
       let parts += ['OmniSharp.exe']
     else
       let parts += ['run']
     endif
     let s:server_path = join(parts, s:dir_separator)
     if !executable(s:server_path)
-      if confirm('The OmniSharp server does not appear to be installed. Would you like to install it?', "&Yes\n&No") == 1
+      if confirm('The OmniSharp server does not appear to be installed. Would you like to install it?', "&Yes\n&No", 2) == 1
         call OmniSharp#Install()
       else
         redraw

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -60,7 +60,7 @@ command! -buffer -bar OmniSharpStartServer         call OmniSharp#StartServer()
 command! -buffer -bar OmniSharpStopAllServers      call OmniSharp#StopAllServers()
 command! -buffer -bar OmniSharpStopServer          call OmniSharp#StopServer()
 command! -buffer -bar OmniSharpTypeLookup          call OmniSharp#TypeLookupWithoutDocumentation()
-command! -buffer -bar OmniSharpInstall             call OmniSharp#Install()
+command! -buffer -bar -nargs=? OmniSharpInstall    call OmniSharp#Install(<f-args>)
 
 
 command! -buffer -nargs=1 OmniSharpRenameTo

--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -70,3 +70,5 @@ if [ "$ext" = "zip" ]; then
 else
     tar -zxvf "$location/$file_name" -C "$location/"
 fi
+
+[ "$mono" -eq 1 ] && chmod +x $(find "$location" -type f)


### PR DESCRIPTION
This pull request adds two new features to to the `OmniSharpInstall` command.

If the variable `g:OmniSharp_server_use_mono` is set to `1`, the automatic installer and the `OmniSharpInstall` command will install the mono variant of the OmniSharp Roslyn server.

The `OmniSharpInstall` command now accepts an optional parameter which will allow a specific version of OmniSharp Roslyn to be installed:

e.g.
```vim
:OmniSharpInstall 'v1.32.1'
```