### PR TITLE
Preserve symlinked path

### DIFF
--- a/python/omnisharp/util.py
+++ b/python/omnisharp/util.py
@@ -83,7 +83,9 @@ class VimUtilCtx(BaseCtx):
 
     @property
     def buffer_name(self):
-        return self._vim.current.buffer.name
+        # We can't use self._vim.current.buffer.name because it returns the real
+        # path. expand('%') will preserve the symlinked path, if one exists.
+        return self._vim.eval("expand('%:p')")
 
     @property
     def translate_cygwin_wsl(self):


### PR DESCRIPTION
I'm working on a project that uses a bunch of windows junctions and a csproj that refers to the symlinked path. When I edit the symlinked files I need to pass the symlinked path because that is the one that omnisharp expects.

`vim.current.buffer.name` is always the real path (tested in vim and neovim)

`vim.eval("expand('%:p')")` will give us the correct, symbolic path