### PR TITLE
Addressing issue #404 with Roslyn Server not installing

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -751,11 +751,10 @@ function! OmniSharp#Install(...) abort
       let l:location = expand('$HOME').'\.omnisharp\omnisharp-roslyn'
       let l:install_result = system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location
           \ .'"'.l:version)
-
-      if l:install_result =~# "Failure"
-        echomsg 'Installation to "' . l:location . '" failed inside PowerShell'
-      else
+      if l:install_result =~# '0'
         echomsg 'OmniSharp installed to: ' . l:location
+      else
+        echomsg 'Installation to "' . l:location . '" failed inside PowerShell. "'. l:install_result. '" was returned.'
       endif
     else
       echomsg 'Powershell is running at an ExecutionPolicy level that blocks OmniSharp-vim from installing the Roslyn server'
@@ -770,11 +769,7 @@ endfunction
 
 function! ValidPowerShellSettings()
     let l:ps_policy_level = system('powershell Get-ExecutionPolicy')
-    if l:ps_policy_level[0:9] ==# "Restricted" || l:ps_policy_level[0:8] ==# "AllSigned"
-      return 0
-    else
-      return 1
-    endif
+    return l:ps_policy_level !~# '^\(Restricted\|AllSigned\)'
 endfunction
 
 function! s:find_solution_files(bufnum) abort

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -749,12 +749,12 @@ function! OmniSharp#Install(...) abort
   if has('win32')
     if ValidPowerShellSettings()
       let l:location = expand('$HOME').'\.omnisharp\omnisharp-roslyn'
-      let l:install_result = system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location
+      call system('powershell "& ""'.s:script_location.'""" -H -l "'.l:location
           \ .'"'.l:version)
-      if l:install_result =~# '0'
-        echomsg 'OmniSharp installed to: ' . l:location
+      if v:shell_error
+        echomsg 'Installation to "' . l:location . '" failed inside PowerShell.'
       else
-        echomsg 'Installation to "' . l:location . '" failed inside PowerShell. "'. l:install_result. '" was returned.'
+        echomsg 'OmniSharp installed to: ' . l:location
       endif
     else
       echomsg 'Powershell is running at an ExecutionPolicy level that blocks OmniSharp-vim from installing the Roslyn server'

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,16 +1,47 @@
+# OmniSharp Installers
+The OmniSharp installers are scripts that omnisharp-vim uses to install the OmniSharp Roslyn server if it is not able to find it when opening a .cs file. There is a shell (.sh) version for Linux, macOS, & Cygwin/WSL and there is a PowerShell (.ps1) version for Windows.
+
+## omnisharp-manager PowerShell script
+
+### Usage Syntax
+> omnisharp-manager.ps1 [-v \<VersionNumber\>] [-l \<InstallLocation\>] [-u] [-H]
+
+Flags | Description
+----- | -----------
+ -v \<VersionNumber\> | version number of server to install (default: the latest version)
+ -l \<InstallLocation\> | where to install the server (default: '%USERPROFILE%\\.omnisharp\')
+ -u | help / usage info
+ -H | install the HTTP version of the server
+
+### Output
+After downloading and installing the server the script will check for the `OmniSharp.Roslyn.dll` library in the install directory. If it locates the file it will return a `0` to the console. If it does not it will return a `1`.
+
+### Examples
+In PowerShell the following will install the v1.32.1 HTTP version of the OmniSharp Roslyn server in `\.omnisharp\omnisharp-roslyn` in the %USERPROFILE% directory:
+>`./omnisharp-manager.ps1 -v 'v1.32.1' -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"`
+
+*Note:* You must run this from the directory that contains the script to run it. This will vary but is typically `\omnisharp-vim\installer` inside the directory where your vim plugins are located.
+
+
 ## PowerShell Restrictions
-PowerShell's default will disable scripts from being run. But on Windows the `omnisharp-manager.ps1` script needs to run to install the OmniSharp Roslyn server.
+By default PowerShell will prevent scripts being executed through what it terms its *Execution Policy*. But on Windows the `omnisharp-manager.ps1` script needs to execute to install the OmniSharp Roslyn server. In the __Install Omnisharp-Roslyn with PowerShell__ section below there are instructions for changing your PowerShell Execution Policy and getting the latest version of the server installed. Alternatively, if you change your Power Execution Policy to Unrestricted, using the first few steps below, you can open a .cs file in Vim and omnisharp-vim will offer to automatically do the installation for you.
 
-## Change PowerShell's Execution Policy
+### Install Omnisharp-Roslyn with PowerShell
 1. Locate PowerShell in the Windows Start Menu
-2. Right-click and choose `Run as administrator`
-3. Use `Get-ExecutionPolicy -List` in PowerShell to verify your current settings
-4. Use `Set-ExecutionPolicy Unrestricted` to allow script to install OmniSharp Roslyn server
-5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim (fn 1) with omnisharp-vim installed
-6. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3. (fn 2)
+1. Right-click and choose `Run as administrator`
+1. Use `Get-ExecutionPolicy -List` in PowerShell to verify and record your current settings
+1. Use `Set-ExecutionPolicy Unrestricted` to change your policy followed by `Y` to confirm
+1. Browse to the `\omnisharp-vim\installer` directory.
+	* It should be wherever your vim plugins are located
+1. Use `./omnisharp-manager.ps1 -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"` from that directory to install the server [fn 1]
+	* You can copy the command above and right-click will paste the clipboard into the PowerShell console
+1. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3. [fn 2]
 
-* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
+> On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` file is in the expected directory. If it finds the file it will return `0`. If it does not find the file it will return `1`.
+
 ---
-### Footnotes (fn #)
-1. Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
-2. By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.
+#### Footnotes [fn \#]
+[1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.
+
+[2]: By default this setting is `Undefined`; which means the restriction may be determined elsewhere but defaults to `Restricted`. Setting to `RemoteSigned` on a typical setup will allow omnisharp-vim to internally run the script in the future.  More at [About Execution Policies | Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-6)
+

--- a/installer/README.md
+++ b/installer/README.md
@@ -6,8 +6,11 @@ PowerShell's default will disable scripts from being run. But on Windows the `om
 2. Right-click and choose `Run as administrator`
 3. Use `Get-ExecutionPolicy -List` in PowerShell to verify your current settings
 4. Use `Set-ExecutionPolicy Unrestricted` to allow script to install OmniSharp Roslyn server
-5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim(fn 1) with omnisharp-vim installed
+5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim (fn 1) with omnisharp-vim installed
 6. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3. (fn 2)
-..* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
-(1): Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
-(2): By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.
+
+* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
+---
+### Footnotes (fn #)
+1. Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
+2. By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.

--- a/installer/README.md
+++ b/installer/README.md
@@ -14,7 +14,7 @@ Flags | Description
  -H | install the HTTP version of the server
 
 ### Output
-After downloading and installing the server the script will check for the `OmniSharp.Roslyn.dll` library in the install directory. If it locates the file it will return a `0` to the console. If it does not it will return a `1`.
+After downloading and installing the server the script will check for the `OmniSharp.Roslyn.dll` library in the install directory. If it locates the file an exit code of `0` will be returned. If it does not it will return a `1`. You can check exit codes in PowerShell by running `$LASTEXITCODE` in the console after running the script.
 
 ### Examples
 In PowerShell the following will install the v1.32.1 HTTP version of the OmniSharp Roslyn server in `\.omnisharp\omnisharp-roslyn` in the %USERPROFILE% directory:
@@ -24,7 +24,7 @@ In PowerShell the following will install the v1.32.1 HTTP version of the OmniSha
 
 
 ## PowerShell Restrictions
-By default PowerShell will prevent scripts being executed through what it terms its *Execution Policy*. But on Windows the `omnisharp-manager.ps1` script needs to execute to install the OmniSharp Roslyn server. In the __Install Omnisharp-Roslyn with PowerShell__ section below there are instructions for changing your PowerShell Execution Policy and getting the latest version of the server installed. Alternatively, if you change your Power Execution Policy to Unrestricted, using the first few steps below, you can open a .cs file in Vim and omnisharp-vim will offer to automatically do the installation for you.
+By default PowerShell will prevent scripts being executed through what it terms its *Execution Policy*. But on Windows the `omnisharp-manager.ps1` script needs to execute to install the OmniSharp Roslyn server. In the __Install Omnisharp-Roslyn with PowerShell__ section below there are instructions for changing your PowerShell Execution Policy and getting the latest version of the server installed. Alternatively, if you change your Power Execution Policy to Unrestricted using the first few steps below you can open a .cs file in Vim and omnisharp-vim will offer to do the installation for you.
 
 ### Install Omnisharp-Roslyn with PowerShell
 1. Locate PowerShell in the Windows Start Menu
@@ -35,13 +35,13 @@ By default PowerShell will prevent scripts being executed through what it terms 
 	* It should be wherever your vim plugins are located
 1. Use `./omnisharp-manager.ps1 -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"` from that directory to install the server [fn 1]
 	* You can copy the command above and right-click will paste the clipboard into the PowerShell console
-1. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3. [fn 2]
+1. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting recorded earlier. [fn 2]
 
-> On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` file is in the expected directory. If it finds the file it will return `0`. If it does not find the file it will return `1`.
+> On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` file is in the expected directory. If it finds the file it will return and exit code of `0`. If it does not find the file it will return `1`. You can check exit codes in PowerShell by running `$LASTEXITCODE` in the console after running the script.
 
 ---
+
 #### Footnotes [fn \#]
 [1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.
 
 [2]: By default this setting is `Undefined`; which means the restriction may be determined elsewhere but defaults to `Restricted`. Setting to `RemoteSigned` on a typical setup will allow omnisharp-vim to internally run the script in the future.  More at [About Execution Policies | Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-6)
-

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,13 +1,13 @@
-#PowerShell Restrictions
+## PowerShell Restrictions
 PowerShell's default will disable scripts from being run. But on Windows the `omnisharp-manager.ps1` script needs to run to install the OmniSharp Roslyn server.
 
-##Change PowerShell's Execution Policy
+## Change PowerShell's Execution Policy
 1. Locate PowerShell in the Windows Start Menu
 2. Right-click and choose `Run as administrator`
 3. Use `Get-ExecutionPolicy -List` in PowerShell to verify your current settings
 4. Use `Set-ExecutionPolicy Unrestricted` to allow script to install OmniSharp Roslyn server
-5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim[^1] with omnisharp-vim installed
-6. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3.[^2]
-* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
-[^1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
-[^2]: By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.
+5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim(fn 1) with omnisharp-vim installed
+6. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3. (fn 2)
+..* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
+(1): Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
+(2): By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,13 @@
+#PowerShell Restrictions
+PowerShell's default will disable scripts from being run. But on Windows the `omnisharp-manager.ps1` script needs to run to install the OmniSharp Roslyn server.
+
+##Change PowerShell's Execution Policy
+1. Locate PowerShell in the Windows Start Menu
+2. Right-click and choose `Run as administrator`
+3. Use `Get-ExecutionPolicy -List` in PowerShell to verify your current settings
+4. Use `Set-ExecutionPolicy Unrestricted` to allow script to install OmniSharp Roslyn server
+5. Run the `omnisharp-manager.ps1` script from the `omnisharp-vim\installer\` directory or you can simply open a .cs file in Vim[^1] with omnisharp-vim installed
+6. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting from step 3.[^2]
+* On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` files is in the expected directory. If it finds the file it will return a confirmation to that directory path. If it does not find the file it will return `Failure`.
+[^1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks `$HOME\.omnisharp\omnisharp-roslyn\`.
+[^2]: By default this setting is `Undefined`. The safest option is explicitly setting `Restricted` which will not allow PowerShell to run any scripts.

--- a/installer/omnisharp-manager.ps1
+++ b/installer/omnisharp-manager.ps1
@@ -11,7 +11,7 @@
 [CmdletBinding()]
 Param(
     [Parameter()][Alias('v')][string]$version,
-    [Parameter()][Alias('l')][string]$location = "$($env:USERPROFILE)\.omnisharp\omnisharp-roslyn\",
+    [Parameter()][Alias('l')][string]$location = "$($env:USERPROFILE)\.omnisharp\",
     [Parameter()][Alias('u')][switch]$usage,
     [Parameter()][Alias('H')][switch]$http_check
 )
@@ -50,7 +50,7 @@ $out = "$($location)\omnisharp$($http)-win-$($machine).zip"
 if (Test-Path -Path $location) {
     Remove-Item $location -Force -Recurse
 }
-New-Item -ItemType Directory -Force -Path $location
+New-Item -ItemType Directory -Force -Path $location | Out-Null
 
 #Run as SilentlyContinue to avoid progress bar that can't be seen
 $ProgressPreference = 'SilentlyContinue'
@@ -70,9 +70,11 @@ else
 #Check for file to confirm download and unzip were successful
 if(Test-Path -path "$($location)\OmniSharp.Roslyn.dll")
 {
-    Write-Output "OmniSharp Roslyn Server installed at '$($location)'"
+    Write-Output 0
+    exit 0
 }
 else
 {
-    Write-Output "Failure"
+    Write-Output 1
+    exit 1
 }

--- a/installer/omnisharp-manager.ps1
+++ b/installer/omnisharp-manager.ps1
@@ -70,11 +70,9 @@ else
 #Check for file to confirm download and unzip were successful
 if(Test-Path -path "$($location)\OmniSharp.Roslyn.dll")
 {
-    Write-Output 0
     exit 0
 }
 else
 {
-    Write-Output 1
     exit 1
 }


### PR DESCRIPTION
This addresses an issue where PowerShell was failing to install the OmniSharp Roslyn server but OmniSharp-vim was confirming the installation. It also addresses the slow install of the server on Windows by disabling the PowerShell UI updates during download.