### PR TITLE
Update package name required in Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ OmniSharp-Roslyn requires Mono on Linux and OSX. The roslyn server [releases](ht
 ```
 
 ##### libuv
-OmniSharp-Roslyn also requires [libuv](http://libuv.org/) on Linux and Mac. This is typically a simple install step, e.g. `brew install libuv` on Mac, `apt-get install libuv` on debian/Ubuntu, `pacman -S libuv` on arch linux, `dnf install libuv libuv-devel` on Fedora, etc.
+OmniSharp-Roslyn also requires [libuv](http://libuv.org/) on Linux and Mac. This is typically a simple install step, e.g. `brew install libuv` on Mac, `apt-get install libuv1-dev` on debian/Ubuntu, `pacman -S libuv` on arch linux, `dnf install libuv libuv-devel` on Fedora, etc.
 
 ### Install Python
 Install the latest version of python 3 ([Python 3.7](https://www.python.org/downloads/release/python-370/)) or 2 ([Python 2.7.15](https://www.python.org/downloads/release/python-2715/)).


### PR DESCRIPTION
👋 
  
After I followed the documentation to get started with OmniSharp, I faced an issue where the OmniSharp server installed by the vim plugin could not start.  
I tried to run it manually, and figured out that it could not run because of libuv package missing, even if I already installed it using `apt-get install libuv1'.    
  
A little search, and found this comment: https://github.com/OmniSharp/omnisharp-roslyn/issues/1144#issuecomment-379270906  
The libuv dev package is needed.   
  
And `apt-cache search libuv` command returns no `libuv` package, but the following:
```
libuv1 - asynchronous event notification library - runtime library
libuv1-dbg - asynchronous event notification library - debugging symbols
libuv1-dev - asynchronous event notification library - development files
```
So the current documentation is, I think, outdated 😃