### PR TITLE
Fix encoding of stdout for ALE linter

### DIFF
--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -27,9 +27,9 @@ function! ale_linters#cs#omnisharp#GetCommand(bufnum) abort
   let linter = OmniSharp#util#path_join(['python', 'ale_lint.py'])
   let host = OmniSharp#GetHost(a:bufnum)
   let cmd = printf(
-        \ '%%e %s --filename %%s --host %s --level %s --cwd %s --delimiter %s',
+        \ '%%e %s --filename %%s --host %s --level %s --cwd %s --delimiter %s --encoding %s',
         \ ale#Escape(linter), ale#Escape(host), ale#Escape(g:OmniSharp_loglevel),
-        \ ale#Escape(getcwd()), ale#Escape(s:delimiter))
+        \ ale#Escape(getcwd()), ale#Escape(s:delimiter), &encoding)
   if g:OmniSharp_translate_cygwin_wsl
     let cmd = cmd . ' --translate'
   endif

--- a/python/ale_lint.py
+++ b/python/ale_lint.py
@@ -76,7 +76,6 @@ def do_codecheck(logger, filename, host, cwd, translate, delimiter, encoding):
 
     keys = ['filename', 'lnum', 'col', 'type', 'subtype', 'text']
     for item in quickfixes:
-        # print(delimiter.join([str(item.get(k, '')) for k in keys]))
         s = delimiter.join([str(item.get(k, '')) for k in keys]) + '\n'
         sys.stdout.buffer.write(s.encode(encoding))
 

--- a/python/ale_lint.py
+++ b/python/ale_lint.py
@@ -50,16 +50,18 @@ def main():
                         choices=log_levels.keys(), default='info')
     parser.add_argument('--translate', action='store_true',
                         help="If provided, translate cygwin/wsl paths")
+    parser.add_argument('--encoding', required=True,
+                        help="Encoding for output")
     args = parser.parse_args()
     logger = _setup_logging(log_levels[args.level])
     try:
         do_codecheck(logger, args.filename.strip(), args.host, args.cwd,
-                     args.translate, args.delimiter)
+                     args.translate, args.delimiter, args.encoding)
     except Exception as e:
         logger.exception("Error doing codecheck")
 
 
-def do_codecheck(logger, filename, host, cwd, translate, delimiter):
+def do_codecheck(logger, filename, host, cwd, translate, delimiter, encoding):
     ctx = UtilCtx(
         buffer_name=filename,
         translate_cygwin_wsl=translate,
@@ -74,7 +76,9 @@ def do_codecheck(logger, filename, host, cwd, translate, delimiter):
 
     keys = ['filename', 'lnum', 'col', 'type', 'subtype', 'text']
     for item in quickfixes:
-        print(delimiter.join([str(item.get(k, '')) for k in keys]))
+        # print(delimiter.join([str(item.get(k, '')) for k in keys]))
+        s = delimiter.join([str(item.get(k, '')) for k in keys]) + '\n'
+        sys.stdout.buffer.write(s.encode(encoding))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The output of the ALE linter is currently generated via vanilla `print()`.  
However, its encoding should be considered since vim's `&encoding` and the encoding of stdout often do not match. (e.g. on Windows, if you use normal Python for Windows, output encoding is cp932, but utf-8 is common for vim's `&encoding` nowadays.)  
This mismatch leads garbling of ALE's linting messages.

This PR makes output of the ALE linter vim's `&encoding`.