### PR TITLE
Fix of #418 (Make python2 compatible)

### DIFF
--- a/python/ale_lint.py
+++ b/python/ale_lint.py
@@ -77,7 +77,10 @@ def do_codecheck(logger, filename, host, cwd, translate, delimiter, encoding):
     keys = ['filename', 'lnum', 'col', 'type', 'subtype', 'text']
     for item in quickfixes:
         s = delimiter.join([str(item.get(k, '')) for k in keys]) + '\n'
-        sys.stdout.buffer.write(s.encode(encoding))
+        if sys.version_info.major == 3:
+            sys.stdout.buffer.write(s.encode(encoding))
+        elif sys.version_info.major == 2:
+            sys.stdout.write(unicode(s).encode(encoding))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As mentioned in https://github.com/OmniSharp/omnisharp-vim/commit/96128451b72c1e4718701c620f6f0dac6544c9ab#commitcomment-30803911, #418 is not python2 compatible. I'm sorry for that.

This PR is fix for that. But I'm afraid that I could not test it well. Could you please test it whether it runs with python2 without any error?