### PR TITLE
Fix #412: Rename function fails on OSX

### DIFF
--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -172,9 +172,13 @@ def renameTo(name):
     }
     response = getResponse(ctx, '/rename', parameters, json=True)
     changes = response['Changes']
+    ret = []
     for change in changes:
-        change['FileName'] = formatPathForClient(ctx, change['FileName'])
-    return changes
+        ret.append({
+            'FileName': formatPathForClient(ctx, change['FileName']),
+            'Buffer': change['Buffer'],
+        })
+    return ret
 
 
 @vimcmd


### PR DESCRIPTION
Fix #412 

Tested and rename function still works, though I never experienced the crash so it would be great to get validation that it actually fixes the issue