### PR TITLE
Type highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ set previewheight=5
 " Tell ALE to use OmniSharp for linting C# files, and no other linters.
 let g:ale_linters = { 'cs': ['OmniSharp'] }
 
+" Fetch semantic type/interface/identifier names on BufEnter and highlight them
+let g:OmniSharp_highlight_types = 1
+
 augroup omnisharp_commands
     autocmd!
 
@@ -242,6 +245,8 @@ augroup omnisharp_commands
     autocmd FileType cs nnoremap <buffer> <C-\> :OmniSharpSignatureHelp<CR>
     autocmd FileType cs inoremap <buffer> <C-\> <C-o>:OmniSharpSignatureHelp<CR>
 
+    " Refresh syntax highlighting for types and interfaces for the current buffer
+    autocmd FileType cs nnoremap <buffer> <Leader>th :OmniSharpHighlightTypes<CR>
 
     " Navigate up and down by method/property/field
     autocmd FileType cs nnoremap <buffer> <C-k> :OmniSharpNavigateUp<CR>
@@ -264,9 +269,6 @@ nnoremap <Leader>cf :OmniSharpCodeFormat<CR>
 " Start the omnisharp server for the current solution
 nnoremap <Leader>ss :OmniSharpStartServer<CR>
 nnoremap <Leader>sp :OmniSharpStopServer<CR>
-
-" Add syntax highlighting for types and interfaces
-nnoremap <Leader>th :OmniSharpHighlightTypes<CR>
 
 " Enable snippet completion
 " let g:OmniSharp_want_snippet=1

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -450,15 +450,15 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   let b:interfaces = s:ReadHighlightKeywords(ret.bufferInterfaces)
 
   if exists('b:types')
-    silent call s:ClearHighlight('csUserType')
-    silent call s:ClearHighlight('csUserInterface')
+    silent call s:ClearHighlight('csOSType')
+    silent call s:ClearHighlight('csOSInterface')
   endif
 
   if !empty(b:types)
-    exec 'syntax keyword csUserType ' . join(b:types)
+    execute 'syntax keyword csOSType' join(b:types)
   endif
   if !empty(b:interfaces)
-    exec 'syntax keyword csUserInterface ' . join(b:interfaces)
+    execute 'syntax keyword csOSInterface' join(b:interfaces)
   endif
 
   " TODO: Remove this line once csUserType is contained in the standard vim
@@ -467,7 +467,7 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   syntax region csNewType
   \ start="@\@1<!\<new\>"hs=s+4
   \ end="[;\n{(<\[]"me=e-1
-  \ contains=csNew,csUserType
+  \ contains=csNew,csOSType
 endfunction
 
 " Wrap this functionality in a function so it can be called with :silent

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -448,10 +448,14 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
 
   let b:types = s:ReadHighlightKeywords(ret.bufferTypes)
   let b:interfaces = s:ReadHighlightKeywords(ret.bufferInterfaces)
+  let b:identifiers = s:ReadHighlightKeywords(ret.bufferIdentifiers)
+
+  echom string(b:identifiers)
 
   if exists('b:types')
     silent call s:ClearHighlight('csUserType')
     silent call s:ClearHighlight('csUserInterface')
+    silent call s:ClearHighlight('csUserIdentifier')
   endif
 
   if !empty(b:types)
@@ -459,6 +463,9 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   endif
   if !empty(b:interfaces)
     execute 'syntax keyword csUserInterface' join(b:interfaces)
+  endif
+  if !empty(b:identifiers)
+    execute 'syntax keyword csUserIdentifier' join(b:identifiers)
   endif
 
   " TODO: Remove this line once csUserType is contained in the standard vim
@@ -479,6 +486,7 @@ function! s:ClearHighlight(groupname)
 endfunction
 
 function! s:ReadHighlightKeywords(spans) abort
+  echom len(a:spans)
   let l:types = []
   for span in a:spans
     let line = getline(span['line'])

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -450,15 +450,15 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   let b:interfaces = s:ReadHighlightKeywords(ret.bufferInterfaces)
 
   if exists('b:types')
-    silent call s:ClearHighlight('csOSType')
-    silent call s:ClearHighlight('csOSInterface')
+    silent call s:ClearHighlight('csUserType')
+    silent call s:ClearHighlight('csUserInterface')
   endif
 
   if !empty(b:types)
-    execute 'syntax keyword csOSType' join(b:types)
+    execute 'syntax keyword csUserType' join(b:types)
   endif
   if !empty(b:interfaces)
-    execute 'syntax keyword csOSInterface' join(b:interfaces)
+    execute 'syntax keyword csUserInterface' join(b:interfaces)
   endif
 
   " TODO: Remove this line once csUserType is contained in the standard vim
@@ -467,7 +467,7 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   syntax region csNewType
   \ start="@\@1<!\<new\>"hs=s+4
   \ end="[;\n{(<\[]"me=e-1
-  \ contains=csNew,csOSType
+  \ contains=csNew,csUserType
 endfunction
 
 " Wrap this functionality in a function so it can be called with :silent

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -449,8 +449,9 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   let b:types = s:ReadHighlightKeywords(ret.bufferTypes)
   let b:interfaces = s:ReadHighlightKeywords(ret.bufferInterfaces)
 
-  if exists('b:allTypes')
-    silent call s:ClearHighlightKeywords()
+  if exists('b:types')
+    silent call s:ClearHighlight('csUserType')
+    silent call s:ClearHighlight('csUserInterface')
   endif
 
   if !empty(b:types)
@@ -462,6 +463,7 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
 
   " TODO: Remove this line once csUserType is contained in the standard vim
   " runtime files
+  silent call s:ClearHighlight('csNewType')
   syntax region csNewType
   \ start="@\@1<!\<new\>"hs=s+4
   \ end="[;\n{(<\[]"me=e-1
@@ -469,12 +471,11 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
 endfunction
 
 " Wrap this functionality in a function so it can be called with :silent
-function! s:ClearHighlightKeywords() abort
-  syntax clear csUserType
-  syntax clear csUserInterface
-  " TODO: Remove this line once csUserType is contained in the standard vim
-  " runtime files
-  syntax clear csNewType
+function! s:ClearHighlight(groupname)
+  try
+    execute 'syntax clear' a:groupname
+  catch
+  endtry
 endfunction
 
 function! s:ReadHighlightKeywords(spans) abort
@@ -491,7 +492,7 @@ function! OmniSharp#EnableTypeHighlighting() abort
 
   augroup OmniSharp#HighlightTypes
     autocmd!
-    autocmd BufRead *.cs call OmniSharp#EnableTypeHighlightingForBuffer(0)
+    autocmd BufEnter *.cs call OmniSharp#EnableTypeHighlightingForBuffer(0)
   augroup END
 endfunction
 

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -450,8 +450,6 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
   let b:interfaces = s:ReadHighlightKeywords(ret.bufferInterfaces)
   let b:identifiers = s:ReadHighlightKeywords(ret.bufferIdentifiers)
 
-  echom string(b:identifiers)
-
   if exists('b:types')
     silent call s:ClearHighlight('csUserType')
     silent call s:ClearHighlight('csUserInterface')
@@ -468,13 +466,13 @@ function! OmniSharp#EnableTypeHighlightingForBuffer(refresh) abort
     execute 'syntax keyword csUserIdentifier' join(b:identifiers)
   endif
 
-  " TODO: Remove this line once csUserType is contained in the standard vim
-  " runtime files
+  " TODO: Remove this line once csUserType and csUserIdentifier is contained in
+  " the standard vim runtime files
   silent call s:ClearHighlight('csNewType')
   syntax region csNewType
   \ start="@\@1<!\<new\>"hs=s+4
   \ end="[;\n{(<\[]"me=e-1
-  \ contains=csNew,csUserType
+  \ contains=csNew,csUserType,csUserIdentifier
 endfunction
 
 " Wrap this functionality in a function so it can be called with :silent
@@ -486,7 +484,6 @@ function! s:ClearHighlight(groupname)
 endfunction
 
 function! s:ReadHighlightKeywords(spans) abort
-  echom len(a:spans)
   let l:types = []
   for span in a:spans
     let line = getline(span['line'])

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -457,7 +457,7 @@ function! OmniSharp#HighlightBuffer() abort
       let line = getline(span['line'])
       call add(l:types, line[span['start']-1 : span['end']-2])
     endfor
-    return sort(uniq(l:types))
+    return uniq(sort(l:types))
   endfunction
 
   let b:OmniSharp_types = s:ReadHighlightKeywords(ret.bufferTypes)

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -68,12 +68,29 @@ Default: '/home/username/.omnisharp/omnisharp-roslyn/run'
     let g:OmniSharp_server_path = '/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
 <
 
+                                                   *'g:OmniSharp_server_ports'*
+Mapping of solution files and/or directories to ports. When auto-starting the
+OmniSharp server, it will bind to the port listed here if the solution file or
+directory matches. If there is no match, the port will be chosen at random.
+Default: {} >
+    let g:OmniSharp_server_ports = {
+      \ 'C:\path\to\myproject.sln': 2003,
+      \ 'C:\path\to\other\project': 2004,
+      \ }
+<
+
                                                 *'g:OmniSharp_server_use_mono'*
 The roslyn server must be run with mono on Linux and OSX. The roslyn server
 binaries usually come with an embedded mono, but this can be overridden to use
 the installed mono with this option. Note that mono must be in the $PATH.
 Default: 0 >
     let g:OmniSharp_server_use_mono = 1
+<
+
+                                                *'g:OmniSharp_highlight_types'*
+Enable semantic type/interface/identifier highlighting on BufEnter.
+Default: 0 >
+    let g:OmniSharp_highlight_types = 1
 <
 
                                                            *'g:OmniSharp_host'*
@@ -99,15 +116,20 @@ Default: 1 >
     let g:OmniSharp_open_quickfix = 0
 <
 
-                                                      *'g:OmniSharp_server_ports'*
-Mapping of solution files and/or directories to ports. When auto-starting the OmniSharp server, it
-will bind to the port listed here if the solution file or directory matches. If there is no
-match, the port will be chosen at random.
-Default: {} >
-    let g:OmniSharp_server_ports = {
-      \ 'C:\path\to\myproject.sln': 2003,
-      \ 'C:\path\to\other\project': 2004,
-      \ }
+                                                    *'g:OmniSharp_selector_ui'*
+Use this option to specify a selector UI for choosing code actions and
+navigating to symbols. When no selector UI plugin is detected, or
+g:OmniSharp_selector_ui is set to '', then the vim command-line and quickfix
+window will be used instead.
+Default: Whichever of unite.vim, ctrlp.vim or fzf.vim is installed, or '' if
+none are. >
+    let g:OmniSharp_selector_ui = 'unite'
+    OR
+    let g:OmniSharp_selector_ui = 'ctrlp'
+    OR
+    let g:OmniSharp_selector_ui = 'fzf'
+    OR
+    let g:OmniSharp_selector_ui = ''
 <
 
                                                         *'g:OmniSharp_timeout'*
@@ -148,22 +170,6 @@ the |:OmniSharpDocumentation| command. Default: 0 >
                                                     *'g:syntastic_cs_checkers'*
 Use this option to enable syntastic integration >
     let g:syntastic_cs_checkers = ['code_checker']
-<
-
-                                                    *'g:OmniSharp_selector_ui'*
-Use this option to specify a selector UI for choosing code actions and
-navigating to symbols. When no selector UI plugin is detected, or
-g:OmniSharp_selector_ui is set to '', then the vim command-line and quickfix
-window will be used instead.
-Default: Whichever of unite.vim, ctrlp.vim or fzf.vim is installed, or '' if
-none are. >
-    let g:OmniSharp_selector_ui = 'unite'
-    OR
-    let g:OmniSharp_selector_ui = 'ctrlp'
-    OR
-    let g:OmniSharp_selector_ui = 'fzf'
-    OR
-    let g:OmniSharp_selector_ui = ''
 <
 
 ===============================================================================
@@ -271,7 +277,8 @@ none are. >
 
                                                      *:OmniSharpHighlightTypes*
 :OmniSharpHighlightTypes
-    Enable advanced type highlighting for current file
+    Highlight/refresh semantic type/interface/identifier highlighting for the
+    current file
 
                                                             *:OmniSharpInstall*
 :OmniSharpInstall

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -62,10 +62,10 @@ command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniShar
 command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
 
-highlight default link csUserType Type
+highlight default link csOSType Type
 " TODO: interfaces should probably also link to Type - but keep them distinct
 " for testing purposes
-highlight default link csUserInterface Include
+highlight default link csOSInterface Include
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= ' | '

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -62,10 +62,10 @@ command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniShar
 command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
 
-highlight default link csOSType Type
+highlight default link csUserType Type
 " TODO: interfaces should probably also link to Type - but keep them distinct
 " for testing purposes
-highlight default link csOSInterface Include
+highlight default link csUserInterface Include
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= ' | '

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -15,7 +15,7 @@ if !exists('g:omnicomplete_fetch_full_documentation')
   let g:omnicomplete_fetch_full_documentation = 0
 endif
 
-augroup plugin-OmniSharp
+augroup OmniSharp#FileType
   autocmd! * <buffer>
 
   autocmd BufLeave <buffer>
@@ -45,7 +45,7 @@ command! -buffer -bar OmniSharpFixUsings                           call OmniShar
 command! -buffer -bar OmniSharpGetCodeActions                      call OmniSharp#GetCodeActions('normal')
 command! -buffer -bar OmniSharpGotoDefinition                      call OmniSharp#GotoDefinition()
 command! -buffer -bar OmniSharpPreviewDefinition                   call OmniSharp#PreviewDefinition()
-command! -buffer -bar OmniSharpHighlightTypes                      call OmniSharp#EnableTypeHighlighting()
+command! -buffer -bar OmniSharpHighlightTypes                      call OmniSharp#HighlightBuffer()
 command! -buffer -bar OmniSharpNavigateUp                          call OmniSharp#NavigateUp()
 command! -buffer -bar OmniSharpNavigateDown                        call OmniSharp#NavigateDown()
 command! -buffer -bar OmniSharpOpenPythonLog                       call OmniSharp#OpenPythonLog()
@@ -63,8 +63,6 @@ command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
 
 highlight default link csUserType Type
-" TODO: interfaces should probably also link to Type - but keep them distinct
-" for testing purposes
 highlight default link csUserInterface Include
 highlight default link csUserIdentifier Identifier
 
@@ -74,7 +72,7 @@ else
   let b:undo_ftplugin = ''
 endif
 let b:undo_ftplugin .= '
-\ execute "autocmd! plugin-OmniSharp * <buffer>"
+\ execute "autocmd! OmniSharp#FileType * <buffer>"
 \
 \|  unlet b:OmniSharp_ftplugin_loaded
 \|  delcommand OmniSharpCodeFormat

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -62,6 +62,11 @@ command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniShar
 command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
 
+highlight default link csUserType Type
+" TODO: interfaces should probably also link to Type - but keep them distinct
+" for testing purposes
+highlight default link csUserInterface Include
+
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= ' | '
 else

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -66,6 +66,7 @@ highlight default link csUserType Type
 " TODO: interfaces should probably also link to Type - but keep them distinct
 " for testing purposes
 highlight default link csUserInterface Include
+highlight default link csUserIdentifier Identifier
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= ' | '

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -44,6 +44,15 @@ let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', 'warning')
 " Default map of solution files and directories to ports
 let g:OmniSharp_server_ports = get(g:, 'OmniSharp_server_ports', {})
 
+" Initialise automatic type and interface highlighting
+let g:OmniSharp_highlight_types = get(g:, 'OmniSharp_highlight_types', 0)
+if g:OmniSharp_highlight_types
+  augroup OmniSharp#HighlightTypes
+    autocmd!
+    autocmd BufEnter *.cs call OmniSharp#HighlightBuffer()
+  augroup END
+endif
+
 " Initialize OmniSharp as an asyncomplete source
 autocmd User asyncomplete_setup call asyncomplete#register_source({
 \   'name': 'OmniSharp',

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -218,9 +218,9 @@ def findHighlightTypes():
                 'start': hi['StartColumn'],
                 'end': hi['EndColumn']
             }
-            if 'class ' in hi['Kind'] or 'enum ' in hi['Kind']:
+            if 'class ' in hi['Kind'] or 'enum ' in hi['Kind'] or 'struct ' in hi['Kind']:
                 bufTypes.append(span)
-            else:
+            elif 'interface ' in hi['Kind']:
                 bufInterfaces.append(span)
     return {
         'bufferTypes': bufTypes,

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -210,21 +210,24 @@ def findHighlightTypes():
     highlights = response.get('Highlights', [])
     bufTypes = []
     bufInterfaces = []
+    bufIdentifiers = []
     for hi in highlights:
+        span = {
+            'line': hi['StartLine'],
+            'start': hi['StartColumn'],
+            'end': hi['EndColumn']
+        }
         # 'class name', 'enum name', 'interface name'
-        if ' name' in hi['Kind']:
-            span = {
-                'line': hi['StartLine'],
-                'start': hi['StartColumn'],
-                'end': hi['EndColumn']
-            }
-            if 'class ' in hi['Kind'] or 'enum ' in hi['Kind'] or 'struct ' in hi['Kind']:
-                bufTypes.append(span)
-            elif 'interface ' in hi['Kind']:
-                bufInterfaces.append(span)
+        if hi['Kind'] in ['class name', 'enum name', 'struct name']:
+            bufTypes.append(span)
+        elif hi['Kind'] == 'interface name':
+            bufInterfaces.append(span)
+        elif hi['Kind'] == 'identifier':
+            bufIdentifiers.append(span)
     return {
         'bufferTypes': bufTypes,
-        'bufferInterfaces': bufInterfaces
+        'bufferInterfaces': bufInterfaces,
+        'bufferIdentifiers': bufIdentifiers
     }
 
 

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -205,23 +205,26 @@ def findSymbols(filter=''):
 
 
 @vimcmd
-def lookupAllUserTypes():
-    response = getResponse(ctx, '/findsymbols', {'filter': ''}, json=True)
-    qf = response.get('QuickFixes', [])
-    slnTypes = []
-    slnInterfaces = []
-    slnAttributes = []
-    for symbol in qf:
-        if symbol['Kind'] == 'Class':
-            slnTypes.append(symbol['Text'])
-            if symbol['Text'].endswith('Attribute'):
-                slnAttributes.append(symbol['Text'][:-9])
-        elif symbol['Kind'] == 'Interface':
-            slnInterfaces.append(symbol['Text'])
+def findHighlightTypes():
+    response = getResponse(ctx, '/highlight', json=True)
+    highlights = response.get('Highlights', [])
+    bufTypes = []
+    bufInterfaces = []
+    for hi in highlights:
+        # 'class name', 'enum name', 'interface name'
+        if ' name' in hi['Kind']:
+            span = {
+                'line': hi['StartLine'],
+                'start': hi['StartColumn'],
+                'end': hi['EndColumn']
+            }
+            if 'class ' in hi['Kind'] or 'enum ' in hi['Kind']:
+                bufTypes.append(span)
+            else:
+                bufInterfaces.append(span)
     return {
-        'userTypes': ' '.join(slnTypes),
-        'userInterfaces': ' '.join(slnInterfaces),
-        'userAttributes': ' '.join(slnAttributes),
+        'bufferTypes': bufTypes,
+        'bufferInterfaces': bufInterfaces
     }
 
 


### PR DESCRIPTION
The previous highlighting functionality was very limited - all classes and interfaces declared in the solution were added as solution-wide keywords.

Instead, use the roslyn-provided syntax highlighting. This entails parsing the highlighting information provided by OmniSharp-roslyn (a json file containing line/column groupings describing syntax fragments), extracting the interesting parts (class and interfaces), then reading the relevant spans from the buffer into an array of type name strings.

The result is much more comprehensive highlighting coverage, but at an efficiency cost.