### PR TITLE
Display an implementation in the preview window

### DIFF
--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -184,6 +184,16 @@ Use this option to enable syntastic integration >
     Fills quicklist with implementations of interface/class under the cursor
     NOTE: Navigates to implementation if only one is found
 
+                                                  *:OmniSharpPreviewDefinition*
+:OmniSharpPreviewDefinition
+    Displays the definition of the symbol under the cursor in the preview window
+
+                                             *:OmniSharpPreviewImplementations*
+:OmniSharpPreviewImplementations
+    Displays the implementation of the interface/class under the cursor in the
+    preview window. If more than one implementation exists, the number of
+    implementations is echoed.
+
                                                          *:OmniSharpFindSymbol*
 :OmniSharpFindSymbol
     Fuzzy-search through symbols

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -45,6 +45,7 @@ command! -buffer -bar OmniSharpFixUsings                           call OmniShar
 command! -buffer -bar OmniSharpGetCodeActions                      call OmniSharp#GetCodeActions('normal')
 command! -buffer -bar OmniSharpGotoDefinition                      call OmniSharp#GotoDefinition()
 command! -buffer -bar OmniSharpPreviewDefinition                   call OmniSharp#PreviewDefinition()
+command! -buffer -bar OmniSharpPreviewImplementation               call OmniSharp#PreviewImplementation()
 command! -buffer -bar OmniSharpHighlightTypes                      call OmniSharp#HighlightBuffer()
 command! -buffer -bar OmniSharpNavigateUp                          call OmniSharp#NavigateUp()
 command! -buffer -bar OmniSharpNavigateDown                        call OmniSharp#NavigateDown()

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -96,10 +96,12 @@ def getCompletions(partialWord):
 def gotoDefinition():
     definition = getResponse(ctx, '/gotodefinition', json=True)
     if definition.get('FileName'):
-        filename = formatPathForClient(ctx, definition['FileName'].replace("'", "''"))
-        openFile(filename, definition['Line'], definition['Column'])
+        return quickfixes_from_response(ctx, [definition])[0]
+        # filename = formatPathForClient(ctx, definition['FileName'].replace("'", "''"))
+        # openFile(filename, definition['Line'], definition['Column'])
     else:
-        print("Not found")
+        return None
+        # print("Not found")
 
 
 @vimcmd


### PR DESCRIPTION
A function for displaying the definition of the symbol under the cursor in the preview window already exists. This PR adds a function for displaying the implementation of the symbol under the cursor in the preview window. When more than one implementation exist, the first is displayed, and the number of implementations is echoed.