### PR TITLE
Display error messages when installing OmniSharp-Roslyn on Unix-like OSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install the vim plugin using your preferred plugin manager:
 | [Pathogen](https://github.com/tpope/vim-pathogen)    | `git clone git://github.com/OmniSharp/omnisharp-vim.git ~/.vim/bundle/omnisharp-vim` |
 
 ### Server
-OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. The first time OmniSharp-vim tries to open a C# file, it will check for the presence of the server, and if not found it will ask if it should be downloaded. Answer 'y' and the latest version will be downloaded and extracted to `~/.omnisharp/omnisharp-roslyn`, ready to use. *Note:* Requires curl on Linux, macOS, Cygwin and WSL.
+OmniSharp-vim depends on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server. The first time OmniSharp-vim tries to open a C# file, it will check for the presence of the server, and if not found it will ask if it should be downloaded. Answer 'y' and the latest version will be downloaded and extracted to `~/.omnisharp/omnisharp-roslyn`, ready to use. *Note:* Requires [`curl`](https://curl.haxx.se/) or [`wget`](https://www.gnu.org/software/wget/) on Linux, macOS, Cygwin and WSL.
 
 **NOTE:** The latest versions of the HTTP OmniSharp-Roslyn server are not accepting HTTP connections on Linux/Mac systems - see [OmniSharp-Roslyn#1274](https://github.com/OmniSharp/omnisharp-roslyn/issues/1274). Until this is resolved, OmniSharp-vim installs the latest working version of OmniSharp-Roslyn, `1.32.1`. To override this behaviour and install a particular release, use the `:OmniSharpInstall` command like this:
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -285,7 +285,7 @@ Use this option to enable syntastic integration >
     Download the latest OmniSharp-roslyn binaries and extract them into
     ~/.omnisharp/omnisharp-roslyn. This can be used to install OmniSharp-roslyn
     initially, and to upgrade to the latest version at any time.
-    Requires "curl" to be installed for Linux, macOS, Cygwin and WSL.
+    Requires "curl" or "wget" to be installed for Linux, macOS, Cygwin and WSL.
 
 ===============================================================================
 5. INTEGRATIONS                                        *omnisharp-integrations*

--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -1,24 +1,33 @@
 #!/bin/sh
-# OmniSharp-roslyn Management tool
+# OmniSharp-Roslyn Installer
 #
 # Works on: Linux, macOS & Cygwin/WSL
 
 usage() {
-    printf "usage: %s [-HMu] [-v version] [-l location]\\n" "$0"
+    printf "usage: %s [-HMuh] [-v version] [-l location]\\n" "$0"
 }
 
-# From: https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
+print_help() {
+    cat << EOF
+$(usage)
+
+Options:
+    -v <version>  | Version to install (if omitted, fetch latest)
+    -l <location> | Directory to install the server to (upon install, this directory will be cleared)
+    -u            | Usage info
+    -h            | Help message
+    -H            | Install the HTTP version of the server
+    -M            | Use the system Mono rather than the bundled Mono
+EOF
+}
+
 get_latest_version() {
-    curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest" |
-    grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    if [ "$(command -v curl)" ]; then
+        curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest"
+    elif [ "$(command -v wget)" ]; then
+        wget -qO- "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest"
+    fi | grep '"tag_name":' | sed 's/.*"\([^"]\+\)".*/\1/'
 }
-
-# Options:
-# -v | version to use (otherwise use latest)
-# -l | where to install the server
-# -u | help / usage info
-# -H | install the HTTP version of the server
-# -M | type of server: mono or regular
 
 location="$HOME/.omnisharp/"
 
@@ -26,7 +35,7 @@ location="$HOME/.omnisharp/"
 # https://github.com/OmniSharp/omnisharp-roslyn/issues/1274
 version='v1.32.1'
 
-while getopts v:l:HMu o "$@"
+while getopts v:l:HMuh o "$@"
 do
     case "$o" in
         v)      version="$OPTARG";;
@@ -34,40 +43,84 @@ do
         H)      http=".http";;
         M)      mono=1;;
         u)      usage && exit 0;;
+        h)      print_help && exit 0;;
         [?])    usage && exit 1;;
     esac
 done
 
-ext="tar.gz"
+# Ensure that either 'curl' or 'wget' is installed
+if [ ! "$(command -v curl)" ] && [ ! "$(command -v wget)" ]; then
+    echo "Error: the installer requires either 'curl' or 'wget'"
+    exit 1
+fi
 
+# Check that either 'tar' or 'unzip' is installed
+# (and set the file extension appropriately)
+if [ "$(command -v tar)" ] && [ "$(command -v gzip)" ]; then
+    ext="tar.gz"
+elif [ "$(command -v unzip)" ]; then
+    ext="zip"
+else
+    echo "Error: the installer requires either 'tar' or 'unzip'"
+    exit 1
+fi
+
+# Check the machine architecture
 case "$(uname -m)" in
     "x86_64")   machine="x64";;
     "i368")     machine="x86";;
-    *)          exit 1;;
+    *)
+        echo "Error: OmniSharp-Roslyn only works on x86 CPU architecture"
+        exit 1
+        ;;
 esac
+
+# Check the operating system
 case "$(uname -s)" in
     "Linux")    os="linux-${machine}";;
     "Darwin")   os="osx";;
     *)
         if [ "$(uname -o)" = "Cygwin" ]; then
             os="win-${machine}"
-            ext="zip"
+
+            if [ "$(command -v unzip)" ]; then
+                ext="zip"
+            else
+                echo "Error: the installer requires 'unzip' to work on Cygwin"
+                exit 1
+            fi
         else
             printf "Error: unknown system: %s\\n" "$(uname -s)"
             exit 1
         fi
         ;;
 esac
-[ ! -z "$mono" ] && os="mono"
+
+[ -n "$mono" ] && os="mono"
+
 file_name="omnisharp${http}-${os}.${ext}"
+
 [ -z "$version" ] && version="$(get_latest_version)"
+
 base_url="https://github.com/OmniSharp/omnisharp-roslyn/releases/download"
 full_url="${base_url}/${version}/${file_name}"
-echo "$full_url"
+# echo "$full_url"
 
 rm -r "$location"
 mkdir -p "$location"
-curl -L "$full_url" -o "$location/$file_name"
+
+if [ "$(command -v curl)" ]; then
+    curl -L "$full_url" -o "$location/$file_name"
+elif [ "$(command -v wget)" ]; then
+    wget -P "$location" "$full_url"
+fi
+
+# Check if the server was successfully downloaded
+if [ $? -gt 0 ] || [ ! -f "$location/$file_name" ]; then
+    echo "Error: failed to download the server, possibly a network issue"
+    exit 1
+fi
+
 if [ "$ext" = "zip" ]; then
     unzip "$location/$file_name" -d "$location/"
     chmod +x $(find "$location" -type f)
@@ -75,4 +128,9 @@ else
     tar -zxvf "$location/$file_name" -C "$location/"
 fi
 
-[ "$mono" -eq 1 ] && chmod +x $(find "$location" -type f)
+# If using the system Mono, make the files executable
+if [ -n "$mono" ] && [ $mono -eq 1 ]; then
+    chmod +x $(find "$location" -type f)
+fi
+
+exit 0


### PR DESCRIPTION
Various enhancements to the installer for Unix-like OSs, includes:
- Check for any errors during the installation process and display the
  error messages in Vim.
- Add help message, to the script.
- Use either `curl` or `wget` depending on which is available.
- Use `tar` (& `gzip`) or `unzip` depending on which is installed.