### PR TITLE
Remove cwindow height parameter

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -927,7 +927,7 @@ function! s:set_quickfix(list, title)
     call setqflist(a:list)
   endif
   if g:OmniSharp_open_quickfix
-    botright cwindow 4
+    botright cwindow
   endif
 endfunction
 


### PR DESCRIPTION
Maybe cwindow default height is better.
cwindow 4 is too short.