### PR TITLE
Highlight syn options

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -600,7 +600,7 @@ function! OmniSharp#StartServerIfNotRunning(...) abort
 endfunction
 
 function! OmniSharp#FugitiveCheck() abort
-  return &buftype ==# 'nofile' || match(expand('%:p'), 'fugitive:///' ) == 0
+  return &buftype ==# 'nofile' || match(expand('%:p'), '\vfugitive:(///|\\\\)' ) == 0
 endfunction
 
 function! OmniSharp#StartServer(...) abort

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -476,6 +476,11 @@ function! OmniSharp#HighlightBuffer() abort
   let ret = OmniSharp#py#eval('findHighlightTypes()')
   if OmniSharp#CheckPyError() | return | endif
 
+  if has_key(ret, 'error')
+    echohl WarningMsg | echom ret.error | echohl None
+    return
+  endif
+
   function! s:ClearHighlight(groupname)
     try
       execute 'syntax clear' a:groupname

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -521,10 +521,10 @@ function! OmniSharp#HighlightBuffer() abort
   endfor
   let b:OmniSharp_hl_matches = []
 
-  call s:Highlight(ret.bufferIdentifiers, 'csUserIdentifier')
-  call s:Highlight(ret.bufferInterfaces, 'csUserInterface')
-  call s:Highlight(ret.bufferMethods, 'csUserMethod')
-  call s:Highlight(ret.bufferTypes, 'csUserType')
+  call s:Highlight(ret.identifiers, 'csUserIdentifier')
+  call s:Highlight(ret.interfaces, 'csUserInterface')
+  call s:Highlight(ret.methods, 'csUserMethod')
+  call s:Highlight(ret.types, 'csUserType')
 
   silent call s:ClearHighlight('csNewType')
   syntax region csNewType start="@\@1<!\<new\>"hs=s+4 end="[;\n{(<\[]"me=e-1

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -483,7 +483,7 @@ function! OmniSharp#HighlightBuffer() abort
 
   let b:OmniSharp_highlight_matches = get(b:, 'OmniSharp_highlight_matches', [])
 
-  function! s:Highlight(spans, name, group) abort
+  function! s:Highlight(spans, group) abort
     silent call s:ClearHighlight(a:group)
     let l:types = []
     for span in a:spans
@@ -521,9 +521,10 @@ function! OmniSharp#HighlightBuffer() abort
   endfor
   let b:OmniSharp_highlight_matches = []
 
-  call s:Highlight(ret.bufferTypes, 'types', 'csUserType')
-  call s:Highlight(ret.bufferInterfaces, 'interfaces', 'csUserInterface')
-  call s:Highlight(ret.bufferIdentifiers, 'identifiers', 'csUserIdentifier')
+  call s:Highlight(ret.bufferIdentifiers, 'csUserIdentifier')
+  call s:Highlight(ret.bufferInterfaces, 'csUserInterface')
+  call s:Highlight(ret.bufferMethods, 'csUserMethod')
+  call s:Highlight(ret.bufferTypes, 'csUserType')
 
   silent call s:ClearHighlight('csNewType')
   syntax region csNewType start="@\@1<!\<new\>"hs=s+4 end="[;\n{(<\[]"me=e-1

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -63,9 +63,10 @@ command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniShar
 command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
 
-highlight default link csUserType Type
-highlight default link csUserInterface Include
 highlight default link csUserIdentifier Identifier
+highlight default link csUserInterface Include
+highlight default link csUserMethod Function
+highlight default link csUserType Type
 
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= ' | '

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -226,7 +226,7 @@ def findHighlightTypes():
         if lnum >= len(bufferLines):
             # An error has occurred with invalid line endings - perhaps a
             # combination of unix and dos line endings?
-            return { 'error': 'Invalid buffer - check line endings' }
+            return {'error': 'Invalid buffer - check line endings'}
         line = bufferLines[lnum]
         types.append({
             'kind': hi['Kind'],

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -208,6 +208,8 @@ def findSymbols(filter=''):
 
 @vimcmd
 def findHighlightTypes():
+    # Original buffer lines
+    lines = ctx.buffer.split('\r\n')
     response = getResponse(ctx, '/highlight', json=True)
     highlights = response.get('Highlights', [])
     bufIdentifiers = []
@@ -220,16 +222,17 @@ def findHighlightTypes():
             'start': hi['StartColumn'],
             'end': hi['EndColumn']
         }
+        keyword = lines[span['line']-1][span['start']-1:span['end']-1]
         if hi['Kind'] in ['class name', 'enum name', 'namespace name',
                           'static symbol', 'struct name']:
-            bufTypes.append(span)
+            bufTypes.append(keyword)
         elif hi['Kind'] in ['interface name']:
-            bufInterfaces.append(span)
+            bufInterfaces.append(keyword)
         elif hi['Kind'] in ['field name', 'local name', 'property name',
                             'identifier', 'parameter name']:
-            bufIdentifiers.append(span)
+            bufIdentifiers.append(keyword)
         elif hi['Kind'] in ['method name']:
-            bufMethods.append(span)
+            bufMethods.append(keyword)
     return {
         'bufferIdentifiers': bufIdentifiers,
         'bufferInterfaces': bufInterfaces,

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -222,7 +222,12 @@ def findHighlightTypes():
 
     types = []
     for hi in highlights:
-        line = bufferLines[hi['StartLine'] - 1]
+        lnum = hi['StartLine'] - 1
+        if lnum >= len(bufferLines):
+            # An error has occurred with invalid line endings - perhaps a
+            # combination of unix and dos line endings?
+            return { 'error': 'Invalid buffer - check line endings' }
+        line = bufferLines[lnum]
         types.append({
             'kind': hi['Kind'],
             'name': line[hi['StartColumn'] - 1:hi['EndColumn'] - 1]

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -209,36 +209,30 @@ def findSymbols(filter=''):
 @vimcmd
 def findHighlightTypes():
     # Original buffer lines
-    lines = ctx.buffer.split('\r\n')
+    bufferLines = ctx.buffer.split('\r\n')
     response = getResponse(ctx, '/highlight', json=True)
     highlights = response.get('Highlights', [])
-    bufIdentifiers = []
-    bufInterfaces = []
-    bufMethods = []
-    bufTypes = []
+
+    identifierKinds = ['constant name', 'enum member name', 'field name',
+                       'identifier', 'local name', 'parameter name',
+                       'property name', 'static symbol']
+    interfaceKinds = ['interface name']
+    methodKinds = ['extension method name', 'method name']
+    typeKinds = ['class name', 'enum name', 'namespace name', 'struct name']
+
+    types = []
     for hi in highlights:
-        span = {
-            'line': hi['StartLine'],
-            'start': hi['StartColumn'],
-            'end': hi['EndColumn']
-        }
-        keyword = lines[span['line']-1][span['start']-1:span['end']-1]
-        if hi['Kind'] in ['class name', 'constant name', 'enum name',
-                          'enum member name', 'namespace name', 'static symbol',
-                          'struct name']:
-            bufTypes.append(keyword)
-        elif hi['Kind'] in ['interface name']:
-            bufInterfaces.append(keyword)
-        elif hi['Kind'] in ['field name', 'local name', 'property name',
-                            'identifier', 'parameter name']:
-            bufIdentifiers.append(keyword)
-        elif hi['Kind'] in ['extension method name', 'method name']:
-            bufMethods.append(keyword)
+        line = bufferLines[hi['StartLine'] - 1]
+        types.append({
+            'kind': hi['Kind'],
+            'name': line[hi['StartColumn'] - 1:hi['EndColumn'] - 1]
+        })
+
     return {
-        'bufferIdentifiers': bufIdentifiers,
-        'bufferInterfaces': bufInterfaces,
-        'bufferMethods': bufMethods,
-        'bufferTypes': bufTypes
+        'identifiers': [t['name'] for t in types if t['kind'] in identifierKinds],
+        'interfaces': [t['name'] for t in types if t['kind'] in interfaceKinds],
+        'methods': [t['name'] for t in types if t['kind'] in methodKinds],
+        'types': [t['name'] for t in types if t['kind'] in typeKinds]
     }
 
 

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -210,26 +210,31 @@ def findSymbols(filter=''):
 def findHighlightTypes():
     response = getResponse(ctx, '/highlight', json=True)
     highlights = response.get('Highlights', [])
-    bufTypes = []
-    bufInterfaces = []
     bufIdentifiers = []
+    bufInterfaces = []
+    bufMethods = []
+    bufTypes = []
     for hi in highlights:
         span = {
             'line': hi['StartLine'],
             'start': hi['StartColumn'],
             'end': hi['EndColumn']
         }
-        # 'class name', 'enum name', 'interface name'
-        if hi['Kind'] in ['class name', 'enum name', 'struct name']:
+        if hi['Kind'] in ['class name', 'enum name', 'namespace name',
+                          'static symbol', 'struct name']:
             bufTypes.append(span)
-        elif hi['Kind'] == 'interface name':
+        elif hi['Kind'] in ['interface name']:
             bufInterfaces.append(span)
-        elif hi['Kind'] == 'identifier':
+        elif hi['Kind'] in ['field name', 'local name', 'property name',
+                            'identifier', 'parameter name']:
             bufIdentifiers.append(span)
+        elif hi['Kind'] in ['method name']:
+            bufMethods.append(span)
     return {
-        'bufferTypes': bufTypes,
+        'bufferIdentifiers': bufIdentifiers,
         'bufferInterfaces': bufInterfaces,
-        'bufferIdentifiers': bufIdentifiers
+        'bufferMethods': bufMethods,
+        'bufferTypes': bufTypes
     }
 
 

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -223,15 +223,16 @@ def findHighlightTypes():
             'end': hi['EndColumn']
         }
         keyword = lines[span['line']-1][span['start']-1:span['end']-1]
-        if hi['Kind'] in ['class name', 'enum name', 'namespace name',
-                          'static symbol', 'struct name']:
+        if hi['Kind'] in ['class name', 'constant name', 'enum name',
+                          'enum member name', 'namespace name', 'static symbol',
+                          'struct name']:
             bufTypes.append(keyword)
         elif hi['Kind'] in ['interface name']:
             bufInterfaces.append(keyword)
         elif hi['Kind'] in ['field name', 'local name', 'property name',
                             'identifier', 'parameter name']:
             bufIdentifiers.append(keyword)
-        elif hi['Kind'] in ['method name']:
+        elif hi['Kind'] in ['extension method name', 'method name']:
             bufMethods.append(keyword)
     return {
         'bufferIdentifiers': bufIdentifiers,


### PR DESCRIPTION
This PR contains various highlighting improvements and bugfixes. It adds several new/updated OmniSharp-roslyn highlight "kinds, and ensures that highlight groups don't collide with vim keywords.

There are also some improvements to how the plugin checks for vim-fugitive buffers, to prevent errors when attempting to highlight or update a fugitive buffer.

Closes #397