### PR TITLE
Store version information from OmniSharpInstall

### DIFF
--- a/installer/omnisharp-manager.ps1
+++ b/installer/omnisharp-manager.ps1
@@ -70,6 +70,7 @@ else
 #Check for file to confirm download and unzip were successful
 if(Test-Path -path "$($location)\OmniSharp.Roslyn.dll")
 {
+    Set-Content -Path "$($location)\OmniSharpInstall-version.txt" -Value "OmniSharp $($version)"
     exit 0
 }
 else

--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -132,4 +132,6 @@ if [ -n "$mono" ] && [ $mono -eq 1 ]; then
     chmod +x $(find "$location" -type f)
 fi
 
+echo "OmniSharp $version" > "$location/OmniSharpInstall-version.txt"
+
 exit 0


### PR DESCRIPTION
If users want to know what version they have (for bug reporting), there
is no obvious method. Now we store the downloaded version in a text
file.

Tested on gvim 8.1 on Windows.

Write the version file inside of the install folder so if different locations are used, it still works. Using a filename referencing the specific vim command to ensure uniqueness.