### PR TITLE
Added simple CoC completion source.

### DIFF
--- a/autoload/coc/source/OmniSharp.vim
+++ b/autoload/coc/source/OmniSharp.vim
@@ -1,0 +1,12 @@
+function! coc#source#OmniSharp#init() abort
+  return {
+  \ 'shortcut': 'OS',
+  \ 'filetypes': ['cs']
+  \ }
+endfunction
+
+function! coc#source#OmniSharp#complete(options, callback) abort
+  call OmniSharp#GetCompletions(a:options.input, a:callback)
+endfunction
+
+" vim:et:sw=2:sts=2


### PR DESCRIPTION
I didn't see any obvious way to hook up Omnisharp completions to coc.nvim without either using the not fully featured lsp mode or the omnifunc source, which isn't recommended.  So, I thought I'd put together a very simple completion source to see if I was on the right track for what I should do.

Does this seem right, and should it work for everyone else, too?