### PR TITLE
Use sed's -E option to fix & simplify regular expression.

### DIFF
--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -26,7 +26,7 @@ get_latest_version() {
         curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest"
     elif [ "$(command -v wget)" ]; then
         wget -qO- "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest"
-    fi | grep '"tag_name":' | sed 's/.*"\([^"]\+\)".*/\1/'
+    fi | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 location="$HOME/.omnisharp/"


### PR DESCRIPTION
I ran into issues using the roslyn auto-install option. It appears to have been related to obtaining the version. I'm not entirely certain why this wasn't working, but using -E fixes the issue with the added bonus IMO of making the regular expression easier to read.

```
$ curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest" | grep '"tag_name":' | sed 's/.*"\([^"]\+\)".*/\1/'
  "tag_name": "v1.32.18",
$ curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest" | grep '"tag_name":' | sed 's/.*"\([^"]+\)".*/\1/'
  "tag_name": "v1.32.18",
$ curl --silent "https://api.github.com/repos/OmniSharp/omnisharp-roslyn/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
v1.32.18
```