### PR TITLE
Support csx

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -627,8 +627,12 @@ function! OmniSharp#StartServer(...) abort
   else
     let sln_or_dir = OmniSharp#FindSolutionOrDir()
     if empty(sln_or_dir)
-      call OmniSharp#util#EchoErr('Could not find solution file or directory to start server')
-      return
+      if expand('%:e') ==# 'csx'
+        let sln_or_dir = expand('%:p:h')
+      else
+        call OmniSharp#util#EchoErr('Could not find solution file or directory to start server')
+        return
+      endif
     endif
   endif
 

--- a/ftdetect/csx.vim
+++ b/ftdetect/csx.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.csx set filetype=cs


### PR DESCRIPTION
Detect .csx files as filetype=cs, and automatically start the server for the current directory for .csx files when no .sln is found.

Closes #463