### PR TITLE
Change selected index of array item coming from vim.eval

### DIFF
--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -137,9 +137,16 @@ def codeActionParameters(mode):
     if mode == 'visual':
         start = vim.eval('getpos("\'<")')
         end = vim.eval('getpos("\'>")')
+        # In visual line mode, getpos("'>")[2] is a large number (2147483647).
+        # In python this is represented as a string, so when the length of this
+        # string is greater than 5 it means the position is greater than 99999.
+        # In this case, use the length of the line as the column position.
+        if len(end[2]) > 5:
+            end[2] = vim.eval('len(getline(%s))' % end[1])
+        logger.error(end)
         parameters['Selection'] = {
             'Start': {'Line': start[1], 'Column': start[2]},
-            'End': {'Line': end[1], 'Column': end[1]}
+            'End': {'Line': end[1], 'Column': end[2]}
         }
     return parameters
 

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -139,7 +139,7 @@ def codeActionParameters(mode):
         end = vim.eval('getpos("\'>")')
         parameters['Selection'] = {
             'Start': {'Line': start[1], 'Column': start[2]},
-            'End': {'Line': end[1], 'Column': end[2]}
+            'End': {'Line': end[1], 'Column': end[1]}
         }
     return parameters
 


### PR DESCRIPTION
While trying to run :OmniSharpGetCodeActions in visual mode I was getting errors. This seems to be because the third element in the array returned from `vim.eval('getpos("\'>")')` is a very large number. The second item seems to be the correct number.

This fix worked for me. May be worth looking into. I am not great at Python, so it's possible I'm just missing something.

Thanks,