### PR TITLE
Listen for Diagnostic events and trigger ALE

### DIFF
--- a/autoload/ale/sources/OmniSharp.vim
+++ b/autoload/ale/sources/OmniSharp.vim
@@ -1,13 +1,15 @@
 function! ale#sources#OmniSharp#WantResults(buffer) abort
+  let g:OmniSharp_ale_diagnostics_requested = 1
   if OmniSharp#FugitiveCheck() | return | endif
   if !OmniSharp#IsServerRunning({ 'bufnum': a:buffer }) | return | endif
 
   call ale#other_source#StartChecking(a:buffer, 'OmniSharp')
   let opts = { 'BufNum': a:buffer }
-  call OmniSharp#stdio#CodeCheck(opts, function('s:CBWantResults', [opts]))
+  let Callback = function('ale#sources#OmniSharp#ProcessResults', [opts])
+  call OmniSharp#stdio#CodeCheck(opts, Callback)
 endfunction
 
-function! s:CBWantResults(opts, locations) abort
+function! ale#sources#OmniSharp#ProcessResults(opts, locations) abort
   let locations = a:locations
   for location in locations
     if get(location, 'subtype', '') ==# 'style'


### PR DESCRIPTION
This PR listens to Diagnostic events from the server. In some situations (especially after an undo), a `/codecheck` event contains old diagnostics, and a followup Diagnostic event contains the updated diagnostics. These will now be caught and the ALE diagnostics updated (when ALE is in use only).