### PR TITLE
Use text properties for symantic highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,24 +253,14 @@ set previewheight=5
 " Tell ALE to use OmniSharp for linting C# files, and no other linters.
 let g:ale_linters = { 'cs': ['OmniSharp'] }
 
-" Fetch semantic type/interface/identifier names on BufEnter and highlight them
-let g:OmniSharp_highlight_types = 1
+" Update symantic highlighting on BufEnter and InsertLeave
+let g:OmniSharp_highlight_types = 2
 
 augroup omnisharp_commands
     autocmd!
 
-    " When Syntastic is available but not ALE, automatic syntax check on events
-    " (TextChanged requires Vim 7.4)
-    " autocmd BufEnter,TextChanged,InsertLeave *.cs SyntasticCheck
-
     " Show type information automatically when the cursor stops moving
     autocmd CursorHold *.cs call OmniSharp#TypeLookupWithoutDocumentation()
-
-    " Update the highlighting whenever leaving insert mode
-    autocmd InsertLeave *.cs call OmniSharp#HighlightBuffer()
-
-    " Alternatively, use a mapping to refresh highlighting for the current buffer
-    autocmd FileType cs nnoremap <buffer> <Leader>th :OmniSharpHighlightTypes<CR>
 
     " The following commands are contextual, based on the cursor position.
     autocmd FileType cs nnoremap <buffer> gd :OmniSharpGotoDefinition<CR>

--- a/README.md
+++ b/README.md
@@ -213,6 +213,74 @@ To use the other features, you'll want to create key bindings for them. See the 
 
 See the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki) for more custom configuration examples.
 
+### Symantic Highlighting
+OmniSharp-roslyn can provide highlighting information about every symbol of the document.
+
+To highlight a document, use command `:OmniSharpHighlightTypes`. To have `.cs` files automatically highlighted when entering a buffer or leaving insert mode, add this to your .vimrc:
+
+```vim
+let g:OmniSharp_highlight_types = 2
+```
+
+#### Vim 8.1 text properties
+In (very) recent versions of Vim, the OmniSharp-roslyn highlighting can be taken full advantage of using Vim text properties, allowing OmniSharp-vim to overwrite the standard Vim regular-expression syntax highlighting with OmniSharp-roslyn's symantic highlighting.
+To check whether your Vim supports text properties, look for `+textprop` in the output of `:version`, or run `:echo has('textprop')`.
+
+The default highlight groups used for symantic highlighting, along with the standard Vim highlight groups they are linked to are as follows:
+
+| Highlight group  | Default link |
+|------------------|--------------|
+| csUserIdentifier | Identifier   |
+| csUserInterface  | Include      |
+| csUserMethod     | Function     |
+| csUserType       | Type         |
+
+Highlight groups are mapped to OmniSharp-roslyn keyword "kinds" using variable `g:OmniSharp_highlight_groups`.
+Here is the default mapping dictionary:
+
+```vim
+let g:OmniSharp_highlight_groups = {
+\ 'csUserIdentifier': [
+\   'constant name', 'enum member name', 'field name', 'identifier',
+\   'local name', 'parameter name', 'property name', 'static symbol'],
+\ 'csUserInterface': ['interface name'],
+\ 'csUserMethod': ['extension method name', 'method name'],
+\ 'csUserType': ['class name', 'enum name', 'namespace name', 'struct name']
+\}
+```
+
+However, any highlight groups can be used, and they can be set to highlight any OmniSharp-roslyn "kinds".
+For example, to only highlight `namespace name` and `enum name` using highlight group `Title`, you could add this to your .vimrc:
+
+```vim
+let g:OmniSharp_highlight_groups = {
+\ 'Title': ['enum name', 'namespace name']
+\}
+```
+
+In order to find out what OmniSharp-roslyn calls a particular element, there is a "debugging" option available, `g:OmniSharp_highlight_debug`. When this is set to `1`, text properties are added to **all** symbols of the document. The text properties are not highlighted so this has no visible effect, but when this mode is enabled, command `:OmniSharpHighlightEchoKind` will echo the OmniSharp-rolsyn "kind" of the symbol under the cursor.
+
+**Note:** Text property highlighting is currently only available when using the stdio server, not for HTTP server usage.
+
+#### Older versions
+When text properties are not available, or when using the HTTP server, limited symantic highlighting is still possible by highlighting keywords.
+Note that this is not perfect - a keyword can only match a single highlight group, meaning that interfaces/classes/methods/parameters with the same name will be highlighted the same as each other.
+
+The configuration options are also more limited.
+The same 4 highlight groups are used as described above (`csUserIdentifier`, `csUserInterface`, `csUserMethod` and `csUserType`).
+To change a highlight group's colors, change the `ctermbg`/`guibg` properties, or link it to another highlight group:
+
+```vim
+highlight csUserInterface ctermfg=12 guifg=Blue
+highlight link csUserType Identifier
+```
+
+To disable a group, link it to `Normal`:
+
+```vim
+highlight link csUserMethod Normal
+```
+
 ## Configuration
 
 ### Example vimrc

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -631,8 +631,12 @@ function! OmniSharp#HighlightBuffer() abort
   if bufname('%') ==# '' || OmniSharp#FugitiveCheck() | return | endif
   let opts = { 'BufNum':  bufnr('%') }
   if g:OmniSharp_server_stdio
-    let Callback = function('s:CBHighlightBuffer', [opts])
-    call OmniSharp#stdio#FindHighlightTypes(Callback)
+    if has('textprop')
+      call OmniSharp#stdio#FindTextProperties(opts.BufNum)
+    else
+      let Callback = function('s:CBHighlightBuffer', [opts])
+      call OmniSharp#stdio#FindHighlightTypes(Callback)
+    endif
   else
     if !OmniSharp#IsServerRunning() | return | endif
     let hltypes = OmniSharp#py#eval('findHighlightTypes()')
@@ -699,6 +703,14 @@ function! s:Highlight(types, group) abort
 
   if len(l:types)
     execute 'syntax keyword' a:group join(l:types)
+  endif
+endfunction
+
+function OmniSharp#HighlightEchoKind() abort
+  if !g:OmniSharp_server_stdio || !has('textprop')
+    echo 'Highlight kinds require text properties, in stdio mode'
+  else
+    call OmniSharp#stdio#HighlightEchoKind()
   endif
 endfunction
 

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -330,8 +330,8 @@ function! s:FindHighlightTypesRH(Callback, bufferLines, response) abort
     endif
     let line = a:bufferLines[lnum]
     call add(types, {
-    \ 'kind': hl['Kind'],
-    \ 'name': line[hl['StartColumn'] - 1 : hl['EndColumn'] - 2]
+    \ 'kind': hl.Kind,
+    \ 'name': line[hl.StartColumn - 1 : hl.EndColumn - 2]
     \})
   endfor
 
@@ -380,6 +380,81 @@ endfunction
 function! s:FindSymbolRH(Callback, response) abort
   if !a:response.Success | return | endif
   call a:Callback(s:LocationsFromResponse(a:response.Body.QuickFixes))
+endfunction
+
+function! OmniSharp#stdio#FindTextProperties(bufnum) abort
+  let bufferLines = getline(1, '$')
+  let opts = {
+  \ 'ResponseHandler': function('s:FindTextPropertiesRH', [a:bufnum, bufferLines])
+  \}
+  call s:Request('/highlight', opts)
+endfunction
+
+function! s:FindTextPropertiesRH(bufnum, bufferLines, response) abort
+  if !a:response.Success | return | endif
+  let highlights = get(a:response.Body, 'Highlights', [])
+  if !get(s:, 'textPropertiesInitialized', 0)
+    let s:groupKinds = get(g:, 'OmniSharp_highlight_groups', {
+    \ 'csUserIdentifier': [
+    \   'constant name', 'enum member name', 'field name', 'identifier',
+    \   'local name', 'parameter name', 'property name', 'static symbol'],
+    \ 'csUserInterface': ['interface name'],
+    \ 'csUserMethod': ['extension method name', 'method name'],
+    \ 'csUserType': ['class name', 'enum name', 'namespace name', 'struct name']
+    \})
+    " Create the inverse dict for fast lookups
+    let s:kindGroups = {}
+    for key in keys(s:groupKinds)
+      call prop_type_add(key, {'highlight': key, 'combine': 1})
+      for kind in s:groupKinds[key]
+        let s:kindGroups[kind] = key
+      endfor
+    endfor
+    let s:textPropertiesInitialized = 1
+  endif
+  let curline = 1
+  for hl in highlights
+    if curline <= hl.StartLine
+      call prop_clear(curline, hl.StartLine, {'bufnr': a:bufnum})
+      let curline = hl.StartLine + 1
+    endif
+    if has_key(s:kindGroups, hl.Kind)
+      call prop_add(hl.StartLine, hl.StartColumn, {
+      \ 'end_lnum': hl.EndLine,
+      \ 'end_col': hl.EndColumn,
+      \ 'type': s:kindGroups[hl.Kind],
+      \ 'bufnr': a:bufnum
+      \})
+    endif
+    if get(g:, 'OmniSharp_highlight_debug', 0)
+      let hlKind = 'cs' . substitute(hl.Kind, ' ', '_', 'g')
+      if !len(prop_type_get(hlKind))
+        call prop_type_add(hlKind, {'highlight': 'Normal'})
+      endif
+      call prop_add(hl.StartLine, hl.StartColumn, {
+      \ 'end_lnum': hl.EndLine,
+      \ 'end_col': hl.EndColumn,
+      \ 'type': hlKind,
+      \ 'bufnr': a:bufnum
+      \})
+    endif
+  endfor
+endfunction
+
+function OmniSharp#stdio#HighlightEchoKind() abort
+  let props = filter(prop_list(line('.')),
+  \ 'v:val.col <= col(".") && v:val.col + v:val.length - 1 >= col(".")')
+  if len(props)
+    for prop in props
+      if has_key(s:groupKinds, prop.type)
+        echon ' (' . prop.type . ')'
+      else
+        echon substitute(props[0].type[2:], '_', ' ', 'g')
+      endif
+    endfor
+  else
+    echo 'No Kind found'
+  endif
 endfunction
 
 function! OmniSharp#stdio#FindUsages(Callback) abort

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -96,9 +96,12 @@ Default: 0 >
 <
 
                                                   *'g:OmniSharp_highlight_types'*
-Enable semantic type/interface/identifier highlighting on BufEnter.
+Enable automatic semantic type/interface/identifier highlighting.
 Default: 0 >
+    " Highlight on BufEnter
     let g:OmniSharp_highlight_types = 1
+    " Highlight on BufEnter and InsertLeave
+    let g:OmniSharp_highlight_types = 2
 <
 
                                                              *'g:OmniSharp_host'*

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -104,6 +104,20 @@ Default: 0 >
     let g:OmniSharp_highlight_types = 2
 <
 
+                                                 *'g:OmniSharp_highlight_groups'*
+Specify which highlight groups should be used to highlight with OmniSharp-roslyn
+"kinds".
+Default: >
+    let g:OmniSharp_highlight_groups = {
+    \ 'csUserIdentifier': [
+    \   'constant name', 'enum member name', 'field name', 'identifier',
+    \   'local name', 'parameter name', 'property name', 'static symbol'],
+    \ 'csUserInterface': ['interface name'],
+    \ 'csUserMethod': ['extension method name', 'method name'],
+    \ 'csUserType': ['class name', 'enum name', 'namespace name', 'struct name']
+    \}
+<
+
                                                              *'g:OmniSharp_host'*
                                                                       HTTP only
 Use this option to specify the host address of the OmniSharp server. Using this

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -31,14 +31,17 @@ command! -buffer -bar -nargs=? OmniSharpFindSymbol                 call OmniShar
 command! -buffer -bar OmniSharpFindUsages                          call OmniSharp#FindUsages()
 command! -buffer -bar OmniSharpFixUsings                           call OmniSharp#FixUsings()
 command! -buffer -bar OmniSharpGetCodeActions                      call OmniSharp#GetCodeActions('normal')
+command! -buffer -bar OmniSharpGlobalCodeCheck                     call OmniSharp#GlobalCodeCheck()
 command! -buffer -bar OmniSharpGotoDefinition                      call OmniSharp#GotoDefinition()
-command! -buffer -bar OmniSharpPreviewDefinition                   call OmniSharp#PreviewDefinition()
-command! -buffer -bar OmniSharpPreviewImplementation               call OmniSharp#PreviewImplementation()
+command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniSharp#Install(<f-args>)
+command! -buffer -bar OmniSharpHighlightEchoKind                   call OmniSharp#HighlightEchoKind()
 command! -buffer -bar OmniSharpHighlightTypes                      call OmniSharp#HighlightBuffer()
 command! -buffer -bar OmniSharpNavigateUp                          call OmniSharp#NavigateUp()
 command! -buffer -bar OmniSharpNavigateDown                        call OmniSharp#NavigateDown()
 command! -buffer -bar OmniSharpOpenLog                             call OmniSharp#OpenLog()
 command! -buffer -bar OmniSharpOpenPythonLog                       call OmniSharp#OpenPythonLog()
+command! -buffer -bar OmniSharpPreviewDefinition                   call OmniSharp#PreviewDefinition()
+command! -buffer -bar OmniSharpPreviewImplementation               call OmniSharp#PreviewImplementation()
 command! -buffer -bar OmniSharpRename                              call OmniSharp#Rename()
 command! -buffer -bar OmniSharpRestartAllServers                   call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer                       call OmniSharp#RestartServer()
@@ -47,8 +50,6 @@ command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniShar
 command! -buffer -bar OmniSharpStopAllServers                      call OmniSharp#StopAllServers()
 command! -buffer -bar OmniSharpStopServer                          call OmniSharp#StopServer()
 command! -buffer -bar OmniSharpTypeLookup                          call OmniSharp#TypeLookupWithoutDocumentation()
-command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniSharp#Install(<f-args>)
-command! -buffer -bar OmniSharpGlobalCodeCheck                     call OmniSharp#GlobalCodeCheck()
 
 command! -buffer -nargs=1 OmniSharpRenameTo
 \ call OmniSharp#RenameTo(<q-args>)
@@ -75,14 +76,17 @@ let b:undo_ftplugin .= '
 \|  delcommand OmniSharpFindUsages
 \|  delcommand OmniSharpFixUsings
 \|  delcommand OmniSharpGetCodeActions
+\|  delcommand OmniSharpGlobalCodeCheck
 \|  delcommand OmniSharpGotoDefinition
-\|  delcommand OmniSharpPreviewDefinition
+\|  delcommand OmniSharpHighlightEchoKind
 \|  delcommand OmniSharpHighlightTypes
 \|  delcommand OmniSharpInstall
 \|  delcommand OmniSharpNavigateUp
 \|  delcommand OmniSharpNavigateDown
 \|  delcommand OmniSharpOpenLog
 \|  delcommand OmniSharpOpenPythonLog
+\|  delcommand OmniSharpPreviewDefinition
+\|  delcommand OmniSharpPreviewImplementation
 \|  delcommand OmniSharpRename
 \|  delcommand OmniSharpRenameTo
 \|  delcommand OmniSharpRestartAllServers
@@ -92,7 +96,6 @@ let b:undo_ftplugin .= '
 \|  delcommand OmniSharpStopAllServers
 \|  delcommand OmniSharpStopServer
 \|  delcommand OmniSharpTypeLookup
-\|  delcommand OmniSharpGlobalCodeCheck
 \
 \|  setlocal omnifunc< errorformat< makeprg<'
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -45,6 +45,10 @@ if g:OmniSharp_highlight_types
   augroup OmniSharp#HighlightTypes
     autocmd!
     autocmd BufEnter *.cs call OmniSharp#HighlightBuffer()
+
+    if g:OmniSharp_highlight_types == 2
+      autocmd InsertLeave *.cs call OmniSharp#HighlightBuffer()
+    endif
   augroup END
 endif
 


### PR DESCRIPTION
This PR replaces the regex-based symantic highlighting with Vim8.1 text properties.

- [x] Replace highlighting with text properties when supported, with `has('textprop')`
- [x] Add `:OmniSharpHighlightEchoKind` command, to echo the OmniSharp-roslyn "Kind" of element under the cursor
- [x] Add documentation, describing how to define custom highlights and how to find out what OmniSharp-roslyn calls the element under the cursor

Closes #453