### PR TITLE
Add server loading timeout

### DIFF
--- a/autoload/OmniSharp/proc.vim
+++ b/autoload/OmniSharp/proc.vim
@@ -64,7 +64,6 @@ function! OmniSharp#proc#neovimJobStart(command) abort
   endif
   let job = {
   \ 'job_id': jobstart(a:command, opts),
-  \ 'loaded': 0,
   \ 'partial': ''
   \}
   let s:channels[job.job_id] = job
@@ -105,8 +104,7 @@ function! OmniSharp#proc#vimJobStart(command) abort
     let opts['out_cb'] = 'OmniSharp#proc#vimOutHandler'
   endif
   let job = {
-  \ 'job_id': job_start(a:command, opts),
-  \ 'loaded': 0
+  \ 'job_id': job_start(a:command, opts)
   \}
   let channel_id = job_getchannel(job.job_id)
   let s:channels[channel_id] = job
@@ -165,14 +163,14 @@ function! OmniSharp#proc#Start(command, jobkey) abort
     if job.job_id > 0
       let s:jobs[a:jobkey] = job
     else
-      call OmniSharp#util#EchoErr('command is not executable: ' . a:command[0])
+      call OmniSharp#util#EchoErr('Command is not executable: ' . a:command[0])
     endif
   elseif OmniSharp#proc#supportsVimJobs()
     let job = OmniSharp#proc#vimJobStart(a:command)
     if job_status(job.job_id) ==# 'run'
       let s:jobs[a:jobkey] = job
     else
-      call OmniSharp#util#EchoErr('could not run command: ' . join(a:command, ' '))
+      call OmniSharp#util#EchoErr('Could not run command: ' . join(a:command, ' '))
     endif
   elseif OmniSharp#proc#supportsVimDispatch()
     let req = OmniSharp#proc#dispatchStart(a:command)
@@ -182,6 +180,10 @@ function! OmniSharp#proc#Start(command, jobkey) abort
     let s:jobs[a:jobkey] = proc
   else
     call OmniSharp#util#EchoErr('Please use neovim, or vim 8.0+ or install either vim-dispatch or vimproc.vim plugin to use this feature')
+  endif
+  if type(job) == type({})
+    let job.sln_or_dir = a:jobkey
+    let job.loaded = 0
   endif
 endfunction
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -75,6 +75,23 @@ Default: '/home/username/.omnisharp/omnisharp-roslyn/run'
     let g:OmniSharp_server_path = '/home/username/omnisharp/omnisharp.http-linux-x64/omnisharp/OmniSharp.exe'
 <
 
+                                           *'g:OmniSharp_server_display_loading'*
+                                                                     Stdio only
+Echo "Server loaded for ...sln" message when the server is ready.
+Default: 1 >
+    let g:OmniSharp_server_display_loading = 1
+<
+
+                                           *'g:OmniSharp_server_loading_timeout'*
+                                                                     Stdio only
+When the server is started, OmniSharp-vim listens for notifications from the
+server to know when the server is ready for requests. However, these
+notifications may not be correctly sent, in which case the server can be
+considered "loaded" after a timeout period.
+Default: 30 (seconds) >
+    let g:OmniSharp_server_loading_timeout = 30
+<
+
                                                      *'g:OmniSharp_server_ports'*
                                                                       HTTP only
 Mapping of solution files and/or directories to ports. When auto-starting the

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -7,6 +7,8 @@ let g:OmniSharp_server_stdio = get(g:, 'OmniSharp_server_stdio', 0)
 " 'Configuration finished' is received.  When this is 0, wait for notification
 " that all projects have been loaded.
 let g:OmniSharp_server_stdio_quickload = get(g:, 'OmniSharp_server_stdio_quickload', 0)
+let g:OmniSharp_server_display_loading = get(g:, 'OmniSharp_server_display_loading', 1)
+let g:OmniSharp_server_loading_timeout = get(g:, 'OmniSharp_server_loading_timeout', 30)
 
 " Use mono to start the roslyn server on *nix
 let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)


### PR DESCRIPTION
Add a 30 second (configurable) timeout when loading a server. If the "Successfully loaded project" server notifications are not received in this time, mark the server as "loaded" and allow sending requests.