### PR TITLE
GotoMetadata feature

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -14,7 +14,6 @@ let s:generated_snippets = {}
 let s:last_completion_dictionary = {}
 let s:alive_cache = []
 let s:initial_server_ports = copy(g:OmniSharp_server_ports)
-let s:temppath = fnamemodify(tempname(), ':p:h')
 
 function! OmniSharp#GetPort(...) abort
   if exists('g:OmniSharp_port')
@@ -323,7 +322,7 @@ endfunction
 function! s:CBGotoMetadata(open_in_preview, opts, response, metadata) abort
   let host = OmniSharp#GetHost()
   let metadata_filename = fnamemodify(a:response.SourceName, ":t")
-  let temp_file = s:temppath.'/'.metadata_filename
+  let temp_file = g:OmniSharp_temp_dir.'/'.metadata_filename
   call writefile(
   \ map(split(a:response.Source, "\n", 1), {i,v -> substitute(v, '\r', '', 'g')}),
   \ temp_file,

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -321,7 +321,8 @@ endfunction
 
 function! s:CBGotoMetadata(open_in_preview, opts, response, metadata) abort
   let host = OmniSharp#GetHost()
-  let metadata_filename = fnamemodify(a:response.SourceName, ":t")
+  let metadata_filename = fnamemodify(
+  \ OmniSharp#util#TranslatePathForClient(a:response.SourceName), ':t')
   let temp_file = g:OmniSharp_temp_dir.'/'.metadata_filename
   call writefile(
   \ map(split(a:response.Source, "\n", 1), {i,v -> substitute(v, '\r', '', 'g')}),
@@ -339,9 +340,9 @@ function! s:CBGotoMetadata(open_in_preview, opts, response, metadata) abort
   \  'col': a:metadata.Column
   \}, 1)
   let b:OmniSharp_host = host
+  let b:OmniSharp_metadata_filename = a:response.SourceName
   silent edit
   execute "normal! \<C-o>"
-  let b:OmniSharp_metadata_filename = a:response.SourceName
   setlocal nomodifiable readonly
   if a:open_in_preview && !jumped_from_preview
     silent wincmd p

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -256,9 +256,10 @@ function! s:CBGotoDefinition(opts, location, metadata) abort
   return found
 endfunction
 
-function! OmniSharp#PreviewDefinition() abort
+function! OmniSharp#PreviewDefinition(...) abort
+  let opts = a:0 ? {'Callback': a:1} : {}
   if g:OmniSharp_server_stdio
-    let Callback = function('s:CBPreviewDefinition')
+    let Callback = function('s:CBPreviewDefinition', [opts])
     call OmniSharp#stdio#GotoDefinition(Callback)
   else
     let loc = OmniSharp#py#eval('gotoDefinition()')
@@ -267,12 +268,13 @@ function! OmniSharp#PreviewDefinition() abort
   endif
 endfunction
 
-function! s:CBPreviewDefinition(loc, metadata) abort
+function! s:CBPreviewDefinition(opts, loc, metadata) abort
   if type(a:loc) != type({}) " Check whether a dict was returned
     if g:OmniSharp_lookup_metadata && type(a:metadata.MetadataSource) == type({})
       let found = OmniSharp#GotoMetadata(
       \ 1,
-      \ a:metadata, {})
+      \ a:metadata,
+      \ a:opts)
     else
       echo 'Not found'
     endif

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -139,13 +139,12 @@ function! s:Request(command, opts) abort
   \   'Filename': filename,
   \   'Line': lnum,
   \   'Column': cnum,
-  \   'Buffer': buffer
   \ }
   \}
 
-  " if !is_metadata
-  "   let body.Arguments.Buffer = buffer
-  " endif
+  if !(is_metadata && a:command == '/gotodefinition')
+    let body.Arguments.Buffer = buffer
+  endif
   return s:RawRequest(body, a:command, a:opts, sep)
 endfunction
 

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -142,7 +142,7 @@ function! s:Request(command, opts) abort
   \ }
   \}
 
-  if !(is_metadata && a:command == '/gotodefinition')
+  if !is_metadata
     let body.Arguments.Buffer = buffer
   endif
   return s:RawRequest(body, a:command, a:opts, sep)

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -139,12 +139,13 @@ function! s:Request(command, opts) abort
   \   'Filename': filename,
   \   'Line': lnum,
   \   'Column': cnum,
+  \   'Buffer': buffer
   \ }
   \}
 
-  if !is_metadata
-    let body.Arguments.Buffer = buffer
-  endif
+  " if !is_metadata
+  "   let body.Arguments.Buffer = buffer
+  " endif
   return s:RawRequest(body, a:command, a:opts, sep)
 endfunction
 
@@ -646,13 +647,8 @@ function! OmniSharp#stdio#GotoMetadata(Callback, metadata) abort
 endfunction
 
 function! s:GotoMetadataRH(Callback, metadata, response) abort
-  if !a:response.Success | return 0 | endif
+  if !a:response.Success || a:response.Body.Source == v:null | return 0 | endif
   return a:Callback(a:response.Body, a:metadata)
-  " if get(a:response.Body, 'FileName', v:null) != v:null
-  "   call a:Callback(s:LocationsFromResponse([a:response.Body])[0])
-  " else
-  "   call a:Callback(0)
-  " endif
 endfunction
 
 function! OmniSharp#stdio#NavigateDown() abort

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -117,8 +117,14 @@ function! s:Request(command, opts) abort
   if has_key(a:opts, 'SavePosition')
     let s:lastPosition = [bufnum, lnum, cnum]
   endif
-  let filename = OmniSharp#util#TranslatePathForServer(
-  \ fnamemodify(bufname(bufnum), ':p'))
+  let metadata_filename = get(b:, 'OmniSharp_metadata_filename', v:null)
+  let is_metadata = type(metadata_filename) == type('')
+  if is_metadata
+    let filename = metadata_filename
+  else
+    let filename = OmniSharp#util#TranslatePathForServer(
+    \ fnamemodify(bufname(bufnum), ':p'))
+  endif
   let lines = getbufline(bufnum, 1, '$')
   let tmp = join(lines, '')
   " Unique string separator which must not exist in the buffer
@@ -133,9 +139,12 @@ function! s:Request(command, opts) abort
   \   'Filename': filename,
   \   'Line': lnum,
   \   'Column': cnum,
-  \   'Buffer': buffer
   \ }
   \}
+
+  if !is_metadata
+    let body.Arguments.Buffer = buffer
+  endif
   return s:RawRequest(body, a:command, a:opts, sep)
 endfunction
 
@@ -209,8 +218,11 @@ function! s:LocationsFromResponse(quickfixes) abort
 endfunction
 
 function! s:MakeChanges(body) abort
-  if len(get(a:body, 'Changes', []))
-    for change in get(a:body, 'Changes', [])
+  let changes = get(a:body, 'Changes', [])
+  if type(changes) == type(v:null) | let changes = [] | endif
+
+  if len(changes)
+    for change in changes
       let text = join(split(change.NewText, '\r\?\n', 1), "\n")
       let start = [change.StartLine, change.StartColumn]
       let end = [change.EndLine, change.EndColumn]
@@ -380,7 +392,8 @@ endfunction
 
 function! s:FindImplementationsRH(Callback, response) abort
   if !a:response.Success | return | endif
-  call a:Callback(s:LocationsFromResponse(a:response.Body.QuickFixes))
+  let responses = a:response.Body.QuickFixes
+  call a:Callback(type(responses) == type([]) ? s:LocationsFromResponse(responses) : [])
 endfunction
 
 function! OmniSharp#stdio#FindMembers(Callback) abort
@@ -498,7 +511,8 @@ endfunction
 
 function! s:FindUsagesRH(Callback, response) abort
   if !a:response.Success | return | endif
-  call a:Callback(s:LocationsFromResponse(a:response.Body.QuickFixes))
+  let usages = a:response.Body.QuickFixes
+  call a:Callback(type(usages) == type([]) ? s:LocationsFromResponse(a:response.Body.QuickFixes) : [])
 endfunction
 
 function! OmniSharp#stdio#FixUsings(Callback) abort
@@ -518,7 +532,11 @@ function! s:FixUsingsRH(Callback, response) abort
   call s:MakeChanges(a:response.Body)
   call winrestview(winview)
   normal! ``
-  let locations = s:LocationsFromResponse(a:response.Body.AmbiguousResults)
+  if type(a:response.Body.AmbiguousResults) == type(v:null)
+    let locations = []
+  else
+    let locations = s:LocationsFromResponse(a:response.Body.AmbiguousResults)
+  endif
   call a:Callback(locations)
 endfunction
 
@@ -600,8 +618,12 @@ function! s:GetCompletionsRH(Callback, response) abort
 endfunction
 
 function! OmniSharp#stdio#GotoDefinition(Callback) abort
+  let parameters = {
+  \ 'WantMetadata': v:true,
+  \}
   let opts = {
-  \ 'ResponseHandler': function('s:GotoDefinitionRH', [a:Callback])
+  \ 'ResponseHandler': function('s:GotoDefinitionRH', [a:Callback]),
+  \ 'Parameters': parameters
   \}
   call s:Request('/gotodefinition', opts)
 endfunction
@@ -609,10 +631,28 @@ endfunction
 function! s:GotoDefinitionRH(Callback, response) abort
   if !a:response.Success | return | endif
   if get(a:response.Body, 'FileName', v:null) != v:null
-    call a:Callback(s:LocationsFromResponse([a:response.Body])[0])
+    call a:Callback(s:LocationsFromResponse([a:response.Body])[0], a:response.Body)
   else
-    call a:Callback(0)
+    call a:Callback(0, a:response.Body)
   endif
+endfunction
+
+function! OmniSharp#stdio#GotoMetadata(Callback, metadata) abort
+  let opts = {
+  \ 'ResponseHandler': function('s:GotoMetadataRH', [a:Callback, a:metadata]),
+  \ 'Parameters': a:metadata.MetadataSource
+  \}
+  return s:Request('/metadata', opts)
+endfunction
+
+function! s:GotoMetadataRH(Callback, metadata, response) abort
+  if !a:response.Success | return 0 | endif
+  return a:Callback(a:response.Body, a:metadata)
+  " if get(a:response.Body, 'FileName', v:null) != v:null
+  "   call a:Callback(s:LocationsFromResponse([a:response.Body])[0])
+  " else
+  "   call a:Callback(0)
+  " endif
 endfunction
 
 function! OmniSharp#stdio#NavigateDown() abort

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -85,6 +85,13 @@ function! OmniSharp#util#TranslatePathForClient(filename) abort
     let filename = substitute(filename, '^\([a-zA-Z]\):\\', prefix . '\l\1/', '')
     let filename = substitute(filename, '\\', '/', 'g')
   endif
+
+  " Check if the file is a metadatafile. If it is, map it to the
+  " correct temp file on disk
+  echom "testing match"
+  if filename =~ '\$metadata\$'
+    let filename = g:OmniSharp_temp_dir .'/'. fnamemodify(filename, ":t")
+  endif
   return fnamemodify(filename, ':.')
 endfunction
 

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -88,7 +88,6 @@ function! OmniSharp#util#TranslatePathForClient(filename) abort
 
   " Check if the file is a metadatafile. If it is, map it to the
   " correct temp file on disk
-  echom "testing match"
   if filename =~ '\$metadata\$'
     let filename = g:OmniSharp_temp_dir .'/'. fnamemodify(filename, ":t")
   endif

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -54,17 +54,18 @@ Default: 0 >
 <
 
                                                      *'g:OmniSharp_lookup_metadata'*
-When using OmniSharpGotoDefinition, fall back to looking up metadata for compiled
-types. This can be set to 'window', 'preview', or a falsey value such as v:false.
+When using `OmniSharpGotoDefinition` and `OmniSharpPreviewDefinition`,
+fall back to looking up metadata for compiled types.
+This can be set to 1, or 0.
 
-If set to 'window' the types are displayed in the current window or a split if 
-there are unsaved changes in the current buffer. This is like the way VSCode or VS
-display metadata.
-If set to 'preview' the types are displayed in the preview window like the 
-OmniSharpDocumentation command.
-If set to a falsey value like v:false or v:null. This feature is disabled.
-Default: 'preview' >
-    let g:OmniSharp_lookup_metadata = 'preview'
+If set to 1 the `OmniSharpGotoDefinition` command will open the compiled
+metadata if available and the `OmniSharpPreviewDefinition` command will
+load the compiled metadata in the preview window if available.
+
+If set to 0 metadata will not be looked up for the `OmniSharpGotoDefinition`
+and `OmniSharpPreviewDefinition` commands.
+Default: 1 >
+    let g:OmniSharp_lookup_metadata = 1
 
 <
                                                              *'g:OmniSharp_port'*

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -53,6 +53,20 @@ Default: 0 >
     let g:OmniSharp_server_stdio = 1
 <
 
+                                                     *'g:OmniSharp_lookup_metadata'*
+When using OmniSharpGotoDefinition, fall back to looking up metadata for compiled
+types. This can be set to 'window', 'preview', or a falsey value such as v:false.
+
+If set to 'window' the types are displayed in the current window or a split if 
+there are unsaved changes in the current buffer. This is like the way VSCode or VS
+display metadata.
+If set to 'preview' the types are displayed in the preview window like the 
+OmniSharpDocumentation command.
+If set to a falsey value like v:false or v:null. This feature is disabled.
+Default: 'preview' >
+    let g:OmniSharp_lookup_metadata = 'preview'
+
+<
                                                              *'g:OmniSharp_port'*
                                                                       HTTP only
 Always use this port when starting an OmniSharp HTTP server. Note that this

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -4,10 +4,6 @@ let g:OmniSharp_loaded = 1
 " Get a global temp path that can be used to store temp files for this instance
 let g:OmniSharp_temp_dir = get(g:, 'OmniSharp_temp_dir', fnamemodify(tempname(), ':p:h'))
 
-" When set to a falsey value, metadata is not looked up
-" for compiled types.
-" When set to 'preview', it uses the preview window
-" When set to 'window', metadata is displayed in the current window. 
 let g:OmniSharp_lookup_metadata = get(g:, 'OmniSharp_lookup_metadata', 1)
 
 let g:OmniSharp_server_stdio = get(g:, 'OmniSharp_server_stdio', 0)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -2,7 +2,7 @@ if exists('g:OmniSharp_loaded') | finish | endif
 let g:OmniSharp_loaded = 1
 
 " Get a global temp path that can be used to store temp files for this instance
-let g:OmniSharp_temp_dir = fnamemodify(tempname(), ':p:h')
+let g:OmniSharp_temp_dir = get(g:, 'OmniSharp_temp_dir', fnamemodify(tempname(), ':p:h'))
 
 " When set to a falsey value, metadata is not looked up
 " for compiled types.

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -5,7 +5,7 @@ let g:OmniSharp_loaded = 1
 " for compiled types.
 " When set to 'preview', it uses the preview window
 " When set to 'window', metadata is displayed in the current window. 
-let g:OmniSharp_lookup_metadata = get(g:, 'OmniSharp_lookup_metadata', 'preview')
+let g:OmniSharp_lookup_metadata = get(g:, 'OmniSharp_lookup_metadata', 1)
 
 let g:OmniSharp_server_stdio = get(g:, 'OmniSharp_server_stdio', 0)
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,6 +1,12 @@
 if exists('g:OmniSharp_loaded') | finish | endif
 let g:OmniSharp_loaded = 1
 
+" When set to a falsey value, metadata is not looked up
+" for compiled types.
+" When set to 'preview', it uses the preview window
+" When set to 'window', metadata is displayed in the current window. 
+let g:OmniSharp_lookup_metadata = get(g:, 'OmniSharp_lookup_metadata', 'preview')
+
 let g:OmniSharp_server_stdio = get(g:, 'OmniSharp_server_stdio', 0)
 
 " When g:OmniSharp_server_stdio_quickload = 1, consider server 'loaded' once

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,6 +1,9 @@
 if exists('g:OmniSharp_loaded') | finish | endif
 let g:OmniSharp_loaded = 1
 
+" Get a global temp path that can be used to store temp files for this instance
+let g:OmniSharp_temp_dir = fnamemodify(tempname(), ':p:h')
+
 " When set to a falsey value, metadata is not looked up
 " for compiled types.
 " When set to 'preview', it uses the preview window

--- a/test/gotometadata.vader
+++ b/test/gotometadata.vader
@@ -1,0 +1,34 @@
+Include: utils/startserver.vader
+Include: utils/async-helper.vader
+
+Given cs():
+  using System.IO;
+
+  public class Test
+  {
+    MemoryStream stream;
+  }
+
+Execute (go to metadata preview):
+  let g:OmniSharp_lookup_metadata = 'preview'
+  call OmniSharpTestInitializeBuffer('GotoMetadata')
+  call search("MemoryStream stream")
+  call OmniSharpTestAwait('OmniSharp#GotoDefinition', [])
+  wincmd p
+  AssertEqual 'MemoryStream.cs', expand('%:t')
+  pclose
+
+Given cs():
+  using System.IO;
+
+  public class Test
+  {
+    MemoryStream stream;
+  }
+
+Execute (go to metadata window):
+  let g:OmniSharp_lookup_metadata = 'window'
+  call OmniSharpTestInitializeBuffer('GotoMetadata')
+  call search("MemoryStream stream")
+  call OmniSharpTestAwait('OmniSharp#GotoDefinition', [])
+  AssertEqual 'MemoryStream.cs', expand('%:t')

--- a/test/gotometadata.vader
+++ b/test/gotometadata.vader
@@ -10,10 +10,9 @@ Given cs():
   }
 
 Execute (go to metadata preview):
-  let g:OmniSharp_lookup_metadata = 'preview'
   call OmniSharpTestInitializeBuffer('GotoMetadata')
   call search("MemoryStream stream")
-  call OmniSharpTestAwait('OmniSharp#GotoDefinition', [])
+  call OmniSharpTestAwait('OmniSharp#PreviewDefinition', [])
   wincmd p
   AssertEqual 'MemoryStream.cs', expand('%:t')
   pclose
@@ -27,7 +26,6 @@ Given cs():
   }
 
 Execute (go to metadata window):
-  let g:OmniSharp_lookup_metadata = 'window'
   call OmniSharpTestInitializeBuffer('GotoMetadata')
   call search("MemoryStream stream")
   call OmniSharpTestAwait('OmniSharp#GotoDefinition', [])


### PR DESCRIPTION
@nickspoons this is my pr for the goto-metadata request #303 

This adds a feature to load metadata for compiled types.

A couple of things to note here:
1. This is implemented on top of the current goto-def and is not currently exposed via a top-level command. I didn't see a need for it, but it should be possible.
2. I added to the goto-def request to bring back metadata info if availabe.
* If the goto-def does not have valid loc info, we kick of the new gotometadata methods that will send another request with the returned metadata info to get the full metadata buffer.
* It is then saved into temp file and loaded. Subsequent requests should use the same file.
3. The code supports multiple ways of presenting the metadata via the `g:OmniSharp_lookup_metadata` option.
* If it is set to 'window' it will be a more traditional vscode like approach with the window you are currently editing in displaying the metadata found. Splitting if the current file has unsaved changes is still honored though.
* If it is set to 'preview' it will use the preview window.
* If it is set to a falsey value, metadata will not be looked up.
* It defaults to 'preview'
4. Going to defs inside a metadata file is supported, though no other file level `omnisharp-vim` functions work that I know of including type highlighting so you're stuck with the base vim highlighting. Not a huge loss as far as I'm concerned, but I will definitely look into it if requested.