### PR TITLE
Enforce OmniSharp server use utf-8 encoding. fix #487

### DIFF
--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -152,6 +152,9 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
     let command = insert(command, 'mono')
   endif
 
+  " Enforce OmniSharp server use utf-8 encoding.
+  let command += [ '-e', 'utf-8' ]
+
   return command
 endfunction
 


### PR DESCRIPTION
omnisharp server usually run with system default encoding, but function `json_decode()` only accept the string arg with utf-8 encoding.
simple case is call `iconv()` before `json_decode()`, but we don't know which encoding is system default encoding, because vim could changed encoding option in vimrc.
so we can enforce server process run with utf-8 encoding alway.
like #418 which do in python mode. this is a patch for stdio mode.

i test on my windows laptop when set vim encoding with utf-8 or system default.
i have not linux/osx with dotnet develop envirment, so i can't test on other system.
If an exception occurs, add a system check statement.