### PR TITLE
Remove py2 tests from appveyor

### DIFF
--- a/python/tox-appveyor.ini
+++ b/python/tox-appveyor.ini
@@ -9,7 +9,7 @@
 
 [tox]
 envlist =
-  py27,
+#  py27,
   py35,
   py36,
   py37


### PR DESCRIPTION
appveyor tests are failing with python2. These are running fine in
travis, and appveyor is successfully running the python3 tests so these
can be safely excluded from the appveyor suite.