### PR TITLE
Update diagnostic response handling

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -227,11 +227,18 @@ function! s:LocationsFromResponse(quickfixes) abort
       let location.end_lnum = quickfix.EndLine
       let location.end_col = quickfix.EndColumn - 1
     endif
-    let loglevel = get(quickfix, 'LogLevel', '')
-    if loglevel !=# ''
-      let location.type = loglevel ==# 'Error' ? 'E' : 'W'
-      if loglevel ==# 'Hidden'
-        let location.subtype = 'style'
+    if has_key(quickfix, 'LogLevel')
+      if quickfix.LogLevel ==# 'Error'
+        let location.type = 'E'
+      elseif quickfix.LogLevel ==# 'Warning'
+        let location.type = 'W'
+      elseif quickfix.LogLevel ==# 'Info'
+        let location.type = 'I'
+      else
+        " diagnostic responses with other LogLevels (i.e. 'hidden') should be
+        " excluded, so as not to be passed on to ALE/syntastic or included in
+        " GlobalCodeCheck results
+        continue
       endif
     endif
     call add(locations, location)

--- a/python/omnisharp/util.py
+++ b/python/omnisharp/util.py
@@ -137,9 +137,14 @@ def quickfixes_from_response(ctx, response):
             'vcol': 0
         }
         if 'LogLevel' in quickfix:
-            item['type'] = 'E' if quickfix['LogLevel'] == 'Error' else 'W'
-            if quickfix['LogLevel'] == 'Hidden':
-                item['subtype'] = 'Style'
+            if quickfix['LogLevel'] == 'Error':
+                item['type'] = 'E'
+            elif quickfix['LogLevel'] == 'Warning':
+                item['type'] = 'W'
+            elif quickfix['LogLevel'] == 'Info':
+                item['type'] = 'I'
+            else:
+                continue
 
         items.append(item)
 

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -182,11 +182,23 @@ def test_quickfixes_from_response(ctx):
 
     response = [
         {
-            'FileName': 'foo.cs',
             'Text': 'some text',
             'Line': 5,
             'Column': 8,
             'LogLevel': 'Hidden',
+        },
+    ]
+    qf = quickfixes_from_response(ctx, response)
+    expected = []
+    assert qf == expected
+
+    response = [
+        {
+            'FileName': 'foo.cs',
+            'Text': 'some text',
+            'Line': 5,
+            'Column': 8,
+            'LogLevel': 'Warning',
         },
     ]
     qf = quickfixes_from_response(ctx, response)
@@ -198,7 +210,28 @@ def test_quickfixes_from_response(ctx):
             'col': 8,
             'vcol': 0,
             'type': 'W',
-            'subtype': 'Style',
+        },
+    ]
+    assert qf == expected
+
+    response = [
+        {
+            'FileName': 'foo.cs',
+            'Text': 'some text',
+            'Line': 5,
+            'Column': 8,
+            'LogLevel': 'Info',
+        },
+    ]
+    qf = quickfixes_from_response(ctx, response)
+    expected = [
+        {
+            'filename': 'foo.cs',
+            'text': 'some text',
+            'lnum': 5,
+            'col': 8,
+            'vcol': 0,
+            'type': 'I',
         },
     ]
     assert qf == expected


### PR DESCRIPTION
Currently we output all diagnostics received from OmniSharp-roslyn.

'Error' diagnostics are reported as "E" errors (for ALE and Syntastic, and in `:OmniSharpGlobalCodeCheck` quickfix entries) and everything else is marked as a "W" warning. Server diagnostics marked as 'Hidden' are currently sent to ALE as "W" warnings with a `"sub_type": "style"`.

However, many of the "Hidden" diagnostics are not meant to be displayed, but merely used by editors for providing notifications that refactorings etc. are available. OmniSharp-vim doesn't make use of these, so "Hidden" diagnostics will be ignored.

Instead, "Info" diagnostics (previously simply converted to "W" warnings) are now marked as "I", meaning that ALE/Syntastic can style them differently. "Info" is how "suggestions" are reported, both from roslyn internals and from roslyn `editorconfig`.

This gives more flexibility for using `editorconfig` and `rulesets` to control diagnostics.

I had considered also providing an OmniSharp-vim level override system. At this stage I don't know whether it's necessary - it might be if we want to fine-tune options which can't be controlled by `editorconfig` (e.g. some diagnostics such as `IDE0010`), or if we again want a subset of diagnostics to be sent to ALE as `"sub_type": "style"`.

See https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/ide/editorconfig-code-style-settings-reference.md for `editorconfig` configuration details.