### PR TITLE
Improve reliability of the invocation of the installer scripts

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,10 +1,14 @@
 # OmniSharp Installers
+
 The OmniSharp installers are scripts that OmniSharp-vim uses to install the OmniSharp Roslyn server if it is not able to find it when opening a .cs file. There is a shell (.sh) version for Linux, macOS, & Cygwin/WSL and there is a PowerShell (.ps1) version for Windows.
 
-## omnisharp-manager PowerShell script
+## PowerShell
 
-### Usage Syntax
-> omnisharp-manager.ps1 [-v \<VersionNumber\>] [-l \<InstallLocation\>] [-u] [-H]
+### Usage
+
+```powershell
+.\omnisharp-manager.ps1 [-v \<VersionNumber\>] [-l \<InstallLocation\>] [-u] [-H]
+```
 
 Flags | Description
 ----- | -----------
@@ -14,34 +18,20 @@ Flags | Description
  -H | install the HTTP version of the server
 
 ### Output
+
 After downloading and installing the server the script will check for the `OmniSharp.Roslyn.dll` library in the install directory. If it locates the file an exit code of `0` will be returned. If it does not it will return a `1`. You can check exit codes in PowerShell by running `$LASTEXITCODE` in the console after running the script.
 
 ### Examples
+
 In PowerShell the following will install the v1.32.1 HTTP version of the OmniSharp Roslyn server in `\.omnisharp\omnisharp-roslyn` in the %USERPROFILE% directory:
 >`./omnisharp-manager.ps1 -v 'v1.32.1' -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"`
 
 *Note:* You must run this from the directory that contains the script to run it. This will vary but is typically `\omnisharp-vim\installer` inside the directory where your vim plugins are located.
-
-
-## PowerShell Restrictions
-By default PowerShell will prevent scripts being executed through what it terms its *Execution Policy*. But on Windows the `omnisharp-manager.ps1` script needs to execute to install the OmniSharp Roslyn server. In the __Install OmniSharp-roslyn with PowerShell__ section below there are instructions for changing your PowerShell Execution Policy and getting the latest version of the server installed. Alternatively, if you change your Power Execution Policy to Unrestricted using the first few steps below you can open a .cs file in Vim and OmniSharp-vim will offer to do the installation for you.
-
-### Install OmniSharp-roslyn with PowerShell
-1. Locate PowerShell in the Windows Start Menu
-1. Right-click and choose `Run as administrator`
-1. Use `Get-ExecutionPolicy -List` in PowerShell to verify and record your current settings
-1. Use `Set-ExecutionPolicy Unrestricted` to change your policy followed by `Y` to confirm
-1. Browse to the `\omnisharp-vim\installer` directory.
-	* It should be wherever your vim plugins are located
-1. Use `./omnisharp-manager.ps1 -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"` from that directory to install the server [fn 1]
-	* You can copy the command above and right-click will paste the clipboard into the PowerShell console
-1. Once this has completed you can use `Set-ExecutionPolicy {previous setting}` using the previous setting recorded earlier. [fn 2]
 
 > On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` file is in the expected directory. If it finds the file it will return and exit code of `0`. If it does not find the file it will return `1`. You can check exit codes in PowerShell by running `$LASTEXITCODE` in the console after running the script.
 
 ---
 
 #### Footnotes [fn \#]
-[1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.
 
-[2]: By default this setting is `Undefined`; which means the restriction may be determined elsewhere but defaults to `Restricted`. Setting to `RemoteSigned` on a typical setup will allow OmniSharp-vim to internally run the script in the future.  More at [About Execution Policies | Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-6)
+[1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,21 +1,42 @@
-# OmniSharp Installers
+# OmniSharp-Roslyn server management scripts
 
-The OmniSharp installers are scripts that OmniSharp-vim uses to install the OmniSharp Roslyn server if it is not able to find it when opening a .cs file. There is a shell (.sh) version for Linux, macOS, & Cygwin/WSL and there is a PowerShell (.ps1) version for Windows.
+The OmniSharp installer scripts are used by OmniSharp-vim to automate the installation and updating of the [OmniSharp-Rosyln server](https://github.com/OmniSharp/omnisharp-roslyn). There is a script for [Linux, macOS and Cygwin/WSL](#unix-like-oss), and another for [Microsoft Windows](#microsoft-windows).
 
-## PowerShell
+## Unix-like OSs
+
+_Works on: Linux, Apple macOS, Cygwin and Windows Subsystem for Linux._
 
 ### Usage
 
-```powershell
-.\omnisharp-manager.ps1 [-v \<VersionNumber\>] [-l \<InstallLocation\>] [-u] [-H]
+```
+./omnisharp-manager.sh [-v VERSION] [-l PATH] [-HMuh]
 ```
 
-Flags | Description
------ | -----------
- -v \<VersionNumber\> | version number of server to install (default: the latest version)
- -l \<InstallLocation\> | where to install the server (default: '%USERPROFILE%\\.omnisharp\')
- -u | help / usage info
- -H | install the HTTP version of the server
+| Option       | Description                                                                                 |
+|--------------|---------------------------------------------------------------------------------------------|
+| `-v VERSION` | Version number of the server to install (defaults to the latest verison).                   |
+| `-l PATH`    | Location to install the server to (defaults to `$HOME/.omnisharp/`).                        |
+| `-H`         | Install the HTTP variant of the server (if not given, the stdio variant will be installed). |
+| `-M`         | Use the system Mono installation rather than the one packaged with OmniSharp-Roslyn.        |
+| `-u`         | Display simple usage information.                                                           |
+| `-h`         | Display this help message.                                                                  |
+
+## Microsoft Windows
+
+_Works on: Microsoft Windows._
+
+### Usage
+
+```
+.\omnisharp-manager.ps1 [-v VERSION] [-l PATH] [-Hu]
+```
+
+| Option       | Description                                                                                 |
+|--------------|---------------------------------------------------------------------------------------------|
+| `-v VERSION` | Version number of server to install (defaults to the latest version).                       |
+| `-l PATH`    | Location to install the server to (defaults to `%USERPROFILE%\.omnisharp\`).                |
+| `-H`         | Install the HTTP variant of the server (if not given, the stdio variant will be installed). |
+| `-u`         | Display simple usage information.                                                           |
 
 ### Output
 
@@ -23,15 +44,9 @@ After downloading and installing the server the script will check for the `OmniS
 
 ### Examples
 
-In PowerShell the following will install the v1.32.1 HTTP version of the OmniSharp Roslyn server in `\.omnisharp\omnisharp-roslyn` in the %USERPROFILE% directory:
->`./omnisharp-manager.ps1 -v 'v1.32.1' -H -l "$env:USERPROFILE/.omnisharp/omnisharp-roslyn"`
+In PowerShell, the following will install version 1.32.1 of the HTTP OmniSharp Roslyn server in the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.
 
-*Note:* You must run this from the directory that contains the script to run it. This will vary but is typically `\omnisharp-vim\installer` inside the directory where your vim plugins are located.
-
-> On completion the `omnisharp-manager.ps1` script will check that the `OmniSharp.Roslyn.dll` file is in the expected directory. If it finds the file it will return and exit code of `0`. If it does not find the file it will return `1`. You can check exit codes in PowerShell by running `$LASTEXITCODE` in the console after running the script.
-
----
-
-#### Footnotes [fn \#]
-
-[1]: Each time a .cs file is opened the OmniSharp-vim plugin checks if OmniSharp Roslyn server is already installed. If not then it runs the `omnisharp-manager.ps1` script. It typically checks the `%USERPROFILE%\.omnisharp\omnisharp-roslyn` directory.
+```powershell
+cd "C:\Users\My Name\vimfiles\pack\plugins\opt\omnisharp-vim" # Navigate to the OmniSharp-vim plugin directory
+.\installer\omnisharp-manager.ps1 -v "v1.32.1" -H -l "$Env:USERPROFILE\.omnisharp\omnisharp-roslyn"
+```


### PR DESCRIPTION
This changeset properly fixes issues caused by PowerShell's "execution policy" feature, where is blocks the execution of scripts it doesn't deem as trustworthy.

Our PowerShell installation script for the OmniSharp-Roslyn server now is executed with the `-ExecutionPolicy Bypass` flag. This flag removes the need for user to manually perform a complex series of steps.

More info on execution policies can be found here: <https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies>

The code which performed the invocation of the PowerShell script has been made significantly simpler and easier to maintain by replacing the "quotation hell" with the much simpler `-File` argument.

The arguments for the scripts all now get correctly quoted and escaped before execution and paths now use the correct file path separators (i.e. `foo\bar` for Windows and `foo/bar` for *nix).

I am currently still working on another pull request which will add error logging and better error handling to the scripts.