### PR TITLE
Add note for required filetype statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Plug 'w0rp/ale'
 call plug#end()
 endif
 
+" Note: this is required for the plugin to work
 filetype indent plugin on
 
 " Use the stdio OmniSharp-roslyn server


### PR DESCRIPTION
The following line is required in the .vimrc file for the plugin (or any such plugin) to work:

``` .vimrc
filetype indent plugin on
```

This commit adds a comment to point that out.

Fixes #494