### PR TITLE
Run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ OmniSharp works on Windows, and on Linux and OS X with Mono.
 
 The plugin relies on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server, a .NET development platform used by several editors including Visual Studio Code, Emacs, Atom and others.
 
+## New! Run unit tests
+
+Using stdio mode, it is now possible to run unit tests via OmniSharp-roslyn, with success/failures listed in the quickfix window for easy navigation:
+
+```vim
+" Run the current unit test (the cursor should be inside the test method)
+:OmniSharpRunTest
+
+" Run all unit tests in the current file
+:OmniSharpRunTestsInFile
+
+" Run all unit tests in the current file, and file `tests/test1.cs`
+:OmniSharpRunTestsInFile % tests/test1.cs
+```
+
+Note that this unfortunately does _not_ work in translated WSL, due to the way OmniSharp-roslyn runs the tests.
+
 ## New! Asynchronous server interactions
 
 For vim8 and neovim, OmniSharp-vim can now use the OmniSharp-roslyn stdio server instead of the HTTP server, using pure vimscript (no python dependency!). All server operations are asynchronous and this results in a much smoother coding experience.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Then open vim to a .cs file and install the stdio server with `:OmniSharpInstall
   * Displays documentation for an entity when using preview window
 * Code error checking
 * Code formatter
+* Run unit tests and navigate to failing assertions
 
 ## Screenshots
 #### Auto Complete

--- a/README.md
+++ b/README.md
@@ -233,11 +233,13 @@ See the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki) for more custom 
 ## Semantic Highlighting
 OmniSharp-roslyn can provide highlighting information about every symbol of the document.
 
-To highlight a document, use command `:OmniSharpHighlightTypes`. To have `.cs` files automatically highlighted when entering a buffer or leaving insert mode, add this to your .vimrc:
+To highlight a document, use command `:OmniSharpHighlightTypes`. To have `.cs` files automatically highlighted after all text changes, add this to your .vimrc:
 
 ```vim
-let g:OmniSharp_highlight_types = 2
+let g:OmniSharp_highlight_types = 3
 ```
+
+This is a lot of highlighting - especially when running synchronously (not using stdio). To only update highlighting when entering a buffer or leaving insert mode, use `g:OmniSharp_highlight_types = 2` instead.
 
 ### Vim 8.1 text properties
 In (very) recent versions of Vim, the OmniSharp-roslyn highlighting can be taken full advantage of using Vim text properties, allowing OmniSharp-vim to overwrite the standard Vim regular-expression syntax highlighting with OmniSharp-roslyn's semantic highlighting.
@@ -366,8 +368,10 @@ set previewheight=5
 " Tell ALE to use OmniSharp for linting C# files, and no other linters.
 let g:ale_linters = { 'cs': ['OmniSharp'] }
 
+" Update semantic highlighting after all text changes
+let g:OmniSharp_highlight_types = 3
 " Update semantic highlighting on BufEnter and InsertLeave
-let g:OmniSharp_highlight_types = 2
+" let g:OmniSharp_highlight_types = 2
 
 augroup omnisharp_commands
     autocmd!

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -10,10 +10,11 @@ if !g:OmniSharp_server_stdio
 endif
 
 " Setup variable defaults
-let s:generated_snippets = {}
-let s:last_completion_dictionary = {}
-let s:alive_cache = []
-let s:initial_server_ports = copy(g:OmniSharp_server_ports)
+let s:generated_snippets = get(s:, 'generated_snippets', {})
+let s:last_completion_dictionary = get(s:, 'last_completion_dictionary', {})
+let s:alive_cache = get(s:, 'alive_cache', [])
+let s:initial_server_ports = get(s:, 'initial_server_ports',
+\ copy(g:OmniSharp_server_ports))
 
 function! OmniSharp#GetPort(...) abort
   if exists('g:OmniSharp_port')

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -951,7 +951,7 @@ endfunction
 
 function! s:RunTestsRH(Callback, tests, response, request) abort
   if !a:response.Success | return | endif
-  if !type(a:response.Body.Results) == type([])
+  if type(a:response.Body.Results) != type([])
     echohl WarningMsg
     echom 'Error: "'  . a:response.Body.Failure .
     \ '"   - this may indicate a failed build'

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -899,7 +899,6 @@ function! s:RunTestsInClass(Callback, codeElements) abort
     endif
   endfor
   let project = OmniSharp#GetHost().project
-  " TODO: handle different test frameworks
   let targetFramework = project.MsBuildProject.TargetFramework
   let opts = {
   \ 'ResponseHandler': function('s:RunTestsRH', [a:Callback, tests]),
@@ -933,7 +932,6 @@ function! s:RunTest(Callback, codeElements) abort
     return
   endif
   let project = OmniSharp#GetHost().project
-  " TODO: handle different test frameworks
   let targetFramework = project.MsBuildProject.TargetFramework
   let opts = {
   \ 'ResponseHandler': function('s:RunTestsRH', [a:Callback, tests]),

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -87,7 +87,7 @@ function! s:HandleServerEvent(job, res) abort
         for line in lines
           if get(a:res.Body, 'MessageLevel', '') ==# 'error'
             echohl WarningMsg | echomsg line | echohl None
-          elseif g:OmniSharp_runtests_echooutput
+          elseif g:OmniSharp_runtests_echo_output
             echomsg line
           endif
         endfor
@@ -975,7 +975,7 @@ function! s:RunTestsInFiles(Callback, bufferCodeStructures) abort
     return
   endif
   if g:OmniSharp_runtests_parallel
-    if g:OmniSharp_runtests_echooutput
+    if g:OmniSharp_runtests_echo_output
       echomsg '---- Running tests ----'
     endif
     call s:AwaitParallel(Requests, a:Callback)
@@ -985,7 +985,7 @@ function! s:RunTestsInFiles(Callback, bufferCodeStructures) abort
 endfunction
 
 function! s:RunTestsInFile(bufnr, tests, Callback) abort
-  if !g:OmniSharp_runtests_parallel && g:OmniSharp_runtests_echooutput
+  if !g:OmniSharp_runtests_parallel && g:OmniSharp_runtests_echo_output
     echomsg '---- Running tests: ' . bufname(a:bufnr) . ' ----'
   endif
   let project = OmniSharp#GetHost(a:bufnr).project

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -1,9 +1,9 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:nextseq = 1001
-let s:requests = {}
-let s:pendingRequests = {}
+let s:nextseq = get(s:, 'nextseq', 1001)
+let s:requests = get(s:, 'requests', {})
+let s:pendingRequests = get(s:, 'pendingRequests', {})
 
 function! s:HandleServerEvent(job, res) abort
   if has_key(a:res, 'Body') && type(a:res.Body) == type({})

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -340,9 +340,9 @@ convenient user re-mapping. These can be used like so: >
     If the test fails, the failure message and location will be displayed in
     the quickfix list.
 
-                                                      *:OmniSharpRunTestsInClass*
-                                           *<Plug>(omnisharp_run_tests_in_class)*
-:OmniSharpRunTestsInClass
+                                                       *:OmniSharpRunTestsInFile*
+                                            *<Plug>(omnisharp_run_tests_in_file)*
+:OmniSharpRunTestsInFile
     Run all unit tests in the current file. The quickfix list will be
     populated with the test results of all tests.
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -153,12 +153,14 @@ Example: >
     \}
 <
                                                   *'g:OmniSharp_highlight_types'*
-Enable automatic semantic type/interface/identifier highlighting.
+Enable automatic semantic highlighting.
 Default: 0 >
     " Highlight on BufEnter
     let g:OmniSharp_highlight_types = 1
     " Highlight on BufEnter and InsertLeave
     let g:OmniSharp_highlight_types = 2
+    " Highlight after all text changes (TextChanged,TextChangedI,TextChangedP)
+    let g:OmniSharp_highlight_types = 3
 <
                                                  *'g:OmniSharp_highlight_groups'*
 Specify which highlight groups should be used to highlight with

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -203,6 +203,22 @@ quickfix window being opened automatically.
 Default: 1 >
     let g:OmniSharp_open_quickfix = 0
 <
+                                             *'g:OmniSharp_runtests_echo_output'*
+When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|,
+echo all test runner output to the |message-history|, so it can be viewed with
+|:messages|.
+Default: 1
+
+                                                *'g:OmniSharp_runtests_parallel'*
+When running multiple unit test files with |:OmniSharpRunTestsInFile|, run
+tests in all files simultaneously - this is the fastest way to run multiple
+test files. The disadvantage is that when |g:OmniSharp_runtests_echo_output|
+is set to 1, tests from multiple files will be interspersed, and therefore
+difficult to read. Set |g:OmniSharp_runtests_parallel| to 0 in order to run
+test files in sequence instead, resulting in readable output in the
+|message-history|.
+Default: 1
+
                                                       *'g:OmniSharp_selector_ui'*
 Use this option to specify a selector UI for choosing code actions and
 navigating to symbols. When no selector UI plugin is detected, or
@@ -345,6 +361,14 @@ convenient user re-mapping. These can be used like so: >
 :OmniSharpRunTestsInFile
     Run all unit tests in the current file. The quickfix list will be
     populated with the test results of all tests.
+    Optionally accepts one or more filenames of files to run tests for.
+>
+    " Run all unit tests in the current file
+    :OmniSharpRunTestsInFile
+
+    " Run all unit tests in the current file, and file `tests/test1.cs`
+    :OmniSharpRunTestsInFile % tests/test1.cs
+<
 
                                                               *:OmniSharpOpenLog*
                                                      *<Plug>(omnisharp_open_log)*

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -331,6 +331,19 @@ convenient user re-mapping. These can be used like so: >
 :OmniSharpNavigateDown
     Navigates to next method or class
 
+                                                              *:OmniSharpRunTest*
+                                                     *<Plug>(omnisharp_run_test)*
+:OmniSharpRunTest
+    Run the current unit test. The cursor can be anywhere in the test method.
+    If the test fails, the failure message and location will be displayed in
+    the quickfix list.
+
+                                                      *:OmniSharpRunTestsInClass*
+                                           *<Plug>(omnisharp_run_tests_in_class)*
+:OmniSharpRunTestsInClass
+    Run all unit tests in the current file. The quickfix list will be
+    populated with the test results of all tests.
+
                                                               *:OmniSharpOpenLog*
                                                      *<Plug>(omnisharp_open_log)*
 :OmniSharpOpenLog

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -45,6 +45,8 @@ command! -buffer -bar OmniSharpRename                              call OmniShar
 command! -buffer -nargs=1 OmniSharpRenameTo                        call OmniSharp#RenameTo(<q-args>)
 command! -buffer -bar OmniSharpRestartAllServers                   call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer                       call OmniSharp#RestartServer()
+command! -buffer -bar OmniSharpRunTest                             call OmniSharp#RunTest()
+command! -buffer -bar OmniSharpRunTestsInClass                     call OmniSharp#RunTestsInClass()
 command! -buffer -bar OmniSharpSignatureHelp                       call OmniSharp#SignatureHelp()
 command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniSharp#StartServer(<q-args>)
 command! -buffer -bar OmniSharpStopAllServers                      call OmniSharp#StopAllServers()
@@ -71,6 +73,8 @@ nnoremap <buffer> <Plug>(omnisharp_preview_implementation) :OmniSharpPreviewImpl
 nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_server) :OmniSharpRestartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_all_servers) OmniSharpRestartAllServers<CR>
+nnoremap <buffer> <Plug>(omnisharp_runtest) :OmniSharpRunTest<CR>
+nnoremap <buffer> <Plug>(omnisharp_runtestsinclass) :OmniSharpRunTestsInClass<CR>
 nnoremap <buffer> <Plug>(omnisharp_signature_help) :OmniSharpSignatureHelp<CR>
 inoremap <buffer> <Plug>(omnisharp_signature_help) <C-\><C-o>:OmniSharpSignatureHelp<CR>
 nnoremap <buffer> <Plug>(omnisharp_start_server) :OmniSharpStartServer<CR>
@@ -115,6 +119,8 @@ let b:undo_ftplugin .= '
 \|  delcommand OmniSharpRenameTo
 \|  delcommand OmniSharpRestartAllServers
 \|  delcommand OmniSharpRestartServer
+\|  delcommand OmniSharpRunTest
+\|  delcommand OmniSharpRunTestsInClass
 \|  delcommand OmniSharpSignatureHelp
 \|  delcommand OmniSharpStartServer
 \|  delcommand OmniSharpStopAllServers

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -22,36 +22,36 @@ if get(g:, 'OmniSharp_start_server', 0) == 1
   call OmniSharp#StartServerIfNotRunning()
 endif
 
-command! -buffer -bar OmniSharpCodeFormat                          call OmniSharp#CodeFormat()
-command! -buffer -bar OmniSharpDocumentation                       call OmniSharp#TypeLookupWithDocumentation()
-command! -buffer -bar OmniSharpFindImplementations                 call OmniSharp#FindImplementations()
-command! -buffer -bar OmniSharpFindMembers                         call OmniSharp#FindMembers()
-command! -buffer -bar -nargs=? OmniSharpFindSymbol                 call OmniSharp#FindSymbol(<q-args>)
-command! -buffer -bar OmniSharpFindUsages                          call OmniSharp#FindUsages()
-command! -buffer -bar OmniSharpFixUsings                           call OmniSharp#FixUsings()
-command! -buffer -bar OmniSharpGetCodeActions                      call OmniSharp#GetCodeActions('normal')
-command! -buffer -bar OmniSharpGlobalCodeCheck                     call OmniSharp#GlobalCodeCheck()
-command! -buffer -bar OmniSharpGotoDefinition                      call OmniSharp#GotoDefinition()
-command! -buffer -bar -nargs=? OmniSharpInstall                    call OmniSharp#Install(<f-args>)
-command! -buffer -bar OmniSharpHighlightEchoKind                   call OmniSharp#HighlightEchoKind()
-command! -buffer -bar OmniSharpHighlightTypes                      call OmniSharp#HighlightBuffer()
-command! -buffer -bar OmniSharpNavigateUp                          call OmniSharp#NavigateUp()
-command! -buffer -bar OmniSharpNavigateDown                        call OmniSharp#NavigateDown()
-command! -buffer -bar OmniSharpOpenLog                             call OmniSharp#OpenLog()
-command! -buffer -bar OmniSharpOpenPythonLog                       call OmniSharp#OpenPythonLog()
-command! -buffer -bar OmniSharpPreviewDefinition                   call OmniSharp#PreviewDefinition()
-command! -buffer -bar OmniSharpPreviewImplementation               call OmniSharp#PreviewImplementation()
-command! -buffer -bar OmniSharpRename                              call OmniSharp#Rename()
-command! -buffer -nargs=1 OmniSharpRenameTo                        call OmniSharp#RenameTo(<q-args>)
-command! -buffer -bar OmniSharpRestartAllServers                   call OmniSharp#RestartAllServers()
-command! -buffer -bar OmniSharpRestartServer                       call OmniSharp#RestartServer()
-command! -buffer -bar OmniSharpRunTest                             call OmniSharp#RunTest()
-command! -buffer -bar OmniSharpRunTestsInClass                     call OmniSharp#RunTestsInClass()
-command! -buffer -bar OmniSharpSignatureHelp                       call OmniSharp#SignatureHelp()
+command! -buffer -bar OmniSharpCodeFormat call OmniSharp#CodeFormat()
+command! -buffer -bar OmniSharpDocumentation call OmniSharp#TypeLookupWithDocumentation()
+command! -buffer -bar OmniSharpFindImplementations call OmniSharp#FindImplementations()
+command! -buffer -bar OmniSharpFindMembers call OmniSharp#FindMembers()
+command! -buffer -bar -nargs=? OmniSharpFindSymbol call OmniSharp#FindSymbol(<q-args>)
+command! -buffer -bar OmniSharpFindUsages call OmniSharp#FindUsages()
+command! -buffer -bar OmniSharpFixUsings call OmniSharp#FixUsings()
+command! -buffer -bar OmniSharpGetCodeActions call OmniSharp#GetCodeActions('normal')
+command! -buffer -bar OmniSharpGlobalCodeCheck call OmniSharp#GlobalCodeCheck()
+command! -buffer -bar OmniSharpGotoDefinition call OmniSharp#GotoDefinition()
+command! -buffer -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
+command! -buffer -bar OmniSharpHighlightEchoKind call OmniSharp#HighlightEchoKind()
+command! -buffer -bar OmniSharpHighlightTypes call OmniSharp#HighlightBuffer()
+command! -buffer -bar OmniSharpNavigateUp call OmniSharp#NavigateUp()
+command! -buffer -bar OmniSharpNavigateDown call OmniSharp#NavigateDown()
+command! -buffer -bar OmniSharpOpenLog call OmniSharp#OpenLog()
+command! -buffer -bar OmniSharpOpenPythonLog call OmniSharp#OpenPythonLog()
+command! -buffer -bar OmniSharpPreviewDefinition call OmniSharp#PreviewDefinition()
+command! -buffer -bar OmniSharpPreviewImplementation call OmniSharp#PreviewImplementation()
+command! -buffer -bar OmniSharpRename call OmniSharp#Rename()
+command! -buffer -nargs=1 OmniSharpRenameTo call OmniSharp#RenameTo(<q-args>)
+command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
+command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()
+command! -buffer -bar OmniSharpRunTest call OmniSharp#RunTest()
+command! -buffer -bar -nargs=* -complete=file OmniSharpRunTestsInFile call OmniSharp#RunTestsInFile(<f-args>)
+command! -buffer -bar OmniSharpSignatureHelp call OmniSharp#SignatureHelp()
 command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniSharp#StartServer(<q-args>)
-command! -buffer -bar OmniSharpStopAllServers                      call OmniSharp#StopAllServers()
-command! -buffer -bar OmniSharpStopServer                          call OmniSharp#StopServer()
-command! -buffer -bar OmniSharpTypeLookup                          call OmniSharp#TypeLookupWithoutDocumentation()
+command! -buffer -bar OmniSharpStopAllServers call OmniSharp#StopAllServers()
+command! -buffer -bar OmniSharpStopServer call OmniSharp#StopServer()
+command! -buffer -bar OmniSharpTypeLookup call OmniSharp#TypeLookupWithoutDocumentation()
 
 nnoremap <buffer> <Plug>(omnisharp_code_format) :OmniSharpCodeFormat<CR>
 nnoremap <buffer> <Plug>(omnisharp_documentation) :OmniSharpDocumentation<CR>
@@ -74,7 +74,7 @@ nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_server) :OmniSharpRestartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_all_servers) OmniSharpRestartAllServers<CR>
 nnoremap <buffer> <Plug>(omnisharp_run_test) :OmniSharpRunTest<CR>
-nnoremap <buffer> <Plug>(omnisharp_run_tests_in_class) :OmniSharpRunTestsInClass<CR>
+nnoremap <buffer> <Plug>(omnisharp_run_tests_in_file) :OmniSharpRunTestsInFile<CR>
 nnoremap <buffer> <Plug>(omnisharp_signature_help) :OmniSharpSignatureHelp<CR>
 inoremap <buffer> <Plug>(omnisharp_signature_help) <C-\><C-o>:OmniSharpSignatureHelp<CR>
 nnoremap <buffer> <Plug>(omnisharp_start_server) :OmniSharpStartServer<CR>
@@ -120,7 +120,7 @@ let b:undo_ftplugin .= '
 \|  delcommand OmniSharpRestartAllServers
 \|  delcommand OmniSharpRestartServer
 \|  delcommand OmniSharpRunTest
-\|  delcommand OmniSharpRunTestsInClass
+\|  delcommand OmniSharpRunTestsInFile
 \|  delcommand OmniSharpSignatureHelp
 \|  delcommand OmniSharpStartServer
 \|  delcommand OmniSharpStopAllServers

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -73,8 +73,8 @@ nnoremap <buffer> <Plug>(omnisharp_preview_implementation) :OmniSharpPreviewImpl
 nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_server) :OmniSharpRestartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_all_servers) OmniSharpRestartAllServers<CR>
-nnoremap <buffer> <Plug>(omnisharp_runtest) :OmniSharpRunTest<CR>
-nnoremap <buffer> <Plug>(omnisharp_runtestsinclass) :OmniSharpRunTestsInClass<CR>
+nnoremap <buffer> <Plug>(omnisharp_run_test) :OmniSharpRunTest<CR>
+nnoremap <buffer> <Plug>(omnisharp_run_tests_in_class) :OmniSharpRunTestsInClass<CR>
 nnoremap <buffer> <Plug>(omnisharp_signature_help) :OmniSharpSignatureHelp<CR>
 inoremap <buffer> <Plug>(omnisharp_signature_help) <C-\><C-o>:OmniSharpSignatureHelp<CR>
 nnoremap <buffer> <Plug>(omnisharp_start_server) :OmniSharpStartServer<CR>

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -50,11 +50,7 @@ let g:OmniSharp_translate_cygwin_wsl = get(g:, 'OmniSharp_translate_cygwin_wsl',
 
 let g:OmniSharp_typeLookupInPreview = get(g:, 'OmniSharp_typeLookupInPreview', 0)
 
-let g:OmniSharp_BufWritePreSyntaxCheck = get(g:, 'OmniSharp_BufWritePreSyntaxCheck', 1)
-let g:OmniSharp_CursorHoldSyntaxCheck = get(g:, 'OmniSharp_CursorHoldSyntaxCheck', 0)
-
 let g:OmniSharp_sln_list_index = get(g:, 'OmniSharp_sln_list_index', -1)
-let g:OmniSharp_sln_list_name = get(g:, 'OmniSharp_sln_list_name', '')
 
 let g:OmniSharp_autoselect_existing_sln = get(g:, 'OmniSharp_autoselect_existing_sln', 1)
 let g:OmniSharp_prefer_global_sln = get(g:, 'OmniSharp_prefer_global_sln', 0)
@@ -69,6 +65,9 @@ let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', defaultlevel)
 " Default map of solution files and directories to ports.
 " Preserve backwards compatibility with older version "g:OmniSharp_sln_ports
 let g:OmniSharp_server_ports = get(g:, 'OmniSharp_server_ports', get(g:, 'OmniSharp_sln_ports', {}))
+
+let g:OmniSharp_runtests_parallel = get(g:, 'OmniSharp_runtests_parallel', 1)
+let g:OmniSharp_runtests_echooutput = get(g:, 'OmniSharp_runtests_echooutput', 1)
 
 " Initialise automatic type and interface highlighting
 let g:OmniSharp_highlight_types = get(g:, 'OmniSharp_highlight_types', 0)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -80,8 +80,15 @@ if g:OmniSharp_highlight_types
     \   call OmniSharp#HighlightBuffer() |
     \ endif
 
-    if g:OmniSharp_highlight_types == 2
+    if g:OmniSharp_highlight_types >= 2
       autocmd InsertLeave *.cs,*.csx
+      \ if OmniSharp#util#CheckCapabilities() |
+      \   call OmniSharp#HighlightBuffer() |
+      \ endif
+    endif
+
+    if g:OmniSharp_highlight_types >= 3
+      autocmd TextChanged,TextChangedI,TextChangedP *.cs,*.csx
       \ if OmniSharp#util#CheckCapabilities() |
       \   call OmniSharp#HighlightBuffer() |
       \ endif

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -23,7 +23,7 @@ if exists('g:OmniSharp_server_path')
 endif
 
 if !exists('g:OmniSharp_server_install')
-  " We should start by seeing if someone already has an install
+  " Check for existing server
   let dir_separator = fnamemodify('.', ':p')[-1 :]
   let install_parts = [expand('$HOME'), '.omnisharp', 'omnisharp-roslyn']
   let prior_install = join(install_parts, dir_separator)
@@ -31,7 +31,6 @@ if !exists('g:OmniSharp_server_install')
   if isdirectory(prior_install)
     let g:OmniSharp_server_install = prior_install
   else
-    " Neovim uses the XDG directory specification, so we should, too
     if has('win32')
       let cache_home_default = expand('$LOCALAPPDATA')
     else
@@ -67,7 +66,7 @@ let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', defaultlevel)
 let g:OmniSharp_server_ports = get(g:, 'OmniSharp_server_ports', get(g:, 'OmniSharp_sln_ports', {}))
 
 let g:OmniSharp_runtests_parallel = get(g:, 'OmniSharp_runtests_parallel', 1)
-let g:OmniSharp_runtests_echooutput = get(g:, 'OmniSharp_runtests_echooutput', 1)
+let g:OmniSharp_runtests_echo_output = get(g:, 'OmniSharp_runtests_echo_output', 1)
 
 " Initialise automatic type and interface highlighting
 let g:OmniSharp_highlight_types = get(g:, 'OmniSharp_highlight_types', 0)


### PR DESCRIPTION
This PR provides test running functionality, using the OmniSharp-rolsyn test runner.

There are 2 commands:

1. `:OmniSharpRunTest` which runs the test method that the cursor is inside.
2. `:OmniSharpRunTestsInFile` which runs all tests in the current file, or all files passed in as arguments

`:OmniSharpRunTest` prints a "success" message if the test succeeds, and if it fails, the failure location is added to the quickfix list. `:OmniSharpRunTestsInFile` _always_ popuplates the quickfix list with all tests, so successful tests can easily be seen listed alongside failures.

Tested "mstest", "nunit" and "xunit" in gVim in Windows10 and terminal Vim in arch linux.

**Major limitation**: This will _NOT_ work via WSL. This is due to the way that the tests are run by OmniSharp-roslyn, which uses `ProcessStartInfo` to start `dotnet` processes (`dotnet` is used even when targetting .NET Framework projects) - these simply fail silently when Vim is running in WSL.

Tasks:

- [X] Run single test with `:OmniSharpRunTest`
- [X] Run all tests in the current buffer with `:OmniSharpRunTestsInFile`
- [X] Run all tests in selected files in parallel with `:OmniSharpRunTestsInFile test1.cs test2.cs`
- [x] Add option to echo test log. Currently this is always on, but users may prefer to hide it.
- [x] Add option to run tests in sequence. Currently `:OmniSharpRunTestsInFile test1.cs test2.cs` runs the 2 test requests simultaneously, which means their logs are mixed together and hard to read.
- [x] Add extra documentation describing the new options, and showing an example of how to run tests in multiple files.

Closes #256