### PR TITLE
Added dot as trigger character for coc.nvim

### DIFF
--- a/autoload/coc/source/OmniSharp.vim
+++ b/autoload/coc/source/OmniSharp.vim
@@ -1,7 +1,8 @@
 function! coc#source#OmniSharp#init() abort
   return {
   \ 'shortcut': 'OS',
-  \ 'filetypes': ['cs']
+  \ 'filetypes': ['cs'],
+  \ 'triggerCharacters': ['.']
   \ }
 endfunction
 


### PR DESCRIPTION
Should fix the same problem as in https://github.com/OmniSharp/omnisharp-vim/issues/524, but for coc.nvim. I have no idea how this remained unnoticed. (Maybe there should be more triggerCharacters, i'm not really into C#)