### PR TITLE
Pass the correct number of arguments to preview

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -264,7 +264,7 @@ function! OmniSharp#PreviewDefinition(...) abort
   else
     let loc = OmniSharp#py#eval('gotoDefinition()')
     if OmniSharp#CheckPyError() | return | endif
-    call s:CBPreviewDefinition(loc)
+    call s:CBPreviewDefinition({}, loc, {})
   endif
 endfunction
 


### PR DESCRIPTION
Fix "E119: Not enough arguments for function: <SNR>326_CBPreviewDefinition" when doing `:OmniSharpPreviewDefinition`.

In 5813d6a0, more arguments were added to CBPreviewDefinition, but they
were only added in the OmniSharp_server_stdio call site. Add empty dicts
to the second callsite to provide the required number of arguments.

Using `let g:OmniSharp_server_stdio = 1`  doesn't work at all for me, but I assume that's because I'm on Win10 with gvim? I've never tried that version, so I can't tell if that code path is also broken, but it looks correct to me.