### PR TITLE
Don't use v:null in core code

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -1009,7 +1009,7 @@ endfunction
 function! OmniSharp#StartServerIfNotRunning(...) abort
   if OmniSharp#FugitiveCheck() | return | endif
   " Bail early in this check if the file is a metadata file
-  if type(get(b:, 'OmniSharp_metadata_filename', v:null)) == type('') | return | endif
+  if type(get(b:, 'OmniSharp_metadata_filename', 0)) == type('') | return | endif
   let sln_or_dir = a:0 ? a:1 : ''
   call OmniSharp#StartServer(sln_or_dir, 1)
 endfunction


### PR DESCRIPTION
Fix #563.

OmniSharp.vim is code still runs on old versions of vim, so avoid using
v:null to maintain compatibility with vim 7.4.

v:null also appears in stdio.vim, but that feature requires more recent
vim, so it's fine.