### PR TITLE
Return the correct type from GetStartCmd

### DIFF
--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -138,7 +138,7 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
         call OmniSharp#Install()
       else
         redraw
-        return
+        return []
       endif
     endif
   endif


### PR DESCRIPTION
Fix error "Can only compare List with List" in s:StartServer when
starting vim without omnisharp server installed and declining the
install.