### PR TITLE
Considering failing projects on server startup to prevent timeout.

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -40,6 +40,9 @@ function! s:HandleServerEvent(job, res) abort
             call add(a:job.loading, project)
           endif
           if message =~# '^Successfully loaded project' || message =~# '^Failed to load project'
+            if message[0] == 'F'
+              echom 'Failed to load project: ' . project
+            endif
             call filter(a:job.loading, {idx,val -> val !=# project})
             if len(a:job.loading) == 0
               if g:OmniSharp_server_display_loading

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -39,7 +39,7 @@ function! s:HandleServerEvent(job, res) abort
           if message =~# '^Queue project'
             call add(a:job.loading, project)
           endif
-          if message =~# '^Successfully loaded project'
+          if message =~# '^Successfully loaded project' || message =~# '^Failed to load project'
             call filter(a:job.loading, {idx,val -> val !=# project})
             if len(a:job.loading) == 0
               if g:OmniSharp_server_display_loading


### PR DESCRIPTION
For cross platform solutions the platform dependent projects can
fail to load. This commit prevents a timeout and therefor speeds
up the time until omnisharp becomes ready.