### PR TITLE
This changeset fixes syntax highlighting via text properties, if the text contains multi byte characters.

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -601,9 +601,11 @@ function! s:FindTextPropertiesRH(bufnum, buftick, response) abort
     endif
     if has_key(s:kindGroups, hl.Kind)
       try
-        call prop_add(hl.StartLine, hl.StartColumn, {
+        let start_col = s:TranslateVirtColToCol(a:bufnum, hl.StartLine, hl.StartColumn)
+        let end_col = s:TranslateVirtColToCol(a:bufnum, hl.EndLine, hl.EndColumn)
+        call prop_add(hl.StartLine, start_col, {
         \ 'end_lnum': hl.EndLine,
-        \ 'end_col': hl.EndColumn,
+        \ 'end_col': end_col,
         \ 'type': s:kindGroups[hl.Kind],
         \ 'bufnr': a:bufnum
         \})
@@ -627,6 +629,19 @@ function! s:FindTextPropertiesRH(bufnum, buftick, response) abort
       catch | endtry
     endif
   endfor
+endfunction
+
+" the vim prop_add api expects the column to be the byte offset and not
+" the character. so for multibyte characters this function returns the
+" byte offset for a given character
+function s:TranslateVirtColToCol(bufnum, lnum, vcol)
+  let buf_line = getbufline(a:bufnum, a:lnum)[0] . "\n"
+  let col = byteidx(buf_line, a:vcol)
+  " fallack if for some reason the translation did not work
+  if col < 0
+    let col = a:lnum
+  endif
+  return col
 endfunction
 
 function OmniSharp#stdio#HighlightEchoKind() abort


### PR DESCRIPTION
The `prop_add` api of vim expects the column to be the byte offset and
not the character count. So if a comment for example would contain
a multi byte character, for example a german umlaut, then the last
character of the comment would not be included in the text property.