### PR TITLE
Fixes the issue that only the first line of a multiline highlight has a text property set.

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -595,9 +595,9 @@ function! s:FindTextPropertiesRH(bufnum, buftick, response) abort
   endif
   let curline = 1
   for hl in highlights
-    if curline <= hl.StartLine
-      call prop_clear(curline, hl.StartLine, {'bufnr': a:bufnum})
-      let curline = hl.StartLine + 1
+    if curline <= hl.EndLine
+      call prop_clear(curline, hl.EndLine, {'bufnr': a:bufnum})
+      let curline = hl.EndLine + 1
     endif
     if has_key(s:kindGroups, hl.Kind)
       try


### PR DESCRIPTION
Since it seems impossible to get the total number of lines for a specific
buffer in vimscript, the current implementation clears the text
properties step by step with each new highlight.

When a highlight spans multiple lines and a there is another highlight
after it, the text properties of the previous multiline highlight are
being cleared.