### PR TITLE
Roll-back global g:OmniSharp dict usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,10 +365,10 @@ When a recent enough Vim or neovim is used, OmniSharp-vim will use Vim's popup w
 * completion documentation (Vim only)
 
 OmniSharp-vim will use popups by default for Vims/neovims which support them.
-To disable popups completely, set `g:OmniSharp.popup` to `0`:
+To disable popups completely, set `g:OmniSharp_popup` to `0`:
 
 ```vim
-let g:OmniSharp = { 'popup': 0 }
+let g:OmniSharp_popup = 0
 ```
 
 ### Popup mappings
@@ -394,18 +394,15 @@ Additionally, the signature-help popup window provides the following mappings fo
 | `sigParamNext` | `<C-l>`         |
 | `sigParamPrev` | `<C-h>`         |
 
-These mappings are all configurable, and you can configure more than one mapping for an action, so to use e.g. `CTRL-N` and `CTRL-P` to navigate between signatures instead of `CTRL-J` and `CTRL-K` and to use either `CTRL-E`/`CTRL-Y` or `j`/`k` for single line scrolling, use `g:OmniSharp.popup.mappings` like this:
+These mappings are all configurable, and you can assign more than one mapping for an action.
+So to use e.g. `CTRL-N` and `CTRL-P` to navigate between signatures instead of `CTRL-J` and `CTRL-K`, and to use either `CTRL-E`/`CTRL-Y` or `j`/`k` for single line scrolling, use `g:OmniSharp_popup_mappings` like this:
 
 ```vim
-let g:OmniSharp = {
-\ 'popup': {
-\   'mappings': {
-\     'sigNext': '<C-n>',
-\     'sigPrev': '<C-p>',
-\     'lineDown': ['<C-e>', 'j'],
-\     'lineUp': ['<C-y>', 'k']
-\   }
-\ }
+let g:OmniSharp_popup_mappings = {
+\ 'sigNext': '<C-n>',
+\ 'sigPrev': '<C-p>',
+\ 'lineDown': ['<C-e>', 'j'],
+\ 'lineUp': ['<C-y>', 'k']
 \}
 ```
 
@@ -422,7 +419,7 @@ By default, Vim uses the `Pmenu` highlight group, with no border or padding.
 Add a border and padding, and use the `Normal` highlight group like this:
 
 ```vim
-let g:OmniSharp.popup.options = {
+let g:OmniSharp_popup_options = {
 \ 'highlight': 'Normal',
 \ 'padding': [1],
 \ 'border': [1]
@@ -433,11 +430,11 @@ See the `:help` link above for options for border characters, border highlight g
 
 #### Popup styling for neovim
 
-The `g:OmniSharp.popup.options` dictionary is a set of window options which can be set for the popup.
+The `g:OmniSharp_popup_options` dictionary is a set of window options which can be set for the popup.
 Enable pseudo-transparency and change the highlight group from the default `NormalFloat` to `Normal` like this:
 
 ```vim
-let g:OmniSharp.popup.options = {
+let g:OmniSharp_popup_options = {
 \ 'winblend': 30,
 \ 'winhl': 'Normal:Normal'
 \}
@@ -446,7 +443,7 @@ let g:OmniSharp.popup.options = {
 ### Popup position
 
 The "documentation" popups (including signature help) are always opened as close as possible to the cursor.
-However "buffer" popups (previewing definitions and implementations) may be configured to open in different ways, using the `g:OmniSharp.popup.position` value:
+However "buffer" popups (previewing definitions and implementations) may be configured to open in different ways, using the `g:OmniSharp_popup_position` value:
 
 - `atcursor`: (default) Next to the cursor. Height expands to display as much as possible, so this may result in a very high window.
 - `peek`: Opens below or above the cursor, with the full width of the current window. Looks like a split, without altering window layout.

--- a/autoload/OmniSharp/popup.vim
+++ b/autoload/OmniSharp/popup.vim
@@ -1,8 +1,6 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let g:OmniSharp.popup = get(g:OmniSharp, 'popup', {})
-
 function! OmniSharp#popup#Buffer(bufnr, lnum, opts) abort
   let a:opts.firstline = a:lnum
   return s:Open(a:bufnr, a:opts)
@@ -28,9 +26,7 @@ function! OmniSharp#popup#Display(content, opts) abort
 endfunction
 
 function! OmniSharp#popup#Enabled() abort
-  if type(g:OmniSharp.popup) == type(0) && g:OmniSharp.popup == 0
-    return 0
-  endif
+  if get(g:, 'OmniSharp_popup', 1) == 0 | return 0 | endif
   if !exists('s:supports_popups')
     let s:supports_popups = 1
     if has('nvim')
@@ -50,9 +46,6 @@ function! OmniSharp#popup#Enabled() abort
   if !s:supports_popups
     return 0
   endif
-  if type(g:OmniSharp.popup) != type({})
-    let g:OmniSharp.popup = {}
-  endif
   return 1
 endfunction
 
@@ -60,7 +53,7 @@ endfunction
 " already exist. The mappings will be removed as soon as the popup window is
 " closed.
 function! OmniSharp#popup#Map(mode, mapName, defaultLHS, funcall) abort
-  let maps = get(g:OmniSharp.popup, 'mappings', {})
+  let maps = get(g:, 'OmniSharp_popup_mappings', {})
   let configLHS = get(maps, a:mapName, a:defaultLHS)
   if configLHS is 0 | return | endif
   for lhs in type(configLHS) == type([]) ? configLHS : [configLHS]
@@ -110,8 +103,8 @@ endfunction
 
 function s:InitialiseOptions(defaultOptions) abort
   if !exists('s:initialised')
-    let g:OmniSharp.popup.options = get(g:OmniSharp.popup, 'options', {})
-    call extend(g:OmniSharp.popup.options, a:defaultOptions, 'keep')
+    let g:OmniSharp_popup_options = get(g:, 'OmniSharp_popup_options', {})
+    call extend(g:OmniSharp_popup_options, a:defaultOptions, 'keep')
     let s:initialised = 1
   endif
 endfunction
@@ -147,7 +140,7 @@ endfunction
 
 function s:NvimGetOptions() abort
   call s:InitialiseOptions({})
-  return g:OmniSharp.popup.options
+  return g:OmniSharp_popup_options
 endfunction
 
 function! s:NvimOpen(what, opts) abort
@@ -160,7 +153,7 @@ function! s:NvimOpen(what, opts) abort
     let lines = a:what
   endif
   let content_height = len(lines)
-  let position = get(g:OmniSharp.popup, 'position', 'atcursor')
+  let position = get(g:, 'OmniSharp_popup_position', 'atcursor')
   let config = {
   \ 'focusable': v:false,
   \ 'style': 'minimal'
@@ -248,13 +241,13 @@ function s:VimGetOptions(opts) abort
   \ 'mapping': v:true,
   \ 'scrollbar': v:true
   \})
-  return extend(copy(g:OmniSharp.popup.options), a:opts)
+  return extend(copy(g:OmniSharp_popup_options), a:opts)
 endfunction
 
 function! s:VimOpen(what, opts) abort
   let popupOpts = s:VimGetOptions(a:opts)
   let popupOpts.callback = function('s:Unmap')
-  let position = get(g:OmniSharp.popup, 'position', 'atcursor')
+  let position = get(g:, 'OmniSharp_popup_position', 'atcursor')
   " Positions 'peek' and 'full' only apply to file buffers, not documentation
   " buffers
   if type(a:what) == v:t_number && position ==? 'peek'

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -16,6 +16,7 @@ CONTENTS                                                     *omnisharp-contents
     1. Dependencies.................................|omnisharp-dependencies|
     2. Usage........................................|omnisharp-usage|
     3. Options......................................|omnisharp-options|
+      3.1 Popups....................................|omnisharp-popup-options|
     4. Commands.....................................|omnisharp-commands|
     5. Autocmds.....................................|omnisharp-autocmds|
     6. Integrations.................................|omnisharp-integrations|
@@ -44,79 +45,62 @@ autocompletion plugin such as asyncomplete or Deoplete.
 ===============================================================================
 3. OPTIONS                                                    *omnisharp-options*
 
-                                                                  *'g:OmniSharp'*
-|g:OmniSharp| is the global configuration dictionary variable. Previously all
-configuration options have had their own global variables but these will be
-migrated to |g:OmniSharp|. All OmniSharp-vim configuration can be done with a
-single command: >
-    let g:OmniSharp = {
-    \ 'popup': {
-    \   'mappings': {
-    \     'close': 'jk'
-    \   }
-    \ }
-    \}
+-------------------------------------------------------------------------------
+3.1 POPUPS                                              *omnisharp-popup-options*
+
+                                                            *'g:OmniSharp_popup'*
+Disable popups entirely by setting to `0`: >
+Default: 1 >
+    let g:OmniSharp_popup = 0
 <
-Alternatively, create the empty dictionary first, then set subkeys afterwards.
-This documentation will assume this format has been used: >
-    let g:OmniSharp= {}
-    let g:OmniSharp.popup = {}
-    let g:OmniSharp.popup.mappings = {}
-    let g:OmniSharp.popup.mappings.close = 'jk'
-<
-                                                            *'g:OmniSharp.popup'*
-Dictionary to manage all popup configuration. Disable popups entirely by
-setting to `0`: >
-    let g:OmniSharp.popup = 0
-<
-                                                   *'g:OmniSharp.popup.mappings'*
+                                                   *'g:OmniSharp_popup_mappings'*
 Dictionary of popup action mappings.
 Defaults: >
-    let g:OmniSharp.popup = {}
-    let g:OmniSharp.popup.mappings = {}
-    let g:OmniSharp.popup.mappings.close =        '<Esc>'
-    let g:OmniSharp.popup.mappings.lineDown =     '<C-e>'
-    let g:OmniSharp.popup.mappings.lineUp =       '<C-y>'
-    let g:OmniSharp.popup.mappings.halfPageDown = '<C-d>'
-    let g:OmniSharp.popup.mappings.halfPageUp =   '<C-u>'
-    let g:OmniSharp.popup.mappings.pageDown =     '<C-f>'
-    let g:OmniSharp.popup.mappings.pageUp =       '<C-b>'
-    let g:OmniSharp.popup.mappings.sigNext =      '<C-j>'
-    let g:OmniSharp.popup.mappings.sigPrev =      '<C-k>'
-    let g:OmniSharp.popup.mappings.sigParamNext = '<C-l>'
-    let g:OmniSharp.popup.mappings.sigParamPrev = '<C-h>'
+    let g:OmniSharp_popup_mappings = {
+    \ 'close': '<Esc>',
+    \ 'lineDown': '<C-e>',
+    \ 'lineUp': '<C-y>',
+    \ 'halfPageDown': '<C-d>',
+    \ 'halfPageUp': '<C-u>',
+    \ 'pageDown': '<C-f>',
+    \ 'pageUp': '<C-b>',
+    \ 'sigNext': '<C-j>',
+    \ 'sigPrev': '<C-k>',
+    \ 'sigParamNext': '<C-l>',
+    \ 'sigParamPrev': '<C-h>'
+    \}
 <
 Apply multiple mappings by providing a list of mappings instead of a string: >
-    let g:OmniSharp.popup.mappings.close = ['<Esc>', 'jk']
+    let g:OmniSharp_popup_mappings = { 'close': ['<Esc>', 'jk'] }
 <
 Disable individual mappings by assigning an empty array: >
-    let g:OmniSharp.popup.mappings.sigNext = []
+    let g:OmniSharp_popup_mappings = { 'sigNext': [] }
 <
-                                                    *'g:OmniSharp.popup.options'*
+                                                    *'g:OmniSharp_popup_options'*
 Dictionary of popup display options. Note that these are different in Vim and
 Neovim.
 
-Vim: |g:OmniSharp.popup.options| are used as |popup_create-arguments| when
+Vim: |g:OmniSharp_popup_options| are used as |popup_create-arguments| when
 creating popups.
 Example: open popups with the |hl-Normal| highlight group (instead of the
 default |hl-Pmenu|), a border and padding: >
-    let g:OmniSharp.popup.options = {
+    let g:OmniSharp_popup_options = {
     \ 'highlight': 'Normal',
     \ 'padding': [1],
     \ 'border': [1]
     \}
 <
-Neovim: |g:OmniSharp.popup.options| is a dictionary of window options which
+Neovim: |g:OmniSharp_popup_options| is a dictionary of window options which
 are to be set for popup windows.
 Example: disable 'wrap', enable pseudo-transparency with 'winblend' and change
 the highlight group from the default |hl-NormalFloat| to |hl-Normal| like this: >
-    let g:OmniSharp.popup.options = {
+    let g:OmniSharp_popup_options = {
     \ 'wrap': v:false,
     \ 'winblend': 30,
     \ 'winhl': 'Normal:Normal'
     \}
 <
-                                                   *'g:OmniSharp.popup.position'*
+                                                   *'g:OmniSharp_popup_position'*
 How popups displaying file buffers (definition, implementation and metadata)
 should be positioned. Note that this does not include documentation and
 signature-help popups, which display text but not file buffers.
@@ -131,7 +115,7 @@ signature-help popups, which display text but not file buffers.
                     filling the entire Vim view, ignoring splits.
 
 Default: atcursor >
-    let g:OmniSharp.popup.position = 'peek'
+    let g:OmniSharp_popup_position = 'peek'
 <
                                                      *'g:OmniSharp_server_stdio'*
 Use the stdio version of OmniSharp-roslyn. When the stdio version is used,

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -92,10 +92,10 @@ default |hl-Pmenu|), a border and padding: >
 <
 Neovim: |g:OmniSharp_popup_options| is a dictionary of window options which
 are to be set for popup windows.
-Example: disable 'wrap', enable pseudo-transparency with 'winblend' and change
+Example: enable 'wrap', enable pseudo-transparency with 'winblend' and change
 the highlight group from the default |hl-NormalFloat| to |hl-Normal| like this: >
     let g:OmniSharp_popup_options = {
-    \ 'wrap': v:false,
+    \ 'wrap': v:true,
     \ 'winblend': 30,
     \ 'winhl': 'Normal:Normal'
     \}

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -1,10 +1,6 @@
 if exists('g:OmniSharp_loaded') | finish | endif
 let g:OmniSharp_loaded = 1
 
-" Single global config variable, to (eventually) replace all individual
-" global variables
-let g:OmniSharp = get(g:, 'OmniSharp', {})
-
 " Get a global temp path that can be used to store temp files for this instance
 let g:OmniSharp_temp_dir = get(g:, 'OmniSharp_temp_dir', fnamemodify(tempname(), ':p:h'))
 

--- a/test/utils/async-helper.vader
+++ b/test/utils/async-helper.vader
@@ -3,7 +3,7 @@ After():
 
 Execute (set up async helper):
   function! s:Callback(...)
-    let g:OmniSharp.test.waiting = 0
+    let g:OmniSharp_test_waiting = 0
   endfunction
 
   function! OmniSharpWarmup(funcname, args) abort
@@ -11,15 +11,15 @@ Execute (set up async helper):
   endfunction
 
   function! OmniSharpTestAwait(funcname, args, warmup = 0) abort
-    let g:OmniSharp.test.waiting = 1
+    let g:OmniSharp_test_waiting = 1
     call function(a:funcname, a:args + [function('s:Callback')])()
     let starttime = reltime()
-    while g:OmniSharp.test.waiting
-    \ && reltime(starttime)[0] < g:OmniSharp.test.timeout
+    while g:OmniSharp_test_waiting
+    \ && reltime(starttime)[0] < g:OmniSharp_test_timeout
       sleep 50m
     endwhile
     if !a:warmup
-      Assert !g:OmniSharp.test.waiting, a:funcname . ' timed out'
+      Assert !g:OmniSharp_test_waiting, a:funcname . ' timed out'
     endif
   endfunction
 

--- a/test/utils/startserver.vader
+++ b/test/utils/startserver.vader
@@ -1,11 +1,9 @@
 Execute (start server):
-  let g:OmniSharp = get(g:, 'OmniSharp', {})
-  let g:OmniSharp.test = get(g:OmniSharp, 'test', {})
-  let g:OmniSharp.test.timeout = get(g:OmniSharp.test, 'timeout', 10)
+  let g:OmniSharp_test_timeout = get(g:, 'OmniSharp_test_timeout', 10)
   edit! example/Program.cs
   let host = OmniSharp#GetHost()
   let job = OmniSharp#proc#GetJob(host.sln_or_dir)
-  while reltime(job.start_time)[0] < g:OmniSharp.test.timeout && !job.loaded
+  while reltime(job.start_time)[0] < g:OmniSharp_test_timeout && !job.loaded
     sleep 50m
   endwhile
   Assert job.loaded, 'Timed out waiting for job to load'

--- a/test/vimrc
+++ b/test/vimrc
@@ -23,7 +23,5 @@ let g:OmniSharp_selector_ui = ''
 let g:OmniSharp_open_quickfix = 0
 let g:OmniSharp_loglevel = 'info'
 
-let g:OmniSharp = {
-\ 'popup': 0,
-\ 'test': { 'timeout': 10 }
-\}
+let g:OmniSharp_popup = 0
+let g:OmniSharp_test_timeout = 10


### PR DESCRIPTION
I now think the global `g:OmniSharp` dict was ill-conceived.

The idea had been that we could have a single dictionary to contain _all_ OmniSharp-vim options. The benefit would have been a clean global environment, and a consistent place to look for configuration.

However there are several problems:

1. Users aren't used to this type of configuration, so the need to initialise the dictionary is strange and will trip up ... probably everybody.
2. Declaring the config dictionary as a single command is messy with lots of backslash line continutations, but declaring the dictionary and its sub-dictionaries separately is also extra boilerplate.
3. Discoverability is reduced, as Vim won't tab-complete dictionary contents. So it is no longer possible to do `:let g:OmniSharp_<Tab>` and find/edit options.

closes #580