### PR TITLE
Bugfix for disappearing empty lines while applying quickfixes.

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -341,7 +341,7 @@ function! s:MakeChanges(body) abort
         noautocmd normal! a<
       endif
       call cursor(change.EndLine, max([1, change.EndColumn - 1]))
-      if change.StartLine < change.EndLine && change.EndColumn == 1
+      if change.StartLine < change.EndLine && (change.EndColumn == 1 || len(getline('.')) == 0)
         " We can't delete before the first character of the line, so add an
         " extra charaqcter which will be immediately deleted again
         noautocmd normal! i>


### PR DESCRIPTION
This pull request fixes the issue, that empty lines were removed, while applying a quickfix. I used the following sample code to reproduce and fix the bug.

```
// Copyright © XYZ-Software, 2020

#region using directives

using System;

#endregion

namespace Project
{
    public static class Program
    {
        public static void Main(string[] args)
        {
            var myArray = new int[3];
            Console.WriteLine("Hello World");
            myArray.Any();
        }
    }
}
```

The cursor is placed on the `Any()` method call, and the first Quickfix is used. The response from omnisharp-roslyn looks like this:

```
{
    "Body": {
        "Changes": [
            {
                "Buffer": null,
                "Changes": [
                    {
                        "EndColumn": 2,
                        "EndLine": 8,
                        "NewText": "using System.Linq;\n\n#endregion\r\n",
                        "StartColumn": 1,
                        "StartLine": 6
                    }
                ],
                "FileName": "/Volumes/devel/playground/omniroslynnewline/Program.cs",
                "ModificationType": 0
            }
        ]
    },
    "Command": "/v2/runcodeaction",
    "Message": null,
    "Request_seq": 1280,
    "Running": true,
    "Seq": 37,
    "Success": true,
    "Type": "response"
}
```
I do not completly understand why `EndColumn` would be 2 in this case? Maybe because `\r\n` is used as delimiter for empty lines?