### PR TITLE
Added diagnostic filter for global code check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ See the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki/Highlighting-conf
 
 **Note:** Text property highlighting is only available when using the stdio server, not for HTTP server usage. Check the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki/Highlighting-configuration#legacy-highlighting) for how to highlight when using the HTTP server, or older Vim/neovims.
 
-## Diagnostic overrides
+## Diagnostics
 
 Diagnostics are returned from OmniSharp-roslyn in various ways - via linting plugins such as ALE or Syntastic, and using the `:OmniSharpGlobalCodeCheck` command.
 These diagnostics come from roslyn and roslyn analyzers, and as such they can be managed at the server level in 2 ways - using [rulesets](https://roslyn-analyzers.readthedocs.io/en/latest/config-analyzer.html), and using an [.editorconfig](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2019) file.
@@ -312,6 +312,15 @@ let g:OmniSharp_diagnostic_showid = 1
 ```
 
 *Note:* Diagnostic overrides are only available in stdio mode, not HTTP mode.
+
+Another method for filtering out diagnostic results is via path exclusion using `g:OmniSharp_diagnostic_exclude_paths`. This variable is a list of regular expressions that will exclude paths that have a match to any of its entries.
+```vim
+let g:OmniSharp_diagnostic_exclude_paths = [
+\ 'obj\\',
+\ '[Tt]emp\\',
+\ '\.nuget\\'
+\]
+```
 
 ## Popups
 

--- a/autoload/OmniSharp/actions/diagnostics.vim
+++ b/autoload/OmniSharp/actions/diagnostics.vim
@@ -70,16 +70,13 @@ function! s:DiagnosticQuickfixFixup(quickfix) abort
     endfor
   endif
 
-  let loglevel = get(a:quickfix, 'LogLevel', '')
-  if loglevel !=# ''
-    let overrides = get(g:, 'OmniSharp_diagnostic_overrides', {})
-    let diag_id = get(a:quickfix, 'Id', '-')
-    if index(keys(overrides), diag_id) >= 0
-      if overrides[diag_id].type ==? 'None'
-        return
-      endif
-      call extend(a:quickfix, overrides[diag_id])
+  let overrides = get(g:, 'OmniSharp_diagnostic_overrides', {})
+  let diag_id = get(a:quickfix, 'Id', '-')
+  if index(keys(overrides), diag_id) >= 0
+    if overrides[diag_id].type ==? 'None'
+      return
     endif
+    call extend(a:quickfix, overrides[diag_id])
   endif
 
   if get(g:, 'OmniSharp_diagnostic_showid') && has_key(a:quickfix, 'Id')

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -23,14 +23,20 @@ function! OmniSharp#locations#Navigate(location, noautocmds) abort
   endif
 endfunction
 
-function! OmniSharp#locations#Parse(quickfixes) abort
+function! s:DefaultFixup(quickfix) abort
+  return a:quickfix
+endfunction
+
+function! OmniSharp#locations#Parse(quickfixes, ...) abort
+  let Fixup = get(a:, 1, function("s:DefaultFixup"))
   let locations = []
-  let overrides = get(g:, 'OmniSharp_diagnostic_overrides', {})
   for quickfix in a:quickfixes
-    let text = get(quickfix, 'Text', get(quickfix, 'Message', ''))
-    if get(g:, 'OmniSharp_diagnostic_showid') && has_key(quickfix, 'Id')
-      let text = quickfix.Id . ': ' . text
+    let quickfix = Fixup(quickfix)
+    if type(quickfix) == 0
+      continue
     endif
+
+    let text = get(quickfix, 'Text', get(quickfix, 'Message', ''))
     if has_key(quickfix, 'FileName')
       let filename = OmniSharp#util#TranslatePathForClient(quickfix.FileName)
     else
@@ -43,19 +49,21 @@ function! OmniSharp#locations#Parse(quickfixes) abort
     \ 'col': quickfix.Column,
     \ 'vcol': 1
     \}
+
     if has_key(quickfix, 'EndLine') && has_key(quickfix, 'EndColumn')
       let location.end_lnum = quickfix.EndLine
       let location.end_col = quickfix.EndColumn - 1
     endif
-    let loglevel = get(quickfix, 'LogLevel', '')
-    if loglevel !=# ''
-      let diag_id = get(quickfix, 'Id', '-')
-      if index(keys(overrides), diag_id) >= 0
-        if overrides[diag_id].type ==? 'None'
-          continue
-        endif
-        call extend(location, overrides[diag_id])
-      else
+
+
+    if has_key(quickfix, 'type')
+      let location.type = get(quickfix, 'type')
+      if has_key(quickfix, 'subtype')
+        let location.subtype = get(quickfix, 'subtype')
+      endif
+    else
+      let loglevel = get(quickfix, 'LogLevel', '')
+      if loglevel !=# ''
         if loglevel ==# 'Error'
           let location.type = 'E'
         elseif loglevel ==# 'Info'
@@ -68,6 +76,7 @@ function! OmniSharp#locations#Parse(quickfixes) abort
         endif
       endif
     endif
+
     call add(locations, location)
   endfor
   return locations

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -23,15 +23,10 @@ function! OmniSharp#locations#Navigate(location, noautocmds) abort
   endif
 endfunction
 
-function! s:DefaultFixup(quickfix) abort
-  return a:quickfix
-endfunction
-
 function! OmniSharp#locations#Parse(quickfixes, ...) abort
-  let Fixup = get(a:, 1, function("s:DefaultFixup"))
   let locations = []
   for quickfix in a:quickfixes
-    let quickfix = Fixup(quickfix)
+    let quickfix = a:0 ? a:1(quickfix) : quickfix
     if type(quickfix) == 0
       continue
     endif

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -201,6 +201,18 @@ Example: >
     \ 'RemoveUnnecessaryImportsFixable': {'type': 'None'}
     \}
 <
+                                         *'g:OmniSharp_diagnostic_exclude_paths'*
+Add paths to be excluded from |:OmniSharpGlobalCodeCheck|. The variable is a
+list where each entry is a regular expression for matching paths to exclude.
+Default: []
+
+Example: >
+    let g:OmniSharp_diagnostic_exclude_paths = [
+    \ 'obj\\',
+    \ '[Tt]emp\\',
+    \ '\.nuget\\'
+    \]
+<
 -------------------------------------------------------------------------------
 3.3 HIGHLIGHTS                                      *omnisharp-highlight-options*
 


### PR DESCRIPTION
Adds support for #504 like so:
```
let g:OmniSharp_diagnostic_exclude_paths = [
\ 'obj\\',
\ 'Temp\\',
\ '\.nuget\\'
\]
```

Before:
![image](https://user-images.githubusercontent.com/8353400/86408992-aac20f80-bc7d-11ea-9fb4-5aa145945806.png)

After:
![image](https://user-images.githubusercontent.com/8353400/86409003-b1e91d80-bc7d-11ea-8d8c-7c3b73973aaa.png)
