### PR TITLE
Added OmniSharpFindType command.

### DIFF
--- a/autoload/OmniSharp/actions/symbols.vim
+++ b/autoload/OmniSharp/actions/symbols.vim
@@ -3,21 +3,22 @@ set cpoptions&vim
 
 function! OmniSharp#actions#symbols#Find(...) abort
   let filter = a:0 && a:1 isnot 0 ? a:1 : ''
+  let symbolfilter = a:0 == 2 ? a:2 : 'TypeAndMember'
   if !OmniSharp#IsServerRunning() | return | endif
   if g:OmniSharp_server_stdio
     let Callback = function('s:CBFindSymbol', [filter])
-    call s:StdioFind(filter, Callback)
+    call s:StdioFind(filter, symbolfilter, Callback)
   else
-    let locs = OmniSharp#py#Eval(printf('findSymbols(%s)', string(filter)))
+    let locs = OmniSharp#py#Eval(printf('findSymbols(%s, %s)', string(filter), string(symbolfilter)))
     if OmniSharp#py#CheckForError() | return | endif
     return s:CBFindSymbol(filter, locs)
   endif
 endfunction
 
-function! s:StdioFind(filter, Callback) abort
+function! s:StdioFind(filter, symbolfilter, Callback) abort
   let opts = {
   \ 'ResponseHandler': function('s:StdioFindRH', [a:Callback]),
-  \ 'Parameters': { 'Filter': a:filter }
+  \ 'Parameters': { 'Filter': a:filter, 'SymbolFilter': a:symbolfilter }
   \}
   call OmniSharp#stdio#Request('/findsymbols', opts)
 endfunction

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -424,6 +424,12 @@ convenient user re-mapping. These can be used like so: >
 :OmniSharpFindSymbol
     Fuzzy-search through symbols
 
+                                                           *:OmniSharpFindType*
+                                                 *<Plug>(omnisharp_find_type)*
+:OmniSharpFindType
+    Fuzzy-search through types. Better performance than OmniSharpFindSymbol in
+    a large codebase.
+
                                                            *:OmniSharpFindUsages*
                                                   *<Plug>(omnisharp_find_usages)*
 :OmniSharpFindUsages

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -31,6 +31,7 @@ command! -buffer -bar OmniSharpDocumentation call OmniSharp#actions#documentatio
 command! -buffer -bar OmniSharpFindImplementations call OmniSharp#actions#implementations#Find()
 command! -buffer -bar OmniSharpFindMembers call OmniSharp#actions#members#Find()
 command! -buffer -bar -nargs=? OmniSharpFindSymbol call OmniSharp#actions#symbols#Find(<q-args>)
+command! -buffer -bar -nargs=? OmniSharpFindType call OmniSharp#actions#symbols#Find(<q-args>, 'Type')
 command! -buffer -bar OmniSharpFindUsages call OmniSharp#actions#usages#Find()
 command! -buffer -bar OmniSharpFixUsings call OmniSharp#actions#usings#Fix()
 command! -buffer -bar OmniSharpGetCodeActions call OmniSharp#actions#codeactions#Get('normal')
@@ -54,6 +55,7 @@ nnoremap <buffer> <Plug>(omnisharp_documentation) :OmniSharpDocumentation<CR>
 nnoremap <buffer> <Plug>(omnisharp_find_implementations) :OmniSharpFindImplementations<CR>
 nnoremap <buffer> <Plug>(omnisharp_find_members) :OmniSharpFindMembers<CR>
 nnoremap <buffer> <Plug>(omnisharp_find_symbol) :OmniSharpFindSymbol<CR>
+nnoremap <buffer> <Plug>(omnisharp_find_type) :OmniSharpFindType<CR>
 nnoremap <buffer> <Plug>(omnisharp_find_usages) :OmniSharpFindUsages<CR>
 nnoremap <buffer> <Plug>(omnisharp_fix_usings) :OmniSharpFixUsings<CR>
 nnoremap <buffer> <Plug>(omnisharp_code_actions) :OmniSharpGetCodeActions<CR>
@@ -97,6 +99,7 @@ let b:undo_ftplugin .= '
 \| delcommand OmniSharpFindImplementations
 \| delcommand OmniSharpFindMembers
 \| delcommand OmniSharpFindSymbol
+\| delcommand OmniSharpFindType
 \| delcommand OmniSharpFindUsages
 \| delcommand OmniSharpFixUsings
 \| delcommand OmniSharpGetCodeActions

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -215,9 +215,10 @@ def fixUsings():
 
 
 @vimcmd
-def findSymbols(filter=''):
+def findSymbols(filter='', symbolfilter=''):
     parameters = {}
     parameters["filter"] = filter
+    parameters["symbolfilter"] = symbolfilter
     response = getResponse(ctx, '/findsymbols', parameters, json=True)
     return quickfixes_from_response(ctx, response['QuickFixes'])
 


### PR DESCRIPTION
This new command behaves exactly like OmniSharpFindSymbol, but only for types. The main motivation was improved performance. The SymbolFilter parameter in the /findsymbols endpoint got added with the merge of pull request [#1823](https://github.com/OmniSharp/omnisharp-roslyn/pull/1823). A version of omnisharp-roslyn with
this PR included needs to be installed.

I have **only** tested the stdio codepath so far.