### PR TITLE
Guard nulls in complete function

### DIFF
--- a/autoload/OmniSharp/actions/complete.vim
+++ b/autoload/OmniSharp/actions/complete.vim
@@ -100,6 +100,9 @@ function! s:StdioGetCompletionsRH(Callback, wantDocPopup, response) abort
       let menu = (cmp.ReturnType != v:null ? cmp.ReturnType . ' ' : '') .
       \ (cmp.DisplayText != v:null ? cmp.DisplayText : cmp.MethodHeader)
     endif
+    if word == v:null
+      continue
+    endif
     let completion = {
     \ 'snip': get(cmp, 'Snippet', ''),
     \ 'word': word,


### PR DESCRIPTION
Hi Nick! It's been a while, but I'm back to doing some C# development. I see you've been busy! This project is a lot better than the last time I used it.

I was setting up deoplete to use the omnifunc as a completion source, but hit a crash in the fuzzy matcher because one of the complete options had `None` for the word. I checked the OmniSharp complete handler, and sure enough there was a null word sneaking in somehow. From [the docs](http://vimdoc.sourceforge.net/htmldoc/insert.html#complete-functions), word is mandatory so I think the correct fix is to filter the null value here before returning it.