### PR TITLE
Use `range` option for codeactions

### DIFF
--- a/autoload/OmniSharp/actions/codeactions.vim
+++ b/autoload/OmniSharp/actions/codeactions.vim
@@ -97,7 +97,7 @@ function! s:CBCountCodeActions(opts, actions) abort
 endfunction
 
 
-function! OmniSharp#actions#codeactions#Get(mode) abort
+function! OmniSharp#actions#codeactions#Get(mode) range abort
   if exists('s:actions')
     call s:CBGetCodeActions(a:mode, s:actions)
   elseif g:OmniSharp_server_stdio


### PR DESCRIPTION
This prevents the code action buffer to spawn multiple times if the GetCodeActions command was used from a multiline visual selection.

Fixes #637