### PR TITLE
Display signatures in OmniSharpFindMembers (stdio only)

### DIFF
--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -63,7 +63,7 @@ function! s:ComputeItemSignature(item) abort
   endif
   let line   = a:item.Ranges.name.Start.Line
   let endcol = a:item.Ranges.name.Start.Column - 2
-  let textBeforeDisplayName = trim(getline(line)[:endcol], " \t", 1)
+  let textBeforeDisplayName = substitute(getline(line)[:endcol], '^\s*', '', '')
   if textBeforeDisplayName !~# '^\(private\|internal\|protected\|public\)'
     let textBeforeDisplayName = a:item.Properties.accessibility . ' ' . textBeforeDisplayName
   endif

--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -64,7 +64,20 @@ function! s:ComputeItemSignature(item) abort
   if textBeforeDisplayName !~# '^\(private\|internal\|protected\|public\)'
     let textBeforeDisplayName = a:item.Properties.accessibility . ' ' . textBeforeDisplayName
   endif
-  return textBeforeDisplayName . a:item.DisplayName
+  return ReduceToOneCharacter(textBeforeDisplayName) . a:item.DisplayName
+endfunction
+
+let s:SingleCharacterSymbolByAccessModifier = {
+ \ 'public': '+',
+ \ 'private': '-',
+ \ 'internal': '&',
+ \ 'protected': '|'
+\}
+
+function! ReduceToOneCharacter(textBeforeDisplayName) abort
+  let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
+  let accessModifierLen = len(accessModifier)
+  return s:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
 endfunction
 
 function! s:CBFindMembers(opts, locations) abort

--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -58,6 +58,9 @@ function! s:ParseCodeStructureItem(item, filename) abort
 endfunction
 
 function! s:ComputeItemSignature(item) abort
+  if type(a:item.Properties) != type({})
+    return get(a:item, 'Kind', '') . ' ' . a:item.DisplayName
+  endif
   let line   = a:item.Ranges.name.Start.Line
   let endcol = a:item.Ranges.name.Start.Column - 2
   let textBeforeDisplayName = trim(getline(line)[:endcol], " \t", 1)
@@ -77,13 +80,13 @@ let s:SingleCharacterSymbolByAccessModifier = {
 function! ReduceToOneCharacter(textBeforeDisplayName) abort
   let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
   let accessModifierLen = len(accessModifier)
-  return '['.s:SingleCharacterSymbolByAccessModifier[accessModifier].']' . a:textBeforeDisplayName[accessModifierLen:]
+  return s:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
 endfunction
 
 function! s:CBFindMembers(opts, locations) abort
   let numMembers = len(a:locations)
   if numMembers > 0
-    call OmniSharp#locations#SetQuickfix(a:locations, 'Members')
+    call OmniSharp#locations#SetQuickfixWithVerticalAlign(a:locations, 'Members')
   endif
   if has_key(a:opts, 'Callback')
     call a:opts.Callback(numMembers)

--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -77,7 +77,7 @@ let s:SingleCharacterSymbolByAccessModifier = {
 function! ReduceToOneCharacter(textBeforeDisplayName) abort
   let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
   let accessModifierLen = len(accessModifier)
-  return s:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
+  return '['.s:SingleCharacterSymbolByAccessModifier[accessModifier].']' . a:textBeforeDisplayName[accessModifierLen:]
 endfunction
 
 function! s:CBFindMembers(opts, locations) abort

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -55,15 +55,59 @@ function! OmniSharp#locations#Preview(location) abort
   endif
 endfunction
 
-function! OmniSharp#locations#SetQuickfix(list, title)
+function! OmniSharp#locations#SetQuickfix(list, title) abort
+  call s:SetQuickfixFromDict(a:list, {'title': a:title})
+endfunction
+
+function! OmniSharp#locations#SetQuickfixWithVerticalAlign(list, title) abort
+  call s:SetQuickfixFromDict(a:list, {'title': a:title, 'quickfixtextfunc': 's:QuickfixVerticalAlignFunction'})
+endfunction
+
+function! s:SetQuickfixFromDict(list, dict) abort
   if !has('patch-8.0.0657')
-  \ || setqflist([], ' ', {'nr': '$', 'items': a:list, 'title': a:title}) == -1
-    call setqflist(a:list)
+  \ || setqflist([], ' ', {'nr': '$', 'items': a:list, 'title': get(a:dict, 'title', 'OmniSharp')}) == -1
+    call setqflist(a:list, ' ', a:dict)
   endif
   silent doautocmd <nomodeline> QuickFixCmdPost OmniSharp
   if g:OmniSharp_open_quickfix
     botright cwindow
   endif
+endfunction
+
+function! s:QuickfixVerticalAlignFunction(info) abort
+	if a:info.quickfix
+		let qfl = getqflist({'id': a:info.id, 'items': 0}).items
+	else
+		let qfl = getloclist(a:info.winid, {'id': a:info.id, 'items': 0}).items
+	endif
+	let l = []
+	let efm_type = {'e': 'error', 'w': 'warning', 'i': 'info', 'n': 'note'}
+	let lnum_width =   len(max(map(range(a:info.start_idx - 1, a:info.end_idx - 1), { _,v -> qfl[v].lnum })))
+	let col_width =    len(max(map(range(a:info.start_idx - 1, a:info.end_idx - 1), {_, v -> qfl[v].col})))
+	let fname_width =  max(map(range(a:info.start_idx - 1, a:info.end_idx - 1), {_, v -> strchars(fnamemodify(bufname(qfl[v].bufnr), ':t'), 1)}))
+	let type_width =   max(map(range(a:info.start_idx - 1, a:info.end_idx - 1), {_, v -> strlen(get(efm_type, qfl[v].type, ''))}))
+	let errnum_width = len(max(map(range(a:info.start_idx - 1, a:info.end_idx - 1),{_, v -> qfl[v].nr})))
+	for idx in range(a:info.start_idx - 1, a:info.end_idx - 1)
+		let e = qfl[idx]
+		if !e.valid
+			call add(l, '|| ' .. e.text)
+		else
+			if e.lnum == 0 && e.col == 0
+				call add(l, bufname(e.bufnr))
+			else
+				let fname = fnamemodify(printf('%-*S', fname_width, bufname(e.bufnr)), ':t')
+				let lnum = printf('%*d', lnum_width, e.lnum)
+				let col = printf('%*d', col_width, e.col)
+				let type = printf('%-*S', type_width, get(efm_type, e.type, ''))
+				let errnum = ''
+				if e.nr
+					let errnum = printf('%*d', errnum_width + 1, e.nr)
+				endif
+				call add(l, printf('%s|%s col %s %s%s| %s', fname, lnum, col, type, errnum, e.text))
+			endif
+		endif
+	endfor
+	return l
 endfunction
 
 let &cpoptions = s:save_cpo


### PR DESCRIPTION
We are using the `v2/codestructure` endpoint instead of the
`/currentfilemembersasflat` endpoint here. The DisplayName of each item
in the response (elements and their children) contains the signature but
not the output type nor the modifiers like static/public/override etc.
so we are simply copying the beginning of the line in order to include
these.

Closes #609 