### PR TITLE
Update the signature help on `TextChangedI`

### DIFF
--- a/autoload/OmniSharp/actions/signature.vim
+++ b/autoload/OmniSharp/actions/signature.vim
@@ -5,9 +5,6 @@ let s:seq = get(s:, 'seq', 0)
 
 function! OmniSharp#actions#signature#SignatureHelp(...) abort
   let opts = a:0 ? a:1 : {}
-  if exists('#OmniSharp_signature_help_insert')
-    autocmd! OmniSharp_signature_help_insert
-  endif
   augroup OmniSharp_signature_help_insert
     autocmd!
     autocmd TextChangedI <buffer>

--- a/autoload/OmniSharp/actions/signature.vim
+++ b/autoload/OmniSharp/actions/signature.vim
@@ -7,8 +7,13 @@ function! OmniSharp#actions#signature#SignatureHelp(...) abort
   let opts = a:0 ? a:1 : {}
   augroup OmniSharp_signature_help_insert
     autocmd!
+    " Update the signature help box when new text is inserted.
     autocmd TextChangedI <buffer>
     \ call  OmniSharp#actions#signature#SignatureHelp()
+
+    " Remove this augroup when leaving insert mode
+    autocmd InsertLeave <buffer>
+    \ autocmd! OmniSharp_signature_help_insert
   augroup END
   if g:OmniSharp_server_stdio
     call s:StdioSignatureHelp(function('s:CBSignatureHelp', [opts]), opts)

--- a/autoload/OmniSharp/actions/signature.vim
+++ b/autoload/OmniSharp/actions/signature.vim
@@ -5,6 +5,14 @@ let s:seq = get(s:, 'seq', 0)
 
 function! OmniSharp#actions#signature#SignatureHelp(...) abort
   let opts = a:0 ? a:1 : {}
+  if exists('#OmniSharp_signature_help_insert')
+    autocmd! OmniSharp_signature_help_insert
+  endif
+  augroup OmniSharp_signature_help_insert
+    autocmd!
+    autocmd TextChangedI <buffer>
+    \ call  OmniSharp#actions#signature#SignatureHelp()
+  augroup END
   if g:OmniSharp_server_stdio
     call s:StdioSignatureHelp(function('s:CBSignatureHelp', [opts]), opts)
   else

--- a/autoload/OmniSharp/actions/signature.vim
+++ b/autoload/OmniSharp/actions/signature.vim
@@ -5,16 +5,18 @@ let s:seq = get(s:, 'seq', 0)
 
 function! OmniSharp#actions#signature#SignatureHelp(...) abort
   let opts = a:0 ? a:1 : {}
-  augroup OmniSharp_signature_help_insert
-    autocmd!
-    " Update the signature help box when new text is inserted.
-    autocmd TextChangedI <buffer>
-    \ call  OmniSharp#actions#signature#SignatureHelp()
+  if !has_key(opts, 'ForCompleteMethod')
+    augroup OmniSharp_signature_help_insert
+      autocmd!
+      " Update the signature help box when new text is inserted.
+      autocmd TextChangedI <buffer>
+      \ call  OmniSharp#actions#signature#SignatureHelp()
 
-    " Remove this augroup when leaving insert mode
-    autocmd InsertLeave <buffer>
-    \ autocmd! OmniSharp_signature_help_insert
-  augroup END
+      " Remove this augroup when leaving insert mode
+      autocmd InsertLeave <buffer>
+      \ autocmd! OmniSharp_signature_help_insert
+    augroup END
+  endif
   if g:OmniSharp_server_stdio
     call s:StdioSignatureHelp(function('s:CBSignatureHelp', [opts]), opts)
   else


### PR DESCRIPTION
It is useful to update the signature help as new text is inserted since
it will:

* Show the most relevant overload.
* Show documentation for the currently active argument.