### PR TITLE
Completion without overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ Install the Vim plugin using your preferred plugin manager:
 | [Vim 8.0+ Native packages](http://vimhelp.appspot.com/repeat.txt.html#packages) | `$ git clone git://github.com/OmniSharp/omnisharp-vim ~/.vim/pack/plugins/start/omnisharp-vim` |
 | [Pathogen](https://github.com/tpope/vim-pathogen)    | `$ git clone git://github.com/OmniSharp/omnisharp-vim ~/.vim/bundle/omnisharp-vim`     |
 
-If not using a plugin manager such as Vim-plug (which does this automatically), make sure your .vimrc contains this line:
+If not using a plugin manager such as Vim-plug (which does this automatically), make sure your .vimrc contains these lines:
 
 ```vim
 filetype indent plugin on
+syntax enable
 ```
 
 ### Server

--- a/autoload/OmniSharp/actions/complete.vim
+++ b/autoload/OmniSharp/actions/complete.vim
@@ -95,6 +95,9 @@ function! s:StdioGetCompletionsRH(Callback, wantDocPopup, response) abort
     if g:OmniSharp_want_snippet
       let word = cmp.MethodHeader != v:null ? cmp.MethodHeader : cmp.CompletionText
       let menu = cmp.ReturnType != v:null ? cmp.ReturnType : cmp.DisplayText
+    elseif g:OmniSharp_completion_without_overloads
+      let word = cmp.CompletionText
+      let menu = ''
     else
       let word = cmp.CompletionText != v:null ? cmp.CompletionText : cmp.MethodHeader
       let menu = (cmp.ReturnType != v:null ? cmp.ReturnType . ' ' : '') .
@@ -108,7 +111,7 @@ function! s:StdioGetCompletionsRH(Callback, wantDocPopup, response) abort
     \ 'word': word,
     \ 'menu': menu,
     \ 'icase': 1,
-    \ 'dup': 1
+    \ 'dup': g:OmniSharp_completion_without_overloads ? 0 : 1
     \}
     if a:wantDocPopup
       let completion.info = cmp.MethodHeader . "\n ..."

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -383,6 +383,15 @@ Use this option to enable snippet completion, when ultisnips is available.
 Default: 0 >
     let g:OmniSharp_want_snippet = 0
 <
+                                       *g:OmniSharp_completion_without_overloads*
+Use this option to get completion results without method arguments. Consequently,
+overloads will not be part of the completion results. For this feature to be 
+enabled it is required that g:OmniSharp_want_snippet is set to 0; the two options
+contradict each other and if both are enabled, g:OmniSharp_want_snippet takes
+precedence.
+Default: 0 >
+    let g:OmniSharp_completion_without_overloads = 0
+<
                                                         *g:syntastic_cs_checkers*
 Use this option to enable syntastic integration >
     let g:syntastic_cs_checkers = ['code_checker']

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -41,6 +41,9 @@ let g:OmniSharp_runtests_echo_output = get(g:, 'OmniSharp_runtests_echo_output',
 " Set to 1 when ultisnips is installed
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
 
+" Only has effect if OmniSharp_want_snippet is 0.
+let g:OmniSharp_completion_without_overloads = get(g:, 'OmniSharp_completion_without_overloads', 0)
+
 let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_documentation', 1)
 
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)

--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -66,6 +66,9 @@ def getCompletions(partialWord):
     want_snippet = \
         bool(int(vim.eval('g:OmniSharp_want_snippet')))
 
+    without_overloads = \
+        bool(int(vim.eval('g:OmniSharp_completion_without_overloads')))
+
     parameters['WantSnippet'] = want_snippet
     parameters['WantMethodHeader'] = True
     parameters['WantReturnType'] = True
@@ -78,6 +81,9 @@ def getCompletions(partialWord):
             if want_snippet:
                 word = cmp['MethodHeader'] or cmp['CompletionText']
                 menu = cmp['ReturnType'] or cmp['DisplayText']
+            elif without_overloads:
+                word = cmp['CompletionText']
+                menu = ''
             else:
                 word = cmp['CompletionText'] or cmp['MethodHeader']
                 menu = cmp['DisplayText'] or cmp['MethodHeader']
@@ -90,7 +96,7 @@ def getCompletions(partialWord):
                 'info': ((cmp['Description'] or ' ')
                          .replace('\r\n', '\n')),
                 'icase': 1,
-                'dup': 1
+                'dup': without_overloads ? 0 : 1
             })
     return vim_completions
 


### PR DESCRIPTION
It can be nice to have fewer options to scroll through in a completion list. With these changes it is possible to indicate a preference for completion results without overloads. The way this is achieved is by ignoring the method signature in the completion results and only showing the method name. That, together with a `dup: 0` setting on the completion result filters down the completion list significantly. 