### PR TITLE
Fix ALE HTTP mode bug

### DIFF
--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -42,7 +42,7 @@ call ale#linter#Define('cs', {
 \   'name': 'omnisharp',
 \   'aliases': ['Omnisharp', 'OmniSharp'],
 \   'executable': 'python',
-\   'command_callback': 'ale_linters#cs#omnisharp#GetCommand',
+\   'command': function('ale_linters#cs#omnisharp#GetCommand'),
 \   'callback': 'ale_linters#cs#omnisharp#ProcessOutput',
 \})
 


### PR DESCRIPTION
dense-analysis/ale@5eda1df0a96e691ebf24e5d8a3585c2feb2a48a3 removed some deprecated ALE features and in doing so broke OmniSharp-Vim's HTTP integration.