### PR TITLE
Fix Python ternary syntax error

### DIFF
--- a/python/omnisharp/commands.py
+++ b/python/omnisharp/commands.py
@@ -96,7 +96,7 @@ def getCompletions(partialWord):
                 'info': ((cmp['Description'] or ' ')
                          .replace('\r\n', '\n')),
                 'icase': 1,
-                'dup': without_overloads ? 0 : 1
+                'dup': 0 if without_overloads else 1
             })
     return vim_completions
 


### PR DESCRIPTION
Introduced by bd2c1a7fedf795f792016548fb768d91bf22a768.