### PR TITLE
bugfix(installer): 'chmod: cannot access'

### DIFF
--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -144,7 +144,7 @@ fi
 set -eu
 if [ "$ext" = "zip" ]; then
     unzip "$download_location/$file_name" -d "$download_location/"
-    chmod +x $(find "$download_location" -type f)
+    find "$download_location" -type f -exec chmod +x {} +
 else
     tar -zxvf "$download_location/$file_name" -C "$download_location/"
 fi
@@ -155,7 +155,7 @@ set +eu
 
 # If using the system Mono, make the files executable
 if [ -n "$mono" ] && [ $mono -eq 1 ]; then
-    chmod +x $(find "$location" -type f)
+    find "$location" -type f -exec chmod +x {} +
 fi
 
 echo "$version" > "$location/OmniSharpInstall-version.txt"


### PR DESCRIPTION
I got an error when the file path contains whitespace, so I fixed it.

install.log
```
chmod: cannot access '/mnt/c/Users/FOO': No such file or directory
chmod: cannot access 'BAR/AppData/Local/omnisharp-vim/omnisharp-roslyn-v1.37.5/.msbuild/Current/Bin/Microsoft.Bcl.AsyncInterfaces.dll': No such file or directory
chmod: cannot access '/mnt/c/Users/FOO': No such file or directory
chmod: cannot access 'BAR/AppData/Local/omnisharp-vim/omnisharp-roslyn-v1.37.5/.msbuild/Current/Bin/Microsoft.Build.dll': No such file or directory
chmod: cannot access '/mnt/c/Users/FOO': No such file or directory
chmod: cannot access 'BAR/AppData/Local/omnisharp-vim/omnisharp-roslyn-v1.37.5/.msbuild/Current/Bin/Microsoft.Build.Framework.dll': No such file or directory
chmod: cannot access '/mnt/c/Users/FOO': No such file or directory
chmod: cannot access 'BAR/AppData/Local/omnisharp-vim/omnisharp-roslyn-v1.37.5/.msbuild/Current/Bin/Microsoft.Build.Framework.tlb': No such file or directory
...
```