### PR TITLE
Add OmniSharpOpenAllUsages command

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ augroup omnisharp_commands
   " The following commands are contextual, based on the cursor position.
   autocmd FileType cs nmap <silent> <buffer> gd <Plug>(omnisharp_go_to_definition)
   autocmd FileType cs nmap <silent> <buffer> <Leader>osfu <Plug>(omnisharp_find_usages)
+  autocmd FileType cs nmap <silent> <buffer> <Leader>osoau <Plug>(omnisharp_open_all_usages)
   autocmd FileType cs nmap <silent> <buffer> <Leader>osfi <Plug>(omnisharp_find_implementations)
   autocmd FileType cs nmap <silent> <buffer> <Leader>ospd <Plug>(omnisharp_preview_definition)
   autocmd FileType cs nmap <silent> <buffer> <Leader>ospi <Plug>(omnisharp_preview_implementations)

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -2,21 +2,26 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 function! OmniSharp#locations#Navigate(location, silentedit) abort
+  let editcommand = get(g:, 'OmniSharp_edit_command', 'edit')
+  if a:silentedit
+    let editcommand = 'edit'
+  endif
+  if &modified && !&hidden && editcommand ==# 'edit'
+    let editcommand = 'split'
+  endif
+  if a:silentedit
+    let editcommand = 'noautocmd ' . editcommand
+  endif
+  let ret = OmniSharp#locations#NavigateWith(a:location, editcommand)
+  return ret
+endfunction
+
+function! OmniSharp#locations#NavigateWith(location, editcommand) abort
   if a:location.filename !=# ''
     " Update the ' mark, adding this location to the jumplist.
     normal! m'
     if fnamemodify(a:location.filename, ':p') !=# expand('%:p')
-      let editcommand = get(g:, 'OmniSharp_edit_command', 'edit')
-      if a:silentedit
-        let editcommand = 'edit'
-      endif
-      if &modified && !&hidden && editcommand ==# 'edit'
-        let editcommand = 'split'
-      endif
-      if a:silentedit
-        let editcommand = 'noautocmd ' . editcommand
-      endif
-      execute editcommand fnameescape(a:location.filename)
+      execute a:editcommand fnameescape(a:location.filename)
     endif
     if get(a:location, 'lnum', 0) > 0
       let col = get(a:location, 'vcol', 0)

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -490,6 +490,12 @@ convenient user re-mapping. These can be used like so: >
     Fills quicklist with usages of symbol under the cursor
     NOTE: Navigates to usage if only one is found
 
+                                                        *:OmniSharpOpenAllUsages*
+                                              *<Plug>(omnisharp_open_all_usages)*
+:OmniSharpOpenAllUsages
+    Searches usages of symbol under the cursor, and opens all files with usages
+    in separate buffers. Skips files which are already open.
+
                                                           *:OmniSharpFindMembers*
                                                  *<Plug>(omnisharp_find_members)*
 :OmniSharpFindMembers

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -41,6 +41,7 @@ command! -buffer -bar OmniSharpHighlight call OmniSharp#actions#highlight#Buffer
 command! -buffer -bar OmniSharpHighlightEcho call OmniSharp#actions#highlight#Echo()
 command! -buffer -bar OmniSharpNavigateUp call OmniSharp#actions#navigate#Up()
 command! -buffer -bar OmniSharpNavigateDown call OmniSharp#actions#navigate#Down()
+command! -buffer -bar -nargs=? OmniSharpOpenAllUsages call OmniSharp#actions#usages#OpenAll(<q-args>)
 command! -buffer -bar OmniSharpPreviewDefinition call OmniSharp#actions#definition#Preview()
 command! -buffer -bar OmniSharpPreviewImplementation call OmniSharp#actions#implementations#Preview()
 command! -buffer -bar OmniSharpRename call OmniSharp#actions#rename#Prompt()
@@ -68,6 +69,7 @@ nnoremap <buffer> <Plug>(omnisharp_go_to_definition) :OmniSharpGotoDefinition<CR
 nnoremap <buffer> <Plug>(omnisharp_highlight) :OmniSharpHighlight<CR>
 nnoremap <buffer> <Plug>(omnisharp_navigate_up) :OmniSharpNavigateUp<CR>
 nnoremap <buffer> <Plug>(omnisharp_navigate_down) :OmniSharpNavigateDown<CR>
+nnoremap <buffer> <Plug>(omnisharp_open_all_usages) :OmniSharpOpenAllUsages<CR>
 nnoremap <buffer> <Plug>(omnisharp_preview_definition) :OmniSharpPreviewDefinition<CR>
 nnoremap <buffer> <Plug>(omnisharp_preview_implementation) :OmniSharpPreviewImplementation<CR>
 nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
@@ -116,6 +118,7 @@ let b:undo_ftplugin .= '
 \| delcommand OmniSharpNavigateDown
 \| delcommand OmniSharpPreviewDefinition
 \| delcommand OmniSharpPreviewImplementation
+\| delcommand OmniSharpOpenAllUsages
 \| delcommand OmniSharpRename
 \| delcommand OmniSharpRenameTo
 \| delcommand OmniSharpRepeatCodeAction


### PR DESCRIPTION
I add here an `OmniSharpOpenAllUsages` command, which searches for usages of the term on the cursor, then opens all filenames which have usages (and aren't already open). As of now, though, this is only useful if `g:OmniSharp_edit_command` is set to something useful; with the default (of edit) it just opens all usages one after the other in the same buffer.

Questions:

1) What should be the default? (My guess is split, but I'm not sure)
2) Should this be a separate configuration, or should we just default to edit in some cases and split in others, and let g:OmniSharp_edit_command override in all of them? (I would say let g:OmniSharp_edit_command override both; this means that we need another argument for Navigate which tells what is the "current" default).
3) Is the current behavior (don't open usages which are already open) the one we want? I also left code for another option, which is load all usages except in current file. (I would say yes, in which case I will delete the logic for special-casing the current file).