### PR TITLE
Added support for android when installing in mono mode

### DIFF
--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -63,15 +63,18 @@ else
     exit 1
 fi
 
-# Check the machine architecture
-case "$(uname -m)" in
-    "x86_64")   machine="x64";;
-    "i368")     machine="x86";;
-    *)
-        echo "Error: OmniSharp-Roslyn only works on x86 CPU architecture"
-        exit 1
-        ;;
-esac
+# If not installing in mono mode
+if [ -z "$mono" ]; then
+    # Check the machine architecture
+    case "$(uname -m)" in
+        "x86_64")   machine="x64";;
+        "i368")     machine="x86";;
+        *)
+            echo "Error: OmniSharp-Roslyn only works on x86 CPU architecture"
+            exit 1
+            ;;
+    esac
+fi
 
 # Check the operating system
 case "$(uname -s)" in


### PR DESCRIPTION
As per issue #678, I've made the required change to allow for install on non-x86 devices that support mono. Tested on both an android phone and an android tv in Termux. 