### PR TITLE
[add] reviewdog's ci in github-actions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,21 @@
+name: reviewdog
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+
+jobs:
+  vint:
+    name: runner / vint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: vint
+        uses: reviewdog/action-vint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          level: error
+          reporter: github-pr-check


### PR DESCRIPTION
I added new test to check Vim script's syntax.
This unit test use `github actions` and reviewdog.
Could you check this Pull Request?
If you don't need this pull request, feel free to close it. 

## reference
> https://github.com/reviewdog/action-vint