### PR TITLE
[fix] limit scope

### DIFF
--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -74,20 +74,21 @@ function! s:ComputeItemSignature(item) abort
   if textBeforeDisplayName !~# '^\(private\|internal\|protected\|public\)'
     let textBeforeDisplayName = a:item.Properties.accessibility . ' ' . textBeforeDisplayName
   endif
-  return ReduceToOneCharacter(textBeforeDisplayName) . a:item.DisplayName
+  return s:ReduceToOneCharacter(textBeforeDisplayName) . a:item.DisplayName
 endfunction
 
-let s:SingleCharacterSymbolByAccessModifier = {
- \ 'public': '+',
- \ 'private': '-',
- \ 'internal': '&',
- \ 'protected': '|'
-\}
 
-function! ReduceToOneCharacter(textBeforeDisplayName) abort
+function! s:ReduceToOneCharacter(textBeforeDisplayName) abort
+  let l:SingleCharacterSymbolByAccessModifier = {
+        \ 'public': '+',
+        \ 'private': '-',
+        \ 'internal': '&',
+        \ 'protected': '|'
+        \}
+
   let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
   let accessModifierLen = len(accessModifier)
-  return s:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
+  return l:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
 endfunction
 
 function! s:CBFindMembers(locations) abort

--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -77,17 +77,16 @@ function! s:ComputeItemSignature(item) abort
   return s:ReduceToOneCharacter(textBeforeDisplayName) . a:item.DisplayName
 endfunction
 
+let s:SingleCharacterSymbolByAccessModifier = {
+      \ 'public': '+',
+      \ 'private': '-',
+      \ 'internal': '&',
+      \ 'protected': '|'
+      \}
 
 function! s:ReduceToOneCharacter(textBeforeDisplayName) abort
-  let l:SingleCharacterSymbolByAccessModifier = {
-        \ 'public': '+',
-        \ 'private': '-',
-        \ 'internal': '&',
-        \ 'protected': '|'
-        \}
-
   let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
-  return l:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[len(accessModifier):]
+  return s:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[len(accessModifier):]
 endfunction
 
 function! s:CBFindMembers(locations) abort

--- a/autoload/OmniSharp/actions/members.vim
+++ b/autoload/OmniSharp/actions/members.vim
@@ -87,8 +87,7 @@ function! s:ReduceToOneCharacter(textBeforeDisplayName) abort
         \}
 
   let accessModifier = matchlist(a:textBeforeDisplayName, '\w\+')[0]
-  let accessModifierLen = len(accessModifier)
-  return l:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[accessModifierLen:]
+  return l:SingleCharacterSymbolByAccessModifier[accessModifier] . a:textBeforeDisplayName[len(accessModifier):]
 endfunction
 
 function! s:CBFindMembers(locations) abort


### PR DESCRIPTION
The ReduceToOneCharacter function was a global function, but there was only one place where it was called, so we restricted its scope.