### PR TITLE
Add configuration variable for log directory

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -429,9 +429,9 @@ function! OmniSharp#Install(...) abort
   let l:http = g:OmniSharp_server_stdio ? '' : '-H'
   let l:version = a:0 > 0 ? '-v ' . shellescape(a:1) : ''
   let l:location = shellescape(OmniSharp#util#ServerDir())
-  let l:logfile = OmniSharp#log#GetLogDir() . '\install.log'
 
   if has('win32')
+    let l:logfile = OmniSharp#log#GetLogDir() . '\install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '\installer\omnisharp-manager.ps1')
     let l:version_file_location = l:location . '\OmniSharpInstall-version.txt'
@@ -440,6 +440,7 @@ function! OmniSharp#Install(...) abort
     \ 'powershell -ExecutionPolicy Bypass -File %s %s -l %s %s',
     \ l:script, l:http, l:location, l:version)
   else
+    let l:logfile = OmniSharp#log#GetLogDir() . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
     let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -431,7 +431,12 @@ function! OmniSharp#Install(...) abort
   let l:location = shellescape(OmniSharp#util#ServerDir())
 
   if has('win32')
-    let l:logfile = s:plugin_root_dir . '\log\install.log'
+    if exists('g:OmniSharp_vim_log_dir')
+      let l:log_dir = g:OmniSharp_vim_log_dir
+    else
+      let l:log_dir = s:plugin_root_dir . '\log'
+    end
+    let l:logfile = l:log_dir . '\install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '\installer\omnisharp-manager.ps1')
     let l:version_file_location = l:location . '\OmniSharpInstall-version.txt'
@@ -440,7 +445,12 @@ function! OmniSharp#Install(...) abort
     \ 'powershell -ExecutionPolicy Bypass -File %s %s -l %s %s',
     \ l:script, l:http, l:location, l:version)
   else
-    let l:logfile = s:plugin_root_dir . '/log/install.log'
+    if exists('g:OmniSharp_vim_log_dir')
+      let l:log_dir = g:OmniSharp_vim_log_dir
+    else
+      let l:log_dir = s:plugin_root_dir . '/log'
+    end
+    let l:logfile = l:log_dir . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
     let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -441,7 +441,6 @@ function! OmniSharp#Install(...) abort
     \ l:script, l:http, l:location, l:version)
   else
     let l:logfile = g:OmniSharp_log_dir . '/install.log'
-    let l:logfile = l:log_dir . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
     let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -429,9 +429,9 @@ function! OmniSharp#Install(...) abort
   let l:http = g:OmniSharp_server_stdio ? '' : '-H'
   let l:version = a:0 > 0 ? '-v ' . shellescape(a:1) : ''
   let l:location = shellescape(OmniSharp#util#ServerDir())
+  let l:logfile = OmniSharp#log#GetLogDir() . '\install.log'
 
   if has('win32')
-    let l:logfile = g:OmniSharp_log_dir . '\install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '\installer\omnisharp-manager.ps1')
     let l:version_file_location = l:location . '\OmniSharpInstall-version.txt'
@@ -440,7 +440,6 @@ function! OmniSharp#Install(...) abort
     \ 'powershell -ExecutionPolicy Bypass -File %s %s -l %s %s',
     \ l:script, l:http, l:location, l:version)
   else
-    let l:logfile = g:OmniSharp_log_dir . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
     let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -431,12 +431,7 @@ function! OmniSharp#Install(...) abort
   let l:location = shellescape(OmniSharp#util#ServerDir())
 
   if has('win32')
-    if exists('g:OmniSharp_log_dir')
-      let l:log_dir = g:OmniSharp_log_dir
-    else
-      let l:log_dir = s:plugin_root_dir . '\log'
-    end
-    let l:logfile = l:log_dir . '\install.log'
+    let l:logfile = g:OmniSharp_log_dir . '\install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '\installer\omnisharp-manager.ps1')
     let l:version_file_location = l:location . '\OmniSharpInstall-version.txt'
@@ -445,11 +440,7 @@ function! OmniSharp#Install(...) abort
     \ 'powershell -ExecutionPolicy Bypass -File %s %s -l %s %s',
     \ l:script, l:http, l:location, l:version)
   else
-    if exists('g:OmniSharp_log_dir')
-      let l:log_dir = g:OmniSharp_log_dir
-    else
-      let l:log_dir = s:plugin_root_dir . '/log'
-    end
+    let l:logfile = g:OmniSharp_log_dir . '/install.log'
     let l:logfile = l:log_dir . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -431,8 +431,8 @@ function! OmniSharp#Install(...) abort
   let l:location = shellescape(OmniSharp#util#ServerDir())
 
   if has('win32')
-    if exists('g:OmniSharp_vim_log_dir')
-      let l:log_dir = g:OmniSharp_vim_log_dir
+    if exists('g:OmniSharp_log_dir')
+      let l:log_dir = g:OmniSharp_log_dir
     else
       let l:log_dir = s:plugin_root_dir . '\log'
     end
@@ -445,8 +445,8 @@ function! OmniSharp#Install(...) abort
     \ 'powershell -ExecutionPolicy Bypass -File %s %s -l %s %s',
     \ l:script, l:http, l:location, l:version)
   else
-    if exists('g:OmniSharp_vim_log_dir')
-      let l:log_dir = g:OmniSharp_vim_log_dir
+    if exists('g:OmniSharp_log_dir')
+      let l:log_dir = g:OmniSharp_log_dir
     else
       let l:log_dir = s:plugin_root_dir . '/log'
     end

--- a/autoload/OmniSharp/log.vim
+++ b/autoload/OmniSharp/log.vim
@@ -1,8 +1,8 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-if exists('g:OmniSharp_vim_log_dir')
-  let s:stdiologfile = g:OmniSharp_vim_log_dir . '/stdio.log'
+if exists('g:OmniSharp_log_dir')
+  let s:stdiologfile = g:OmniSharp_log_dir . '/stdio.log'
 else
   let s:stdiologfile = expand('<sfile>:p:h:h:h') . '/log/stdio.log'
 end

--- a/autoload/OmniSharp/log.vim
+++ b/autoload/OmniSharp/log.vim
@@ -1,7 +1,11 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:stdiologfile = expand('<sfile>:p:h:h:h') . '/log/stdio.log'
+if exists('g:OmniSharp_vim_log_dir')
+  let s:stdiologfile = g:OmniSharp_vim_log_dir . '/stdio.log'
+else
+  let s:stdiologfile = expand('<sfile>:p:h:h:h') . '/log/stdio.log'
+end
 
 " Log from OmniSharp-vim
 function! OmniSharp#log#Log(job, message, ...) abort

--- a/autoload/OmniSharp/log.vim
+++ b/autoload/OmniSharp/log.vim
@@ -1,7 +1,23 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:stdiologfile = g:OmniSharp_log_dir . '/stdio.log'
+if has('win32')
+  let default_log_dir = expand('<sfile>:p:h:h:h') . '\log'
+else
+  let default_log_dir = expand('<sfile>:p:h:h:h') . '/log'
+end
+
+let s:logdir = get(g:, 'OmniSharp_log_dir', default_log_dir)
+let s:stdiologfile = s:logdir . '/stdio.log'
+
+" Make the log directory if it doesn't exist
+if !isdirectory(g:OmniSharp_log_dir)
+  call mkdir(g:OmniSharp_log_dir, 'p')
+end
+
+function! OmniSharp#log#GetLogDir() abort
+  return s:logdir
+endfunction
 
 " Log from OmniSharp-vim
 function! OmniSharp#log#Log(job, message, ...) abort

--- a/autoload/OmniSharp/log.vim
+++ b/autoload/OmniSharp/log.vim
@@ -1,11 +1,7 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-if exists('g:OmniSharp_log_dir')
-  let s:stdiologfile = g:OmniSharp_log_dir . '/stdio.log'
-else
-  let s:stdiologfile = expand('<sfile>:p:h:h:h') . '/log/stdio.log'
-end
+let s:stdiologfile = g:OmniSharp_log_dir . '/stdio.log'
 
 " Log from OmniSharp-vim
 function! OmniSharp#log#Log(job, message, ...) abort

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -107,6 +107,16 @@ and back.
 Default: 0 >
     let g:OmniSharp_translate_cygwin_wsl = 1
 <
+                                                            *g:OmniSharp_log_dir*
+Sets the log directory.
+
+Use this option to specify the directory log files will be written to. If the
+directory specified does not exist, it will be created. When no log directory is
+specified, logs are written to the log directory in the Omnisharp-vim plugin
+directory.
+Default: /omnisharp-vim/log >
+    let g:OmniSharp_log_dir = '/omnisharp-vim/log'
+<
                                                            *g:OmniSharp_loglevel*
 Sets the log level.
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -30,6 +30,13 @@ let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_soluti
 " Automatically start server
 let g:OmniSharp_start_server = get(g:, 'OmniSharp_start_server', get(g:, 'Omnisharp_start_server', 1))
 
+if has('win32')
+  let default_log_dir = expand('<sfile>:p:h:h') . '\log'
+else
+  let default_log_dir = expand('<sfile>:p:h:h') . '/log'
+end
+let g:OmniSharp_log_dir = get(g:, 'OmniSharp_log_dir', default_log_dir)
+
 let defaultlevel = g:OmniSharp_server_stdio ? 'info' : 'warning'
 let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', defaultlevel)
 
@@ -129,5 +136,10 @@ if g:OmniSharp_selector_ui ==? 'ctrlp'
     let g:ctrlp_extensions += ['findsymbols', 'findcodeactions']
   endif
 endif
+
+" Make the log directory if it doesn't exist
+if !isdirectory(g:OmniSharp_log_dir)
+  call mkdir(g:OmniSharp_log_dir, "p")
+end
 
 " vim:et:sw=2:sts=2

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -30,13 +30,6 @@ let g:OmniSharp_start_without_solution = get(g:, 'OmniSharp_start_without_soluti
 " Automatically start server
 let g:OmniSharp_start_server = get(g:, 'OmniSharp_start_server', get(g:, 'Omnisharp_start_server', 1))
 
-if has('win32')
-  let default_log_dir = expand('<sfile>:p:h:h') . '\log'
-else
-  let default_log_dir = expand('<sfile>:p:h:h') . '/log'
-end
-let g:OmniSharp_log_dir = get(g:, 'OmniSharp_log_dir', default_log_dir)
-
 let defaultlevel = g:OmniSharp_server_stdio ? 'info' : 'warning'
 let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', defaultlevel)
 
@@ -136,10 +129,5 @@ if g:OmniSharp_selector_ui ==? 'ctrlp'
     let g:ctrlp_extensions += ['findsymbols', 'findcodeactions']
   endif
 endif
-
-" Make the log directory if it doesn't exist
-if !isdirectory(g:OmniSharp_log_dir)
-  call mkdir(g:OmniSharp_log_dir, "p")
-end
 
 " vim:et:sw=2:sts=2


### PR DESCRIPTION
I am attempting to use omnisharp-vim as part of my nix configuration. However, omnisharp-vim tries writing logs to the plugin directory, which is in my nix store and is a read only directory.

This change adds a configuration variable for the log directory. If the configuration variable is left unset, the logs are written in the plugin directory as before. If the configuration variable is set, logs are written to the specified directory. If the directory doesn't exist, it gets created.