### PR TITLE
Cache Projects TargetPath from OmniSharp-Roslyn

### DIFF
--- a/autoload/OmniSharp/actions/workspace.vim
+++ b/autoload/OmniSharp/actions/workspace.vim
@@ -23,7 +23,7 @@ function! s:ProjectsRH(job, response) abort
   " are no projects and the job can be marked as ready
   let projects = get(get(a:response.Body, 'MsBuild', {}), 'Projects', {})
   let a:job.projects = map(projects,
-  \ {_,project -> {"name": project.AssemblyName, "path": project.Path}})
+  \ {_,project -> {"name": project.AssemblyName, "path": project.Path, "target": project.TargetPath}})
   if get(a:job, 'projects_total', 0) > 0
     call OmniSharp#log#Log(a:job, 'Workspace complete: ' . a:job.projects_total . ' project(s)')
   else


### PR DESCRIPTION
From discussion in https://github.com/OmniSharp/omnisharp-vim/issues/386#issuecomment-923519148.

This PR makes it so that the example debugger configuration helper function I wrote in the [wiki](https://github.com/OmniSharp/omnisharp-vim/wiki/Build-command-with-autocomplete-for-.csproj-files#debugger-integration) works. Not sure when to best call it. On `OmniSharpReady` I suppose.