### PR TITLE
Add plug mapping for new debug command

### DIFF
--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -75,6 +75,7 @@ nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_server) :OmniSharpRestartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_all_servers) :OmniSharpRestartAllServers<CR>
 nnoremap <buffer> <Plug>(omnisharp_run_test) :OmniSharpRunTest<CR>
+nnoremap <buffer> <Plug>(omnisharp_debug_test) :OmniSharpDebugTest<CR>
 nnoremap <buffer> <Plug>(omnisharp_run_tests_in_file) :OmniSharpRunTestsInFile<CR>
 nnoremap <buffer> <Plug>(omnisharp_signature_help) :OmniSharpSignatureHelp<CR>
 inoremap <buffer> <Plug>(omnisharp_signature_help) <C-o>:OmniSharpSignatureHelp<CR>


### PR DESCRIPTION
Hi again!

So I forgot to add plug a mapping for the new command. I think we need this right?

Also, this is somewhat sad, but I don't really get what those are for. They seem to be a new thing that a lot of projects are using. What is their advantage over doing your own `nnoremap`s yourself?

Thanks!