### PR TITLE
Update buffer on change

### DIFF
--- a/autoload/OmniSharp/actions/diagnostics.vim
+++ b/autoload/OmniSharp/actions/diagnostics.vim
@@ -54,6 +54,7 @@ function! OmniSharp#actions#diagnostics#StdioCheck(bufnr, Callback) abort
   let opts = {
   \ 'ResponseHandler': function('s:StdioCheckRH', [a:Callback]),
   \ 'BufNum': a:bufnr,
+  \ 'SendBuffer': 0,
   \ 'ReplayOnLoad': 1
   \}
   call OmniSharp#stdio#Request('/codecheck', opts)

--- a/autoload/OmniSharp/actions/diagnostics.vim
+++ b/autoload/OmniSharp/actions/diagnostics.vim
@@ -51,6 +51,9 @@ endfunction
 " directly from autoload/ale/sources/OmniSharp.vim so requires a full autoload
 " function name.
 function! OmniSharp#actions#diagnostics#StdioCheck(bufnr, Callback) abort
+  " OmniSharp#actions#buffer#Update only updates the server state when the
+  " buffer has been modified since the last server update
+  call OmniSharp#actions#buffer#Update()
   let opts = {
   \ 'ResponseHandler': function('s:StdioCheckRH', [a:Callback]),
   \ 'BufNum': a:bufnr,

--- a/autoload/OmniSharp/actions/signature.vim
+++ b/autoload/OmniSharp/actions/signature.vim
@@ -97,7 +97,7 @@ function! s:StdioSignatureHelpRH(Callback, seq, opts, response) abort
   if has_key(a:opts, 'ForCompleteMethod') && !g:OmniSharp_want_snippet
     " Because of our 'falsified' request with an extra '(', re-synchronise the
     " server's version of the buffer with the actual buffer contents.
-    call OmniSharp#actions#buffer#Update(0, 0, 1)
+    call OmniSharp#actions#buffer#Update({'SendBuffer': 1})
   endif
   call a:Callback(a:response.Body)
 endfunction

--- a/autoload/OmniSharp/buffer.vim
+++ b/autoload/OmniSharp/buffer.vim
@@ -10,8 +10,10 @@ function! OmniSharp#buffer#Initialize(job, bufnr, command, opts) abort
   let a:job.pending_requests[a:bufnr][a:command] = a:opts
   if has_key(OmniSharp#GetHost(a:bufnr), 'initializing') | return | endif
   let host.initializing = 1
-  let Callback = function('s:CBInitialize', [a:job, a:bufnr, host])
-  call OmniSharp#actions#buffer#Update(Callback, 1)
+  call OmniSharp#actions#buffer#Update({
+  \ 'Callback': function('s:CBInitialize', [a:job, a:bufnr, host]),
+  \ 'Initializing': 1
+  \})
 endfunction
 
 function! s:CBInitialize(job, bufnr, host) abort

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -199,7 +199,7 @@ function! OmniSharp#stdio#Request(command, opts) abort
     let sep = ''
   endif
 
-  call s:Request(job, body, a:command, a:opts, sep)
+  call s:Request(job, body, a:command, a:opts, sep, bufnr)
 
   if has_key(a:opts, 'ReplayOnLoad')
     let replay_opts = filter(copy(a:opts), 'v:key !=# "ReplayOnLoad"')
@@ -210,10 +210,10 @@ function! OmniSharp#stdio#Request(command, opts) abort
 endfunction
 
 function! OmniSharp#stdio#RequestGlobal(job, command, opts) abort
-  call s:Request(a:job, {}, a:command, a:opts)
+  call s:Request(a:job, {}, a:command, a:opts, '', -1)
 endfunction
 
-function! s:Request(job, body, command, opts, ...) abort
+function! s:Request(job, body, command, opts, sep, bufnr) abort
   call OmniSharp#log#Log(a:job, 'Request: ' . a:command, 1)
 
   let a:body['Command'] = a:command
@@ -222,14 +222,14 @@ function! s:Request(job, body, command, opts, ...) abort
   if has_key(a:opts, 'Parameters')
     call extend(a:body.Arguments, a:opts.Parameters, 'force')
   endif
-  let sep = a:0 ? a:1 : ''
-  if sep !=# ''
-    let encodedBody = substitute(json_encode(a:body), sep, '\\r\\n', 'g')
+  if a:sep !=# ''
+    let encodedBody = substitute(json_encode(a:body), a:sep, '\\r\\n', 'g')
   else
     let encodedBody = json_encode(a:body)
   endif
 
   let s:requests[s:nextseq] = {
+  \ 'BufNum': a:bufnr,
   \ 'Command': a:command,
   \ 'Seq': s:nextseq,
   \ 'StartTime': reltime()

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -174,18 +174,6 @@ function! OmniSharp#stdio#Request(command, opts) abort
     \ fnamemodify(bufname(bufnr), ':p'))
     let send_buffer = get(a:opts, 'SendBuffer', 1)
   endif
-  let lines = getbufline(bufnr, 1, '$')
-  if has_key(a:opts, 'OverrideBuffer')
-    let lines[a:opts.OverrideBuffer.LineNr - 1] = a:opts.OverrideBuffer.Line
-    let cnum = a:opts.OverrideBuffer.Col
-  endif
-  let tmp = join(lines, '')
-  " Unique string separator which must not exist in the buffer
-  let sep = '@' . matchstr(reltimestr(reltime()), '\v\.@<=\d+') . '@'
-  while stridx(tmp, sep) >= 0
-    let sep = '@' . matchstr(reltimestr(reltime()), '\v\.@<=\d+') . '@'
-  endwhile
-  let buffer = join(lines, sep)
 
   let body = {
   \ 'Arguments': {
@@ -195,7 +183,20 @@ function! OmniSharp#stdio#Request(command, opts) abort
   \ }
   \}
   if send_buffer
-    let body.Arguments.Buffer = buffer
+    let lines = getbufline(bufnr, 1, '$')
+    if has_key(a:opts, 'OverrideBuffer')
+      let lines[a:opts.OverrideBuffer.LineNr - 1] = a:opts.OverrideBuffer.Line
+      let cnum = a:opts.OverrideBuffer.Col
+    endif
+    let tmp = join(lines, '')
+    " Unique string separator which must not exist in the buffer
+    let sep = '@' . matchstr(reltimestr(reltime()), '\v\.@<=\d+') . '@'
+    while stridx(tmp, sep) >= 0
+      let sep = '@' . matchstr(reltimestr(reltime()), '\v\.@<=\d+') . '@'
+    endwhile
+    let body.Arguments.Buffer = join(lines, sep)
+  else
+    let sep = ''
   endif
 
   call s:Request(job, body, a:command, a:opts, sep)

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -123,8 +123,6 @@ function! OmniSharp#util#CheckCapabilities() abort
   endif
 
   if !s:capable
-    " Clear BufEnter and InsertLeave autocmds
-    silent! autocmd! OmniSharp_HighlightTypes
     " Clear plugin integration autocmds
     silent! autocmd! OmniSharp_Integrations
   endif

--- a/autoload/ale/sources/OmniSharp.vim
+++ b/autoload/ale/sources/OmniSharp.vim
@@ -1,10 +1,13 @@
-function! ale#sources#OmniSharp#WantResults(buffer) abort
-  let g:OmniSharp_diagnostics_requested = 1
+function! ale#sources#OmniSharp#WantResults() abort
+  if !g:OmniSharp_server_stdio | return | endif
+  let bufnr = g:ale_want_results_buffer
+  if getbufvar(bufnr, '&filetype') !=# 'cs' | return | endif
   if OmniSharp#FugitiveCheck() | return | endif
-  call ale#other_source#StartChecking(a:buffer, 'OmniSharp')
-  let opts = { 'BufNum': a:buffer }
+  let g:OmniSharp_diagnostics_requested = 1
+  call ale#other_source#StartChecking(bufnr, 'OmniSharp')
+  let opts = { 'BufNum': bufnr }
   let Callback = function('ale#sources#OmniSharp#ProcessResults', [opts])
-  call OmniSharp#actions#diagnostics#StdioCheck(a:buffer, Callback)
+  call OmniSharp#actions#diagnostics#StdioCheck(bufnr, Callback)
 endfunction
 
 function! ale#sources#OmniSharp#ProcessResults(opts, locations) abort

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -3,10 +3,19 @@ if !OmniSharp#util#CheckCapabilities() | finish | endif
 if get(b:, 'OmniSharp_ftplugin_loaded', 0) | finish | endif
 let b:OmniSharp_ftplugin_loaded = 1
 
+if get(g:, 'OmniSharp_start_server', 0)
+  call OmniSharp#StartServerIfNotRunning()
+endif
+
+call OmniSharp#actions#buffer#Update()
+if g:OmniSharp_highlighting
+  call OmniSharp#actions#highlight#Buffer()
+endif
+
 augroup OmniSharp_FileType
   autocmd! * <buffer>
 
-  autocmd BufLeave <buffer>
+  autocmd BufEnter,BufLeave <buffer>
   \ if !pumvisible() |
   \   call OmniSharp#actions#buffer#Update() |
   \ endif
@@ -14,15 +23,23 @@ augroup OmniSharp_FileType
   autocmd CompleteDone <buffer> call OmniSharp#actions#complete#ExpandSnippet()
 
   autocmd TextChanged <buffer> call OmniSharp#actions#buffer#Update()
+
+  if g:OmniSharp_highlighting
+    autocmd BufEnter <buffer> call OmniSharp#actions#highlight#Buffer()
+  endif
+  if g:OmniSharp_highlighting >= 2
+    autocmd InsertLeave,TextChanged <buffer> call OmniSharp#actions#highlight#Buffer()
+  endif
+  if g:OmniSharp_highlighting >= 3
+    autocmd TextChangedI <buffer> call OmniSharp#actions#highlight#Buffer()
+    if exists('##TextChangedP')
+      autocmd TextChangedP <buffer> call OmniSharp#actions#highlight#Buffer()
+    endif
+  endif
+
 augroup END
 
 setlocal omnifunc=OmniSharp#Complete
-
-if get(g:, 'OmniSharp_start_server', 0)
-  call OmniSharp#StartServerIfNotRunning()
-endif
-
-call OmniSharp#actions#buffer#Update()
 
 command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -24,17 +24,23 @@ augroup OmniSharp_FileType
 
   autocmd TextChanged <buffer> call OmniSharp#actions#buffer#Update()
 
-  if g:OmniSharp_highlighting
-    autocmd BufEnter <buffer> call OmniSharp#actions#highlight#Buffer()
-  endif
-  if g:OmniSharp_highlighting >= 2
-    autocmd InsertLeave,TextChanged <buffer> call OmniSharp#actions#highlight#Buffer()
-  endif
-  if g:OmniSharp_highlighting >= 3
-    autocmd TextChangedI <buffer> call OmniSharp#actions#highlight#Buffer()
-    if exists('##TextChangedP')
-      autocmd TextChangedP <buffer> call OmniSharp#actions#highlight#Buffer()
-    endif
+  autocmd BufEnter <buffer>
+  \ if g:OmniSharp_highlighting |
+  \   call OmniSharp#actions#highlight#Buffer() |
+  \ endif
+  autocmd InsertLeave,TextChanged <buffer>
+  \ if g:OmniSharp_highlighting >= 2 |
+  \   call OmniSharp#actions#highlight#Buffer() |
+  \ endif
+  autocmd TextChangedI <buffer>
+  \ if g:OmniSharp_highlighting >= 3 |
+  \   call OmniSharp#actions#highlight#Buffer() |
+  \ endif
+  if exists('##TextChangedP')
+    autocmd TextChangedP <buffer>
+    \ if g:OmniSharp_highlighting >= 3 |
+    \   call OmniSharp#actions#highlight#Buffer() |
+    \ endif
   endif
 
 augroup END

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -12,6 +12,8 @@ augroup OmniSharp_FileType
   \ endif
 
   autocmd CompleteDone <buffer> call OmniSharp#actions#complete#ExpandSnippet()
+
+  autocmd TextChanged <buffer> call OmniSharp#actions#buffer#Update()
 augroup END
 
 setlocal omnifunc=OmniSharp#Complete
@@ -19,6 +21,8 @@ setlocal omnifunc=OmniSharp#Complete
 if get(g:, 'OmniSharp_start_server', 0)
   call OmniSharp#StartServerIfNotRunning()
 endif
+
+call OmniSharp#actions#buffer#Update()
 
 command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -15,7 +15,11 @@ endif
 augroup OmniSharp_FileType
   autocmd! * <buffer>
 
-  autocmd BufEnter,BufLeave <buffer>
+  autocmd BufEnter <buffer>
+  \ if !pumvisible() |
+  \   call OmniSharp#actions#buffer#Update({'SendBuffer': 1}) |
+  \ endif
+  autocmd BufLeave <buffer>
   \ if !pumvisible() |
   \   call OmniSharp#actions#buffer#Update() |
   \ endif

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -53,13 +53,6 @@ command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)
 " Preserve backwards compatibility with older version g:OmniSharp_highlight_types
 let g:OmniSharp_highlighting = get(g:, 'OmniSharp_highlighting', get(g:, 'OmniSharp_highlight_types', 2))
 
-function! s:ALEWantResults() abort
-  if !g:OmniSharp_server_stdio | return | endif
-  if getbufvar(g:ale_want_results_buffer, '&filetype') ==# 'cs'
-    call ale#sources#OmniSharp#WantResults(g:ale_want_results_buffer)
-  endif
-endfunction
-
 augroup OmniSharp_Integrations
   autocmd!
 
@@ -82,7 +75,7 @@ augroup OmniSharp_Integrations
   \})
 
   " Listen for ALE requests
-  autocmd User ALEWantResults call s:ALEWantResults()
+  autocmd User ALEWantResults call ale#sources#OmniSharp#WantResults()
 augroup END
 
 if !exists('g:OmniSharp_selector_ui')

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -50,39 +50,8 @@ command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
 command! -bar -nargs=? OmniSharpOpenLog call OmniSharp#log#Open(<q-args>)
 command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)
 
-" Initialise automatic type and interface highlighting
 " Preserve backwards compatibility with older version g:OmniSharp_highlight_types
 let g:OmniSharp_highlighting = get(g:, 'OmniSharp_highlighting', get(g:, 'OmniSharp_highlight_types', 2))
-if g:OmniSharp_highlighting
-  augroup OmniSharp_HighlightTypes
-    autocmd!
-    autocmd BufEnter *.cs,*.csx
-    \ if !pumvisible() && OmniSharp#util#CheckCapabilities() |
-    \   call OmniSharp#actions#highlight#Buffer() |
-    \ endif
-
-    if g:OmniSharp_highlighting >= 2
-      autocmd InsertLeave,TextChanged *.cs,*.csx
-      \ if OmniSharp#util#CheckCapabilities() |
-      \   call OmniSharp#actions#highlight#Buffer() |
-      \ endif
-    endif
-
-    if g:OmniSharp_highlighting >= 3
-      autocmd TextChangedI *.cs,*.csx
-      \ if OmniSharp#util#CheckCapabilities() |
-      \   call OmniSharp#actions#highlight#Buffer() |
-      \ endif
-
-      if exists('##TextChangedP')
-        autocmd TextChangedP *.cs,*.csx
-        \ if OmniSharp#util#CheckCapabilities() |
-        \   call OmniSharp#actions#highlight#Buffer() |
-        \ endif
-      endif
-    endif
-  augroup END
-endif
 
 function! s:ALEWantResults() abort
   if !g:OmniSharp_server_stdio | return | endif

--- a/test/utils/async-helper.vader
+++ b/test/utils/async-helper.vader
@@ -31,7 +31,8 @@ Execute (set up async helper):
     if has_key(b:, 'OmniSharp_UpdateChangeTick')
       unlet b:OmniSharp_UpdateChangeTick
     endif
-    call OmniSharpTestAwait('OmniSharp#actions#buffer#Update', [])
+    call OmniSharpTestAwait('OmniSharp#actions#buffer#Update',
+    \ [{'Callback': function('s:CallbackStopWaiting')}])
   endfunction
 
   function! OmniSharpTestCleanupBuffer() abort


### PR DESCRIPTION
This branch should hopefully provide performance improvements, while also fixing issues raised in #736 

Currently, almost all requests to the server contain the full buffer contents, keeping the server synchronised with the editor. However in very large buffers, this can cause understandably slow server interactions.

We recently stopped sending the buffer contents along with highlighting requests, and this PR also drops the buffer contents from diagnostic requests. Instead, autocmds are used to explicitly update the server buffer contents after the buffer has been edited.

The highlighting autocmds are also moved from `plugin/OmniSharp.vim` to `ftplugin/cs/OmniSharp.vim`, which gives 2 benefits:

1. Vim initialisation is improved - there is no need to create highlighting autocmds for sessions that do not include .cs files
2. It is possible to change `g:OmniSharp_highlighting` during a session, meaning highlighting can be enabled/disabled or made more or less agressive (by increasing or lowering the `g:OmniSharp_highlighting` value) while editing