### PR TITLE
WIP: debug-project and create-debug file features

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,20 @@ It is possible to run unit tests via OmniSharp-roslyn, with success/failures lis
 
 **Note:** this is only available using the stdio server, and unfortunately does _not_ work in translated WSL, due to the way OmniSharp-roslyn runs the tests.
 
+## Debugging
+
+Using Vimspector, you can debug C# projects and tests.
+For debugging tests see the [Run unit tests](##Run unit tests) section.
+
+```vim
+" Starts vimspector with an ad-hoc config that will debug the current project
+:OmniSharpDebugProject
+
+" Create a .vimspector config that you can use to debug the current project and
+" change as needed.
+:OmniSharpCreateDebugConfig
+```
+
 
 ## Configuration
 

--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -21,6 +21,81 @@ function! s:ProjectRH(Callback, bufnr, response) abort
   call a:Callback()
 endfunction
 
+function! OmniSharp#actions#project#DebugProject(stopAtEntry, ...) abort
+  if !OmniSharp#util#HasVimspector()
+    echohl WarningMsg
+    echomsg 'Vimspector required to debug project'
+    echohl None
+    return
+  endif
+  let bufnr = bufnr('%')
+  function! DebugProjectCb(bufnr, stopAtEntry, args) abort
+    let project = getbufvar(a:bufnr, 'OmniSharp_host').project
+    " Make sure we're not running on a csx script
+    if project.ScriptProject is v:null
+      call vimspector#LaunchWithConfigurations({
+      \  'launch': {
+      \    'adapter': 'netcoredbg',
+      \    'configuration': {
+      \      'request': 'launch', 
+      \      'program': project.MsBuildProject.TargetPath,
+      \      'args': a:args,
+      \      'stopAtEntry': a:stopAtEntry ? v:true : v:false
+      \    }
+      \  }
+      \})
+    else
+      echohl WarningMsg
+      echomsg 'DebugProject is not currently implemented for csx files'
+      echohl None
+    endif
+  endfunction
+  call OmniSharp#actions#project#Get(bufnr, function('DebugProjectCb', [bufnr, a:stopAtEntry, a:000]))
+endfunction
+
+function! OmniSharp#actions#project#CreateDebugConfig(stopAtEntry, ...) abort
+  let bufnr = bufnr('%')
+  function! CreateDebugConfigCb(bufnr, stopAtEntry, args) abort
+    let host = getbufvar(a:bufnr, 'OmniSharp_host')
+    let contents = [
+          \' {',
+          \'   "configurations": {',
+          \'     "attach": {',
+          \'       "adapter": "netcoredbg",',
+          \'       "configuration": {',
+          \'         "request": "attach",',
+          \'         "processId": "${pid}"',
+          \'       }',
+          \'     },',
+          \'     "launch": {',
+          \'       "adapter": "netcoredbg",',
+          \'       "configuration": {',
+          \'         "request": "launch",',
+          \'         "program": "'.host.project.MsBuildProject.TargetPath.'",',
+          \'         "args": ' . json_encode(a:args) . ',',
+          \'         "stopAtEntry": ' . (a:stopAtEntry ? 'true' : 'false'),
+          \'       }',
+          \'     }',
+          \'   }',
+          \' }',
+    \ ]
+    if isdirectory(host.sln_or_dir)
+      let hostdir = host.sln_or_dir
+    else
+      let hostdir = fnamemodify(host.sln_or_dir, ':h:p')
+    endif
+    let filename = hostdir . '/.vimspector.json'
+    call writefile(contents, filename)
+    execute 'edit ' . filename
+    if !OmniSharp#util#HasVimspector()
+      echohl WarningMsg
+      echomsg 'Vimspector does not seem to be installed. You will need it to run the created configuration.'
+      echohl None
+    endif
+  endfunction
+  call OmniSharp#actions#project#Get(bufnr, function('CreateDebugConfigCb', [bufnr, a:stopAtEntry, a:000]))
+endfunction
+
 let &cpoptions = s:save_cpo
 unlet s:save_cpo
 

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -23,7 +23,7 @@ function! OmniSharp#actions#test#Run(...) abort
 endfunction
 
 function! OmniSharp#actions#test#Debug(...) abort
-  if !exists('g:vimspector_home')
+  if !OmniSharp#util#HasVimspector()
     echohl WarningMsg
     echomsg 'Vimspector required to debug tests'
     echohl None

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -33,6 +33,10 @@ function! s:is_wsl() abort
   return s:is_wsl_val
 endfunction
 
+function! OmniSharp#util#HasVimspector() abort
+  return exists('g:vimspector_home')
+endfunction
+
 " Call a list of async functions in parallel, and wait for them all to complete
 " before calling the OnAllComplete function.
 function! OmniSharp#util#AwaitParallel(Funcs, OnAllComplete) abort

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -623,6 +623,25 @@ convenient user re-mapping. These can be used like so: >
 :OmniSharpCodeFormat
     Formats code
 
+                                                    *:OmniSharpDebugProject*
+                                          *<Plug>(omnisharp_debug_project)*
+:OmniSharpDebugProject
+    Run vimspector with an ad-hoc config on the current project.
+    Running this with a bang (OmniSharpDebugProject!) will break on entry in the 
+    debugger.
+    The command takes optional arguments that will be passed to the debugged 
+    process as args.
+
+                                                    *:OmniSharpCreateDebugConfig*
+                                          *<Plug>(omnisharp_create_debug_config)*
+:OmniSharpCreateDebugConfig
+    Creates a .vimspector config next to the open sln file. Or at the root of the
+    open directory if a directory is being used.
+    For example, use this command to dump a configuration to disk when it gets to
+    complicated to run using OmniSharpDebugProject.
+    The command takes optional arguments that will be inserted into the generated
+    config as args.
+
                                                     *:OmniSharpRestartAllServers*
                                           *<Plug>(omnisharp_restart_all_servers)*
 :OmniSharpRestartAllServers

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -82,6 +82,8 @@ command! -buffer -bar OmniSharpDebugTest call OmniSharp#actions#test#Debug()
 command! -buffer -bar -nargs=* -complete=file OmniSharpRunTestsInFile call OmniSharp#actions#test#RunInFile(<f-args>)
 command! -buffer -bar OmniSharpSignatureHelp call OmniSharp#actions#signature#SignatureHelp()
 command! -buffer -bar OmniSharpTypeLookup call OmniSharp#actions#documentation#TypeLookup()
+command! -buffer -bar -nargs=* -bang OmniSharpDebugProject call OmniSharp#actions#project#DebugProject(<bang>0, <f-args>)
+command! -buffer -bar -nargs=* -bang OmniSharpCreateDebugConfig call OmniSharp#actions#project#CreateDebugConfig(<bang>0, <f-args>)
 
 nnoremap <buffer> <Plug>(omnisharp_code_format) :OmniSharpCodeFormat<CR>
 nnoremap <buffer> <Plug>(omnisharp_documentation) :OmniSharpDocumentation<CR>
@@ -114,6 +116,8 @@ nnoremap <buffer> <Plug>(omnisharp_start_server) :OmniSharpStartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_stop_all_servers) :OmniSharpStopAllServers<CR>
 nnoremap <buffer> <Plug>(omnisharp_stop_server) :OmniSharpStopServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_type_lookup) :OmniSharpTypeLookup<CR>
+nnoremap <buffer> <Plug>(omnisharp_debug_project) :OmniSharpDebugProject<CR>
+nnoremap <buffer> <Plug>(omnisharp_create_debug_config) :OmniSharpCreateDebugConfig<CR>
 
 " The following commands and mappings have been renamed, but the old versions
 " are kept here for backwards compatibility
@@ -162,6 +166,8 @@ let b:undo_ftplugin .= '
 \| delcommand OmniSharpStopAllServers
 \| delcommand OmniSharpStopServer
 \| delcommand OmniSharpTypeLookup
+\| delcommand OmniSharpDebugProject
+\| delcommand OmniSharpCreateDebugConfig
 \
 \| setlocal omnifunc<'
 


### PR DESCRIPTION
This PR adds two things:
* An `OmniSharpDebugProject` command
> Launches Vimspector with an ad-hoc config targeting the current project. This will not work for any complex use-cases such as passing args or stop-on-entry of course.

* An `OmniSharpCreateDebugFile` command.
> This creates a new .vimspector configuration file in the same location of the loaded sln or dir.

@nickspoons this is not quite finished yet, I just want to get it in so you can get an idea of what I'm thinking and make early course corrections if necessary (and not insignificantly, to light a fire under me to actually get it done.)

I still need to add a vimspector check (I will find a way to share this code with the check in the existing vimspector command.)
Also, I am debating whether or not to forge forward with trying to figure out if I can get this to work with .csx files. That would be one of my biggest use-cases so far but the issue I'm running into ATM is that I can't get Vimspector to just work with the file as it is. I have to publish the dll and then run the debugger on that. I'm not sure if that's extraneous logic that we want to have in the project or not (no loss to me if we don't, I've got a personal plugin I use for edge cases like this.)