### PR TITLE
Support the new O#-roslyn net6.0 server version

### DIFF
--- a/.github/workflows/vader.yml
+++ b/.github/workflows/vader.yml
@@ -21,10 +21,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@main
 
-    - name: Setup dotnet
+    - name: Setup dotnet 3.1
       uses: actions/setup-dotnet@main
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '3.1'
+
+    - name: Setup dotnet 6.0
+      uses: actions/setup-dotnet@main
+      with:
+        dotnet-version: '6.0'
 
     - name: Setup Vim
       uses: rhysd/action-setup-vim@v1
@@ -34,7 +39,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        installer/omnisharp-manager.sh -l $HOME/.omnisharp/omnisharp-roslyn
+        installer/omnisharp-manager.sh -6 -l $HOME/.omnisharp/omnisharp-roslyn
         git clone https://github.com/junegunn/vader.vim.git $GITHUB_WORKSPACE/../vader.vim
 
     - name: Run Test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 OmniSharp-vim is a plugin for Vim to provide IDE like abilities for C#.
 
-OmniSharp works on Windows, and on Linux and OS X with Mono.
+OmniSharp works on Windows, Linux and MacOS.
 
 The plugin relies on the [OmniSharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn) server, a .NET development platform used by several editors including Visual Studio Code and Emacs.
 
@@ -103,7 +103,9 @@ let g:OmniSharp_server_stdio = 0
 ```
 
 #### Manual installation
-To install the server manually, first decide which version (stdio or HTTP) you wish to use, as described above. Download the latest release for your platform from the [OmniSharp-roslyn releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page. For stdio on a 64-bit Windows system, the `omnisharp.win-x64.zip` package should be downloaded, whereas Mac users wanting to use the HTTP version should select `omnisharp.http-osx.tar.gz` etc.
+To install the server manually, first decide which version (stdio or HTTP) you wish to use, as described above.
+Download the latest release for your platform from the [OmniSharp-roslyn releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) page.
+For stdio on a 64-bit Windows system, the `omnisharp.win-x64.zip` package should be downloaded, whereas Mac users wanting to use the HTTP version should select `omnisharp.http-osx.tar.gz` etc.
 
 Extract the binaries and configure your vimrc with the path to the `run` script (Linux and Mac) or `OmniSharp.exe` file (Window), e.g.:
 
@@ -130,14 +132,24 @@ The automatic installation script for cygwin downloads the *Windows* OmniSharp-r
 
 **Note:** The Windows stdio server unfortunately does not work from cygwin, so when cygwin is detected (`has('win32unix')`) the HTTP server is used by default.
 
-#### Linux and Mac
-OmniSharp-Roslyn requires Mono on Linux and OSX. The roslyn server [releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) come with an embedded Mono, but this can be overridden to use the installed Mono by setting `g:OmniSharp_server_use_mono` in your vimrc. See [The Mono Project](https://www.mono-project.com/download/stable/) for installation details.
+#### Linux and MacOS
+The default version of OmniSharp-roslyn requires `mono` on Linux and MacOS.
+The roslyn server [releases](https://github.com/OmniSharp/omnisharp-roslyn/releases) come with an embedded `mono`, but this can be overridden to use the installed `mono` by setting `g:OmniSharp_server_use_mono` in your vimrc.
+See [The Mono Project](https://www.mono-project.com/download/stable/) for installation details.
 
 ```vim
     let g:OmniSharp_server_use_mono = 1
 ```
 
 Any time `g:OmniSharp_server_use_mono` is modified, the server needs to be re-installed with `:OmniSharpInstall`.
+
+#### Native net6.0
+From version 1.38.0 of OmniSharp-roslyn, a dotnet native net6.0 server version is available.
+To use this version, set `g:OmniSharp_server_use_net6` in your vimrc before installing the server.
+
+```vim
+    let g:OmniSharp_server_use_net6 = 1
+```
 
 ##### libuv
 For the HTTP server, OmniSharp-Roslyn also requires [libuv](http://libuv.org/) on Linux and Mac. This is typically a simple install step, e.g. `brew install libuv` on Mac, `apt-get install libuv1-dev` on debian/Ubuntu, `pacman -S libuv` on arch linux, `dnf install libuv libuv-devel` on Fedora/CentOS, etc.

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -444,10 +444,11 @@ function! OmniSharp#Install(...) abort
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
     let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''
+    let l:net6 = g:OmniSharp_server_use_net6 ? '-6' : ''
     let l:version_file_location = l:location . '/OmniSharpInstall-version.txt'
 
-    let l:command = printf('/bin/sh %s %s %s -l %s %s',
-    \ l:script, l:http, l:mono, l:location, l:version)
+    let l:command = printf('/bin/sh %s %s %s %s -l %s %s',
+    \ l:script, l:http, l:mono, l:net6, l:location, l:version)
 
     if g:OmniSharp_translate_cygwin_wsl
       let l:command .= ' -W'

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -161,6 +161,8 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
     \ || g:OmniSharp_translate_cygwin_wsl
     \ || g:OmniSharp_server_use_mono
       let parts += ['OmniSharp.exe']
+    elseif g:OmniSharp_server_use_net6
+      let parts += ['OmniSharp']
     else
       let parts += ['run']
     endif

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -81,12 +81,21 @@ Default: None >
     let g:OmniSharp_server_path = '/home/username/omnisharp/OmniSharp.exe'
 <
                                                     *g:OmniSharp_server_use_mono*
-The roslyn server must be run with mono on Linux and OSX. The roslyn server
-binaries usually come with an embedded mono, but this can be overridden to use
-the installed mono with this option. Note that mono must be in the $PATH.
+By default, the roslyn server is run with mono on Linux and OSX. The roslyn
+server binaries usually come with an embedded mono, but this can be overridden
+to use the installed mono with this option. Note that mono must be in the
+$PATH.
 Note: changes require server reinstall: |:OmniSharpInstall|
 Default: 0 >
     let g:OmniSharp_server_use_mono = 1
+<
+                                                    *g:OmniSharp_server_use_net6*
+This variable tells OmniSharp-vim to use the new native dotnet net6.0 version
+of OmniSharp-roslyn, which does not require mono.
+Note: |g:OmniSharp_server_use_mono| must be set to 0
+Note: changes require server reinstall: |:OmniSharpInstall|
+Default: 0 >
+    let g:OmniSharp_server_use_net6 = 1
 <
                                                        *g:OmniSharp_start_server*
 Use this option to specify whether OmniSharp will start automatically upon

--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -14,6 +14,7 @@ $(usage)
 Options:
     -v <version>  | Version to install (if omitted, fetch latest)
     -l <location> | Directory to install the server to (upon install, this directory will be cleared)
+    -6            | Use the net6.0 server version
     -u            | Usage info
     -h            | Help message
     -H            | Install the HTTP version of the server
@@ -32,11 +33,12 @@ get_latest_version() {
 
 location="$HOME/.omnisharp/"
 
-while getopts v:l:HMWuh o "$@"
+while getopts v:l:6HMWuh o "$@"
 do
     case "$o" in
         v)      version="$OPTARG";;
         l)      location="$OPTARG";;
+        6)      net6=1;;
         H)      http=".http";;
         M)      mono=1;;
         W)      windows=1;;
@@ -82,13 +84,19 @@ if [ -n "$mono" ]; then
 else
     case "$(uname -s)" in
         "Linux")
-            if [ "$machine" = "arm64" ]; then
-                echo "Error: OmniSharp-Roslyn only works on x86 CPU architecture on Linux"
-                exit 1
+            if [ -n "$net6" ]; then
+                os="linux-${machine}-net6.0"
+            else
+                os="linux-${machine}"
             fi
-            os="linux-${machine}"
             ;;
-        "Darwin")   os="osx";;
+        "Darwin")
+            if [ -n "$net6" ]; then
+                os="osx-${machine}-net6.0"
+            else
+                os="osx"
+            fi
+            ;;
         *)
             if [ "$(uname -o)" = "Cygwin" ]; then
                 os="win-${machine}"

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -12,6 +12,9 @@ let g:OmniSharp_server_loading_timeout = get(g:, 'OmniSharp_server_loading_timeo
 " Use mono to start the roslyn server on *nix
 let g:OmniSharp_server_use_mono = get(g:, 'OmniSharp_server_use_mono', 0)
 
+" Use the native net6.0 server build
+let g:OmniSharp_server_use_net6 = get(g:, 'OmniSharp_server_use_net6', 0)
+
 let g:OmniSharp_open_quickfix = get(g:, 'OmniSharp_open_quickfix', 1)
 
 let g:OmniSharp_timeout = get(g:, 'OmniSharp_timeout', 1)

--- a/test/vimrc
+++ b/test/vimrc
@@ -17,6 +17,7 @@ syntax on
 set cmdheight=3
 
 let g:OmniSharp_server_stdio = 1
+let g:OmniSharp_server_use_net6 = 1
 let g:OmniSharp_start_without_solution = 1
 let g:OmniSharp_highlighting = 0
 let g:OmniSharp_selector_ui = ''


### PR DESCRIPTION
This PR adds a new variable `g:OmniSharp_server_use_net6` to support the new native dotnet net6.0 server version