### PR TITLE
Improve vimspector config file generation

### DIFF
--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -33,18 +33,14 @@ function! OmniSharp#actions#project#DebugProject(stopAtEntry, ...) abort
     let project = getbufvar(a:bufnr, 'OmniSharp_host').project
     " Make sure we're not running on a csx script
     if project.ScriptProject is v:null
-      let targetProgramFilename =    fnamemodify(project.MsBuildProject.TargetPath, ':t')
-      let folderWithAppConfigFiles = fnamemodify(project.MsBuildProject.TargetPath, ':h:p')
-      if has('win32')
-        let folderWithAppConfigFiles = substitute(folderWithAppConfigFiles, '\', '/', 'g')
-      endif
+      let programPath = project.MsBuildProject.TargetPath
+      if has('win32') | let programPath = substitute(programPath, '\', '/', 'g') | endif
       call vimspector#LaunchWithConfigurations({
       \  'launch': {
       \    'adapter': 'netcoredbg',
       \    'configuration': {
       \      'request': 'launch',
-      \      'cwd': folderWithAppConfigFiles,
-      \      'program': targetProgramFilename,
+      \      'program': programPath,
       \      'args': a:args,
       \      'stopAtEntry': a:stopAtEntry ? v:true : v:false
       \    }
@@ -63,11 +59,8 @@ function! OmniSharp#actions#project#CreateDebugConfig(stopAtEntry, ...) abort
   let bufnr = bufnr('%')
   function! CreateDebugConfigCb(bufnr, stopAtEntry, args) abort
     let host = getbufvar(a:bufnr, 'OmniSharp_host')
-    let targetProgramFilename =    fnamemodify(host.project.MsBuildProject.TargetPath, ':t')
-    let folderWithAppConfigFiles = fnamemodify(host.project.MsBuildProject.TargetPath, ':h:p')
-    if has('win32')
-      let folderWithAppConfigFiles = substitute(folderWithAppConfigFiles, '\', '/', 'g')
-    endif
+    let programPath = host.project.MsBuildProject.TargetPath
+    if has('win32') | let programPath = substitute(programPath, '\', '/', 'g') | endif
     let contents = [
           \' {',
           \'   "configurations": {',
@@ -82,8 +75,7 @@ function! OmniSharp#actions#project#CreateDebugConfig(stopAtEntry, ...) abort
           \'       "adapter": "netcoredbg",',
           \'       "configuration": {',
           \'         "request": "launch",',
-          \'         "cwd": "' . folderWithAppConfigFiles . '",',
-          \'         "program": "' . targetProgramFilename . '",',
+          \'         "program": "'.programPath.'",',
           \'         "args": ' . json_encode(a:args) . ',',
           \'         "stopAtEntry": ' . (a:stopAtEntry ? 'true' : 'false'),
           \'       }',


### PR DESCRIPTION
Currently:
1. the working directory is not set which means access to runtime config files may or may not be possible
2. on windows, the targetPath is expressed with non-escaped backslashes, which makes the json value not the one the user wants