### PR TITLE
Install Omnisharp-Roslyn arm64 for architecture reported as aarch64

### DIFF
--- a/installer/omnisharp-manager.sh
+++ b/installer/omnisharp-manager.sh
@@ -72,6 +72,7 @@ if [ -z "$mono" ]; then
         "x86_64")   machine="x64";;
         "i368")     machine="x86";;
         "arm64")    machine="arm64";;
+        "aarch64")    machine="arm64";;
         *)
             echo "Error: architecture not supported"
             exit 1


### PR DESCRIPTION
Various arm64-compatible linux versions (including the base docker images for Ubuntu and Debian) report their architecture as 'aarch64' when installed on an arm64 platform (e.g., an M1 mac).  Omnisharp-vim does not recognize that architecture and so fails on the install of Omnisharp-Roslyn with "Error: architecture not supported."  In fact, however, it will work fine if the arm64 version is installed[ because the architectures are the same](https://stackoverflow.com/questions/31851611/differences-between-arm64-and-aarch64/47274698#47274698).

This minor patch causes the installer to treat aarch64 as arm64, allowing the install to proceed.