### PR TITLE
fix timeout for autocompletion on Windows

### DIFF
--- a/autoload/OmniSharp/actions/complete.vim
+++ b/autoload/OmniSharp/actions/complete.vim
@@ -16,7 +16,7 @@ function! OmniSharp#actions#complete#Get(partial, ...) abort
       " No callback has been passed in, so this function should return
       " synchronously, so it can be used as an omnifunc
       let starttime = reltime()
-      while s:complete_pending && reltime(starttime)[0] < g:OmniSharp_timeout
+      while s:complete_pending && reltimefloat(reltime(starttime)) < g:OmniSharp_timeout
         sleep 50m
       endwhile
       if s:complete_pending | return [] | endif


### PR DESCRIPTION
On Windows, `reltime(starttime)[0]` seems to always be `0`, while `reltime(starttime)[1]` seems to be a number of milliseconds.

From vim's doc about `reltime`:
> reltime([{start} [, {end}]])				*reltime()*
		Return an item that represents a time value.  The item is a
		list with items that depend on the system.  In Vim 9 script
		list<any> can be used.
		The item can be passed to |reltimestr()| to convert it to a
		string or |reltimefloat()| to convert to a Float.

If the output of  `reltime` is OS-related, then I think the use of `reltimefloat` is justified so the behaviour is the same no matter the OS.