### PR TITLE
Allow calling /updatebuffer with an empty buffer content

### DIFF
--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -182,7 +182,10 @@ function! OmniSharp#stdio#Request(command, opts) abort
   \   'Column': cnum,
   \ }
   \}
-  if send_buffer
+  if has_key(a:opts, 'EmptyBuffer')
+    let body.Arguments.Buffer = ''
+    let sep = ''
+  elseif send_buffer
     let lines = getbufline(bufnr, 1, '$')
     if has_key(a:opts, 'OverrideBuffer')
       let lines[a:opts.OverrideBuffer.LineNr - 1] = a:opts.OverrideBuffer.Line


### PR DESCRIPTION
I'm using custom script in order to rename/move a file, using dirvish.

Whenever I do that, OmniSharp has to be notified that the former buffer is obsolete and that it has to stop trying to use it.

One way of doing that is to send the information that the former buffer is empty, before the renaming/moving operation.

Omnisharp doesn't offer yet a way through its public interface to configure the `body.Arguments.Buffer` value.

I don't see a case where anyone would manually send a custom `Buffer` argument apart from an empty one, hence the implementation I'm suggesting using a `EmptyBuffer` value.