### PR TITLE
Use virtualedit to simplify inserting buffer edits

### DIFF
--- a/autoload/OmniSharp/buffer.vim
+++ b/autoload/OmniSharp/buffer.vim
@@ -100,7 +100,8 @@ function! OmniSharp#buffer#Update(responseBody) abort
   let changes = get(a:responseBody, 'Changes', [])
   if type(changes) == type(v:null) | let changes = [] | endif
 
-  let virtualedit = &virtualedit ==? 'all'
+  let virtualedit_bak = &virtualedit
+  let &l:virtualedit = 'all'
   if len(changes)
     for change in changes
       let text = join(split(change.NewText, '\r\?\n', 1), "\n")
@@ -111,15 +112,6 @@ function! OmniSharp#buffer#Update(responseBody) abort
       let start = [change.StartLine, startCol]
       let end = [change.EndLine, endCol]
       call cursor(start)
-      if startCol > len(getline('.')) && !virtualedit
-        " We can't set a mark after the last character of the line, so add an
-        " extra charaqcter which will be immediately deleted again
-        noautocmd normal! a<
-        if start == end
-          let endCol += 1
-          let end[0] = endCol
-        endif
-      endif
       call cursor(change.EndLine, max([1, endCol - 1]))
       let lineLen = len(getline('.'))
       if change.StartLine < change.EndLine && (endCol == 1 || lineLen == 0)
@@ -156,6 +148,7 @@ function! OmniSharp#buffer#Update(responseBody) abort
     let pos[1] = min([pos[1], line('$')])
     call setpos('.', pos)
   endif
+  let &l:virtualedit = virtualedit_bak
 endfunction
 
 function! OmniSharp#buffer#Valid(...) abort

--- a/test/fixusings.vader
+++ b/test/fixusings.vader
@@ -106,6 +106,76 @@ Expect cs(should add another required using):
 
 
 Given cs():
+  using System;
+
+  using System.Text;
+
+  public class Test
+  {
+    public Test()
+    {
+        Console.WriteLine(Encoding.UTF8.ToString());
+        Console.WriteLine(DateTime.Parse("1999-01-01T00:01:01Z", CultureInfo.InvariantCulture));
+    }
+  }
+
+Execute (run fix usings with empty line and virtualedit=):
+  call OmniSharpTestInitializeBuffer('FixUsings4')
+  set virtualedit=
+  call OmniSharpWarmup('OmniSharp#actions#usings#Fix', [])
+  call OmniSharpTestAwait('OmniSharp#actions#usings#Fix', [])
+
+Expect cs(should add another required using between the others):
+  using System;
+  using System.Globalization;
+  using System.Text;
+
+  public class Test
+  {
+    public Test()
+    {
+        Console.WriteLine(Encoding.UTF8.ToString());
+        Console.WriteLine(DateTime.Parse("1999-01-01T00:01:01Z", CultureInfo.InvariantCulture));
+    }
+  }
+
+
+Given cs():
+  using System;
+
+  using System.Text;
+
+  public class Test
+  {
+    public Test()
+    {
+        Console.WriteLine(Encoding.UTF8.ToString());
+        Console.WriteLine(DateTime.Parse("1999-01-01T00:01:01Z", CultureInfo.InvariantCulture));
+    }
+  }
+
+Execute (run fix usings with empty line and virtualedit=all):
+  call OmniSharpTestInitializeBuffer('FixUsings4')
+  set virtualedit=all
+  call OmniSharpWarmup('OmniSharp#actions#usings#Fix', [])
+  call OmniSharpTestAwait('OmniSharp#actions#usings#Fix', [])
+
+Expect cs(should add another required using between the others):
+  using System;
+  using System.Globalization;
+  using System.Text;
+
+  public class Test
+  {
+    public Test()
+    {
+        Console.WriteLine(Encoding.UTF8.ToString());
+        Console.WriteLine(DateTime.Parse("1999-01-01T00:01:01Z", CultureInfo.InvariantCulture));
+    }
+  }
+
+
+Given cs():
   public class test {
       class1 ns1 = new class1();
   }


### PR DESCRIPTION
Previously we used a clumsy hack to handle inserting buffer changes from the server at the end of a line. However there were cases where this still wasn't working correctly.

This change temporarily sets `virtualedit=all` (locally for the window), which simplifies the code and removes the hack.