### PR TITLE
WIP: Test runner

### DIFF
--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -298,12 +298,15 @@ function! s:run.process(Callback, bufnr, tests, response) abort
   \ 'locations': []
   \}
   for result in a:response.Body.Results
+    " Strip method signature from test method fullname
+    let fullname = substitute(result.MethodName, '(.*)$', '', '')
     " Strip namespace and classname from test method name
+    let name = substitute(result.MethodName, '^.*\.', '', '')
     let location = {
     \ 'bufnr': a:bufnr,
-    \ 'fullname': result.MethodName,
+    \ 'fullname': fullname,
     \ 'filename': bufname(a:bufnr),
-    \ 'name': substitute(result.MethodName, '^.*\.', '', '')
+    \ 'name': name
     \}
     let locations = [location]
     " Write any standard output to message-history

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -410,6 +410,7 @@ function! s:utils.init.extract(Callback, codeStructures) abort
   \ 'bufnr': cs[0],
   \ 'tests': s:utils.extractTests(cs[1])
   \}})
+  call OmniSharp#testrunner#SetTests(bufferTests)
   call a:Callback(bufferTests)
 endfunction
 

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -148,19 +148,20 @@ function! s:run.single.test(testName, bufferTests) abort
 endfunction
 
 function! s:run.single.complete(summary) abort
-  if len(a:summary.locations) > 1
+  let locations = filter(copy(a:summary.locations), 'has_key(v:val, "bufnr")')
+  if len(locations) > 1
     " A single test was run, but multiple test results were returned. This can
     " happen when using e.g. NUnit TestCaseSources which re-run the test using
     " different arguments.
     call s:run.multiple.complete([a:summary])
     return
   endif
-  if a:summary.pass && len(a:summary.locations) == 0
+  if a:summary.pass && len(locations) == 0
     echomsg 'No tests were run'
     " Do we ever reach here?
     " call OmniSharp#testrunner#StateSkipped(bufnr)
   endif
-  let location = a:summary.locations[0]
+  let location = locations[0]
   call OmniSharp#testrunner#StateComplete(location)
   if a:summary.pass
     if get(location, 'type', '') ==# 'W'

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -305,6 +305,8 @@ function! s:run.process(Callback, bufnr, tests, response) abort
     if result.Outcome =~? 'failed'
       let location.type = 'E'
       let location.text = location.name . ': ' . result.ErrorMessage
+      let location.message = split(result.ErrorMessage, '\r\?\n')
+      let location.stacktrace = split(result.ErrorStackTrace, '\r\?\n')
       let st = result.ErrorStackTrace
       let parsed = matchlist(st, '.* in \(.\+\):line \(\d\+\)')
       if len(parsed) > 0

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -159,7 +159,7 @@ function! s:run.single.complete(summary) abort
   else
     echomsg location.name . ': failed'
     let title = 'Test failure: ' . location.name
-    if get(g:, 'OmniSharp_test_quickfix', 1) == 0 | return | endif
+    if get(g:, 'OmniSharp_runtests_quickfix', 0) == 0 | return | endif
     let what = {}
     if len(a:summary.locations) > 1
       let what.quickfixtextfunc = {info->
@@ -274,7 +274,7 @@ function! s:run.multiple.complete(summary) abort
     endif
     call s:utils.log.warn(title)
   endif
-  if get(g:, 'OmniSharp_test_quickfix', 1) == 0 | return | endif
+  if get(g:, 'OmniSharp_runtests_quickfix', 0) == 0 | return | endif
   call OmniSharp#locations#SetQuickfix(locations, title)
 endfunction
 

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -131,18 +131,19 @@ function! s:run.single.test(testName, bufferTests) abort
   let currentTest = currentTest[0]
   let project = OmniSharp#GetHost(bufnr).project
   let targetFramework = project.MsBuildProject.TargetFramework
+  let currentTestName = substitute(currentTest.name, '(.*)$', '', '')
   let opts = {
   \ 'ResponseHandler': funcref('s:run.process', [s:run.single.complete, bufnr, tests]),
   \ 'BufNum': bufnr,
   \ 'Parameters': {
-  \   'MethodName': substitute(currentTest.name, '(.*)$', '', ''),
+  \   'MethodName': currentTestName,
   \   'NoBuild': get(s:, 'nobuild', 0),
   \   'TestFrameworkName': currentTest.framework,
   \   'TargetFrameworkVersion': targetFramework
   \ },
   \ 'SendBuffer': 0
   \}
-  echomsg 'Running test ' . currentTest.name
+  echomsg 'Running test ' . currentTestName
   call OmniSharp#stdio#Request('/v2/runtest', opts)
 endfunction
 
@@ -243,7 +244,7 @@ function! s:run.multiple.inBuffer(bufnr, tests, Callback) abort
   \ 'ResponseHandler': funcref('s:run.process', [a:Callback, a:bufnr, a:tests]),
   \ 'BufNum': a:bufnr,
   \ 'Parameters': {
-  \   'MethodNames': map(copy(a:tests), {i,t -> t.name}),
+  \   'MethodNames': map(copy(a:tests), {i,t -> substitute(t.name, '(.*)$', '', '')}),
   \   'NoBuild': get(s:, 'nobuild', 0),
   \   'TestFrameworkName': a:tests[0].framework,
   \   'TargetFrameworkVersion': targetFramework
@@ -427,7 +428,6 @@ function! s:utils.extractTests(bufnr, codeElements) abort
       let testStart = min(filter(copy(testlines), {_,l -> l >= testStart}))
       for dt in OmniSharp#GetHost(a:bufnr).project.tests
         if dt.CodeFilePath ==# filename && dt.LineNumber == testStart
-          " \ 'name': element.Properties.testMethodName,
           call add(tests, {
           \ 'name': dt.FullyQualifiedName,
           \ 'framework': element.Properties.testFramework,

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -1,30 +1,38 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:runningTest = 0
+
+" Function dict for debug-test functions
+let s:debug = {}
+let s:debug.process = {}
+let s:run = {}
+let s:run.running = 0
+let s:run.single = {}
+let s:run.multiple = {}
+let s:utils = {}
+let s:utils.log = {}
 
 function! OmniSharp#actions#test#Debug(nobuild) abort
-  if !s:CheckCapabilities() | return | endif
+  if !s:utils.capabilities() | return | endif
   let s:nobuild = a:nobuild
   if !OmniSharp#util#HasVimspector()
-    return s:Warn('Vimspector required to debug tests')
+    return s:utils.log.warn('Vimspector required to debug tests')
   endif
-  call s:InitializeTestBuffers([bufnr('%')], function('s:DebugTest'))
+  call s:utils.initialize([bufnr('%')], s:debug.prepare)
 endfunction
 
-function! s:DebugTest(bufferCodeStructures) abort
+function! s:debug.prepare(bufferCodeStructures) abort
   let bufnr = a:bufferCodeStructures[0][0]
   let codeElements = a:bufferCodeStructures[0][1]
-  let tests = s:FindTests(codeElements)
-  let currentTest = s:FindTest(tests)
+  let tests = s:utils.extractTests(codeElements)
+  let currentTest = s:utils.findTest(tests)
   if type(currentTest) != type({})
-    let s:runningTest = 0
-    return s:Warn('No test found')
+    return s:utils.log.warn('No test found')
   endif
   let project = OmniSharp#GetHost(bufnr).project
   let targetFramework = project.MsBuildProject.TargetFramework
   let opts = {
-  \ 'ResponseHandler': function('s:DebugTestsRH', [bufnr, tests]),
+  \ 'ResponseHandler': funcref('s:debug.launch', [bufnr, tests]),
   \ 'Parameters': {
   \   'MethodName': currentTest.name,
   \   'NoBuild': get(s:, 'nobuild', 0),
@@ -37,81 +45,82 @@ function! s:DebugTest(bufferCodeStructures) abort
   call OmniSharp#stdio#Request('/v2/debugtest/getstartinfo', opts)
 endfunction
 
-function! s:DebugTestsRH(bufnr, tests, response) abort
-  let testhost = [a:response.Body.FileName] + split(substitute(a:response.Body.Arguments, '\"', '', 'g'), ' ')
-  let testhost_job_pid = s:StartTestProcess(testhost)
-  let g:testhost_job_pid = testhost_job_pid
-
+function! s:debug.launch(bufnr, tests, response) abort
+  let args = split(substitute(a:response.Body.Arguments, '\"', '', 'g'), ' ')
+  let cmd = a:response.Body.FileName
+  let testhost = [cmd] + args
+  if !s:debug.process.start(testhost) | return | endif
+  let s:run.running = 1
   let host = OmniSharp#GetHost()
   let s:omnisharp_pre_debug_cwd = getcwd()
   let new_cwd = fnamemodify(host.sln_or_dir, ':p:h')
   call vimspector#LaunchWithConfigurations({
-  \  'attach': {
-  \    'adapter': 'netcoredbg',
-  \    'configuration': {
-  \      'request': 'attach',
-  \      'processId': testhost_job_pid
-  \    }
-  \  }
+  \ 'attach': {
+  \   'adapter': 'netcoredbg',
+  \   'configuration': {
+  \     'request': 'attach',
+  \     'processId': s:debug.process.pid
+  \   }
+  \ }
   \})
   execute 'tcd' new_cwd
   let opts = {
-  \ 'ResponseHandler': function('s:DebugComplete'),
+  \ 'ResponseHandler': s:debug.complete,
   \ 'Parameters': {
-  \   'TargetProcessId': testhost_job_pid
+  \   'TargetProcessId': s:debug.process.pid
   \ }
   \}
   echomsg 'Launching debugged test'
   call OmniSharp#stdio#Request('/v2/debugtest/launch', opts)
 endfunction
 
-function! s:DebugComplete(response) abort
+function! s:debug.complete(response) abort
   if !a:response.Success
-    call s:Warn(['Error debugging unit test', a:response.Message])
+    call s:utils.log.warn(['Error debugging unit test', a:response.Message])
   endif
 endfunction
 
-function! s:StartTestProcess(command) abort
-  function! s:TestProcessClosed(...) abort
-    call OmniSharp#stdio#Request('/v2/debugtest/stop', {})
-    let s:runningTest = 0
-    call vimspector#Reset()
-    execute 'tcd' s:omnisharp_pre_debug_cwd
-    unlet s:omnisharp_pre_debug_cwd
-  endfunction
+function! s:debug.process.start(command) abort
   if OmniSharp#proc#supportsNeovimJobs()
-    let job = jobpid(jobstart(a:command, {
-      \ 'on_exit': function('s:TestProcessClosed')
-    \ }))
+    let jobid = jobstart(a:command, { 'on_exit': self.closed })
+    let self.pid = jobpid(jobid)
   elseif OmniSharp#proc#supportsVimJobs()
-    let job = split(job_start(a:command, {
-      \ 'close_cb': function('s:TestProcessClosed')
-    \ }), ' ',)[1]
+    let job = job_start(a:command, { 'close_cb': self.closed })
+    let self.pid = split(job, ' ')[1]
   else
-    call s:Warn('Cannot launch test process.')
+    return s:utils.log.warn('Cannot launch test process.')
   endif
-  return job
+  return 1
 endfunction
+
+function! s:debug.process.closed(...) abort
+  call OmniSharp#stdio#Request('/v2/debugtest/stop', {})
+  let s:run.running = 0
+  call vimspector#Reset()
+  execute 'tcd' s:omnisharp_pre_debug_cwd
+  unlet s:omnisharp_pre_debug_cwd
+endfunction
+
 
 function! OmniSharp#actions#test#Run(nobuild) abort
-  if !s:CheckCapabilities() | return | endif
+  if !s:utils.capabilities() | return | endif
   let s:nobuild = a:nobuild
-  call s:InitializeTestBuffers([bufnr('%')], function('s:RunTest'))
+  call s:utils.initialize([bufnr('%')], s:run.single.test)
 endfunction
 
-function! s:RunTest(bufferCodeStructures) abort
+function! s:run.single.test(bufferCodeStructures) abort
   let bufnr = a:bufferCodeStructures[0][0]
   let codeElements = a:bufferCodeStructures[0][1]
-  let tests = s:FindTests(codeElements)
-  let currentTest = s:FindTest(tests)
+  let tests = s:utils.extractTests(codeElements)
+  let currentTest = s:utils.findTest(tests)
   if type(currentTest) != type({})
-    let s:runningTest = 0
-    return s:Warn('No test found')
+    return s:utils.log.warn('No test found')
   endif
+  let s:run.running = 1
   let project = OmniSharp#GetHost(bufnr).project
   let targetFramework = project.MsBuildProject.TargetFramework
   let opts = {
-  \ 'ResponseHandler': function('s:RunTestsRH', [function('s:RunComplete'), bufnr, tests]),
+  \ 'ResponseHandler': funcref('s:run.process', [s:run.single.complete, bufnr, tests]),
   \ 'Parameters': {
   \   'MethodName': currentTest.name,
   \   'NoBuild': get(s:, 'nobuild', 0),
@@ -124,29 +133,31 @@ function! s:RunTest(bufferCodeStructures) abort
   call OmniSharp#stdio#Request('/v2/runtest', opts)
 endfunction
 
-function! s:RunComplete(summary) abort
+function! s:run.single.complete(summary) abort
   if a:summary.pass
     if len(a:summary.locations) == 0
       echomsg 'No tests were run'
     elseif get(a:summary.locations[0], 'type', '') ==# 'W'
-      call s:Warn(a:summary.locations[0].name . ': skipped')
+      call s:utils.log.warn(a:summary.locations[0].name . ': skipped')
     else
-      call s:Emphasize(a:summary.locations[0].name . ': passed')
+      call s:utils.log.emphasize(a:summary.locations[0].name . ': passed')
     endif
   else
     echomsg a:summary.locations[0].name . ': failed'
     let title = 'Test failure: ' . a:summary.locations[0].name
     let what = {}
     if len(a:summary.locations) > 1
-      let what = {'quickfixtextfunc': function('s:QuickfixTextFuncStackTrace')}
+      let what.quickfixtextfunc = {info->
+      \ map(getqflist({'id': info.id, 'items': 1}).items, {_,i -> i.text})}
     endif
     call OmniSharp#locations#SetQuickfix(a:summary.locations, title, what)
   endif
 endfunction
 
+
 function! OmniSharp#actions#test#RunInFile(nobuild, ...) abort
   let s:nobuild = a:nobuild
-  if !s:CheckCapabilities() | return | endif
+  if !s:utils.capabilities() | return | endif
   if a:0 && type(a:1) == type([])
     let files = a:1
   elseif a:0 && type(a:1) == type('')
@@ -163,51 +174,46 @@ function! OmniSharp#actions#test#RunInFile(nobuild, ...) abort
       if filereadable(l:file)
         let nr = bufadd(l:file)
       else
-        call s:Warn('File not found: ' . l:file)
+        call s:utils.log.warn('File not found: ' . l:file)
         continue
       endif
     endif
     call add(buffers, nr)
   endfor
-  if len(buffers) == 0
-    return
-  endif
-  let s:runningTest = 1
-  call s:InitializeTestBuffers(buffers, function('s:RunTestsInFiles'))
+  if len(buffers) == 0 | return | endif
+  call s:utils.initialize(buffers, s:run.multiple.prepare)
 endfunction
 
-function! s:RunTestsInFiles(bufferCodeStructures) abort
+function! s:run.multiple.prepare(bufferCodeStructures) abort
   let Requests = []
   for bcs in a:bufferCodeStructures
     let bufnr = bcs[0]
     let codeElements = bcs[1]
-    let tests = s:FindTests(codeElements)
+    let tests = s:utils.extractTests(codeElements)
     if len(tests)
-      call add(Requests, function('s:RunTestsInFile', [bufnr, tests]))
+      call add(Requests, funcref('s:run.multiple.inBuffer', [bufnr, tests]))
     endif
   endfor
-  if len(Requests) == 0
-    let s:runningTest = 0
-    return s:Warn('No tests found')
-  endif
+  if len(Requests) == 0 | return s:utils.log.warn('No tests found') | endif
+  let s:run.running = 1
   if g:OmniSharp_runtests_parallel
     if g:OmniSharp_runtests_echo_output
       echomsg '---- Running tests ----'
     endif
-    call OmniSharp#util#AwaitParallel(Requests, function('s:RunInFileComplete'))
+    call OmniSharp#util#AwaitParallel(Requests, s:run.multiple.complete)
   else
-    call OmniSharp#util#AwaitSequence(Requests, function('s:RunInFileComplete'))
+    call OmniSharp#util#AwaitSequence(Requests, s:run.multiple.complete)
   endif
 endfunction
 
-function! s:RunTestsInFile(bufnr, tests, Callback) abort
+function! s:run.multiple.inBuffer(bufnr, tests, Callback) abort
   if !g:OmniSharp_runtests_parallel && g:OmniSharp_runtests_echo_output
     echomsg '---- Running tests: ' . bufname(a:bufnr) . ' ----'
   endif
   let project = OmniSharp#GetHost(a:bufnr).project
   let targetFramework = project.MsBuildProject.TargetFramework
   let opts = {
-  \ 'ResponseHandler': function('s:RunTestsRH', [a:Callback, a:bufnr, a:tests]),
+  \ 'ResponseHandler': funcref('s:run.process', [a:Callback, a:bufnr, a:tests]),
   \ 'BufNum': a:bufnr,
   \ 'Parameters': {
   \   'MethodNames': map(copy(a:tests), {i,t -> t.name}),
@@ -220,7 +226,7 @@ function! s:RunTestsInFile(bufnr, tests, Callback) abort
   call OmniSharp#stdio#Request('/v2/runtestsinclass', opts)
 endfunction
 
-function! s:RunInFileComplete(summary) abort
+function! s:run.multiple.complete(summary) abort
   let pass = 1
   let locations = []
   for summary in a:summary
@@ -231,7 +237,7 @@ function! s:RunInFileComplete(summary) abort
   endfor
   if pass
     let title = len(locations) . ' tests passed'
-    call s:Emphasize(title)
+    call s:utils.log.emphasize(title)
   else
     let passed = 0
     let noStackTrace = 0
@@ -247,17 +253,18 @@ function! s:RunInFileComplete(summary) abort
     if noStackTrace
       let title .= '. Check :messages for details.'
     endif
-    call s:Warn(title)
+    call s:utils.log.warn(title)
   endif
   call OmniSharp#locations#SetQuickfix(locations, title)
 endfunction
 
-" Response handler used when running a single test, or tests in files
-function! s:RunTestsRH(Callback, bufnr, tests, response) abort
-  let s:runningTest = 0
+
+" Response handler used when running a single test, or multiple tests in files
+function! s:run.process(Callback, bufnr, tests, response) abort
+  let s:run.running = 0
   if !a:response.Success | return | endif
   if type(a:response.Body.Results) != type([])
-    return s:Warn('Error: "' . a:response.Body.Failure .
+    return s:utils.log.warn('Error: "' . a:response.Body.Failure .
     \ '"   - this may indicate a failed build')
   endif
   let summary = {
@@ -318,7 +325,7 @@ function! s:RunTestsRH(Callback, bufnr, tests, response) abort
     endif
     if !has_key(location, 'lnum')
       " Success, or unexpected test failure.
-      let test = s:FindTest(a:tests, result.MethodName)
+      let test = s:utils.findTest(a:tests, result.MethodName)
       if type(test) == type({})
         let location.lnum = test.nameRange.Start.Line
         let location.col = test.nameRange.Start.Column
@@ -332,54 +339,26 @@ function! s:RunTestsRH(Callback, bufnr, tests, response) abort
   call a:Callback(summary)
 endfunction
 
-" Utilities
-" =========
 
-function! s:CheckCapabilities() abort
+function! OmniSharp#actions#test#Validate() abort
+  return s:utils.capabilities()
+endfunction
+
+function! s:utils.capabilities() abort
   if !g:OmniSharp_server_stdio
-    return s:Warn('stdio only, sorry')
+    return self.log.warn('stdio only, sorry')
   endif
   if g:OmniSharp_translate_cygwin_wsl
-    return s:Warn('Tests do not work in WSL unfortunately')
+    return self.log.warn('Tests do not work in WSL unfortunately')
   endif
-  if s:runningTest
-    return s:Warn('A test is already running')
+  if s:run.running
+    return self.log.warn('A test is already running')
   endif
   return 1
-endfunction
-
-function! s:EchoMessages(highlightGroup, message) abort
-  let messageLines = type(a:message) == type([]) ? a:message : [a:message]
-  execute 'echohl' a:highlightGroup
-  for messageLine in messageLines
-    echomsg messageLine
-  endfor
-  echohl None
-endfunction
-
-function! s:Emphasize(message) abort
-  call s:EchoMessages('Title', a:message)
-  return 1
-endfunction
-
-" Find the test in a list of tests that matches the current cursor position
-function! s:FindTest(tests, ...) abort
-  for test in a:tests
-    if a:0
-      if test.name ==# a:1
-        return test
-      endif
-    else
-      if line('.') >= test.range.Start.Line && line('.') <= test.range.End.Line
-        return test
-      endif
-    endif
-  endfor
-  return 0
 endfunction
 
 " Find all of the test methods in a CodeStructure response
-function! s:FindTests(codeElements) abort
+function! s:utils.extractTests(codeElements) abort
   if type(a:codeElements) != type([]) | return [] | endif
   let tests = []
   for element in a:codeElements
@@ -394,15 +373,31 @@ function! s:FindTests(codeElements) abort
       \ 'nameRange': element.Ranges.name,
       \})
     endif
-    call extend(tests, s:FindTests(get(element, 'Children', [])))
+    call extend(tests, self.extractTests(get(element, 'Children', [])))
   endfor
   return tests
+endfunction
+
+" Find the test in a list of tests that matches the current cursor position
+function! s:utils.findTest(tests, ...) abort
+  for test in a:tests
+    if a:0
+      if test.name ==# a:1
+        return test
+      endif
+    else
+      if line('.') >= test.range.Start.Line && line('.') <= test.range.End.Line
+        return test
+      endif
+    endif
+  endfor
+  return 0
 endfunction
 
 " For the given buffers, fetch the project structures, then fetch the buffer
 " code structures. All operations are performed asynchronously, and the
 " a:Callback is called when all buffer code structures have been fetched.
-function! s:InitializeTestBuffers(buffers, Callback) abort
+function! s:utils.initialize(buffers, Callback) abort
   function! s:AwaitForBuffers(buffers, functionName, AwaitCallback, ...) abort
     call OmniSharp#util#AwaitParallel(
     \ map(copy(a:buffers), {i,b -> function(a:functionName, [b])}),
@@ -413,14 +408,23 @@ function! s:InitializeTestBuffers(buffers, Callback) abort
   \   [a:buffers, 'OmniSharp#actions#codestructure#Get', a:Callback]))
 endfunction
 
-function! s:Warn(message) abort
-  call s:EchoMessages('WarningMsg', a:message)
-  return 0
+function! s:utils.log.echo(highlightGroup, message) abort
+  let messageLines = type(a:message) == type([]) ? a:message : [a:message]
+  execute 'echohl' a:highlightGroup
+  for messageLine in messageLines
+    echomsg messageLine
+  endfor
+  echohl None
 endfunction
 
-function! s:QuickfixTextFuncStackTrace(info) abort
-  let items = getqflist({'id' : a:info.id, 'items' : 1}).items
-  return map(items, {_,i -> i.text})
+function! s:utils.log.emphasize(message) abort
+  call self.echo('Title', a:message)
+  return 1
+endfunction
+
+function! s:utils.log.warn(message) abort
+  call self.echo('WarningMsg', a:message)
+  return 0
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -110,6 +110,11 @@ function! s:debug.process.closed(...) abort
 endfunction
 
 
+function! OmniSharp#actions#test#Reset() abort
+  let s:run.running = 0
+endfunction
+
+
 function! OmniSharp#actions#test#Run(nobuild, ...) abort
   if !s:utils.capabilities() | return | endif
   if !s:utils.isrunning() | return | endif

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -1,8 +1,6 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-
-" Function dict for debug-test functions
 let s:debug = {}
 let s:debug.process = {}
 let s:run = {}
@@ -142,7 +140,7 @@ function! s:run.single.complete(summary) abort
     " call OmniSharp#testrunner#StateSkipped(bufnr)
   endif
   let location = a:summary.locations[0]
-  call s:run.updatestate(location)
+  call OmniSharp#testrunner#StateComplete(location)
   if a:summary.pass
     if get(location, 'type', '') ==# 'W'
       call s:utils.log.warn(location.name . ': skipped')
@@ -245,7 +243,7 @@ function! s:run.multiple.complete(summary) abort
     endif
   endfor
   for location in locations
-    call s:run.updatestate(location)
+    call OmniSharp#testrunner#StateComplete(location)
   endfor
   if pass
     let title = len(locations) . ' tests passed'
@@ -295,9 +293,11 @@ function! s:run.process(Callback, bufnr, tests, response) abort
     let locations = [location]
     " Write any standard output to message-history
     if len(get(result, 'StandardOutput', []))
+      let location.output = []
       echomsg 'Standard output from test ' . location.name . ':'
       for output in result.StandardOutput
         for line in split(trim(output), '\r\?\n', 1)
+          call add(location.output, line)
           echomsg '  ' . line
         endfor
       endfor
@@ -352,16 +352,6 @@ function! s:run.process(Callback, bufnr, tests, response) abort
     endfor
   endfor
   call a:Callback(summary)
-endfunction
-
-function! s:run.updatestate(location) abort
-  if get(a:location, 'type', '') ==# 'E'
-    call OmniSharp#testrunner#StateFailed(a:location.bufnr, a:location.fullname)
-  elseif get(a:location, 'type', '') ==# 'W'
-    call OmniSharp#testrunner#StateSkipped(a:location.bufnr, a:location.fullname)
-  else
-    call OmniSharp#testrunner#StatePassed(a:location.bufnr, a:location.fullname)
-  endif
 endfunction
 
 

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -149,6 +149,7 @@ function! s:run.single.complete(summary) abort
   else
     echomsg location.name . ': failed'
     let title = 'Test failure: ' . location.name
+    if get(g:, 'OmniSharp_test_quickfix', 1) == 0 | return | endif
     let what = {}
     if len(a:summary.locations) > 1
       let what.quickfixtextfunc = {info->
@@ -263,6 +264,7 @@ function! s:run.multiple.complete(summary) abort
     endif
     call s:utils.log.warn(title)
   endif
+  if get(g:, 'OmniSharp_test_quickfix', 1) == 0 | return | endif
   call OmniSharp#locations#SetQuickfix(locations, title)
 endfunction
 

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -13,6 +13,7 @@ let s:utils.log = {}
 
 function! OmniSharp#actions#test#Debug(nobuild, ...) abort
   if !s:utils.capabilities() | return | endif
+  if !s:utils.isrunning() | return | endif
   let s:nobuild = a:nobuild
   if !OmniSharp#util#HasVimspector()
     return s:utils.log.warn('Vimspector required to debug tests')
@@ -111,6 +112,7 @@ endfunction
 
 function! OmniSharp#actions#test#Run(nobuild, ...) abort
   if !s:utils.capabilities() | return | endif
+  if !s:utils.isrunning() | return | endif
   let s:nobuild = a:nobuild
   let bufnr = a:0 ? (type(a:1) == type('') ? bufnr(a:1) : a:1) : bufnr('%')
   let RunTest = funcref('s:run.single.test', [a:0 > 1 ? a:2 : ''])
@@ -186,6 +188,7 @@ endfunction
 function! OmniSharp#actions#test#RunInFile(nobuild, ...) abort
   let s:nobuild = a:nobuild
   if !s:utils.capabilities() | return | endif
+  if !s:utils.isrunning() | return | endif
   if a:0 && type(a:1) == type([])
     let files = a:1
   elseif a:0 && type(a:1) == type('')
@@ -395,6 +398,10 @@ function! s:utils.capabilities() abort
   if g:OmniSharp_translate_cygwin_wsl
     return self.log.warn('Tests do not work in WSL unfortunately')
   endif
+  return 1
+endfunction
+
+function! s:utils.isrunning() abort
   if s:run.running
     return self.log.warn('A test is already running')
   endif

--- a/autoload/OmniSharp/actions/test.vim
+++ b/autoload/OmniSharp/actions/test.vim
@@ -424,6 +424,7 @@ endfunction
 " code structures. All operations are performed asynchronously, and the
 " a:Callback is called when all buffer code structures have been fetched.
 function! s:utils.initialize(buffers, Callback) abort
+  call OmniSharp#testrunner#Init(a:buffers)
   call s:utils.init.await(a:buffers, 'OmniSharp#actions#project#Get',
   \ funcref('s:utils.init.await', [a:buffers, 'OmniSharp#actions#codestructure#Get',
   \   funcref('s:utils.init.extract', [a:Callback])]))

--- a/autoload/OmniSharp/popup.vim
+++ b/autoload/OmniSharp/popup.vim
@@ -322,6 +322,8 @@ function! s:VimOpen(what, opts) abort
   endif
   " Prevent popup buffer from being listed in buffer list (`:ls`)
   call setbufvar(winbufnr(winid), '&buflisted', 0)
+  " Make wrapping occur at word boundaries
+  call setwinvar(winid, '&linebreak', 1)
   return winid
 endfunction
 

--- a/autoload/OmniSharp/preview.vim
+++ b/autoload/OmniSharp/preview.vim
@@ -6,10 +6,10 @@ function! OmniSharp#preview#Display(content, title) abort
   silent wincmd P
   setlocal modifiable noreadonly
   setlocal nobuflisted buftype=nofile bufhidden=wipe
-  0,$d
+  0,$delete
   silent put =a:content
-  0d_
-  setfiletype omnisharpdoc
+  0delete _
+  set filetype=omnisharpdoc
   setlocal conceallevel=3
   setlocal nomodifiable readonly
   let winid = winnr()

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -106,7 +106,8 @@ function! s:HandleServerEvent(job, res) abort
 
     " Diagnostics received while running tests
     if get(a:res, 'Event', '') ==# 'TestMessage'
-      let lines = split(body.Message, '\n')
+      let lines = split(body.Message, '\r\?\n')
+      call OmniSharp#testrunner#Log(lines)
       for line in lines
         if get(body, 'MessageLevel', '') ==# 'error'
           echohl WarningMsg | echomsg line | echohl None

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -630,7 +630,7 @@ function! s:utils.findTest() abort
   endif
   if testline > 0
     let line = getline(testline)
-    let testname = matchlist(line, '[-|*!]        \%(|| .\{-} || \)\?\zs.*$')[0]
+    let testname = matchlist(line, '[-|*!]        \%(|| .\{-} || \)\?\zs\S*')[0]
     let projectline = search('^;', 'bcnWz')
     let projectkey = matchlist(getline(projectline), '^\S\+')[0]
     let fileline = search('^    \f', 'bcnWz')

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -118,12 +118,12 @@ function! s:Paint() abort
           for stacktraceline in get(test, 'stacktrace', [])
             let line = trim(stacktraceline.text)
             if has_key(stacktraceline, 'filename')
-              let line = '__ ' . line . ' __'
+              let line = '__ ' . line . ' ___ ' . stacktraceline.filename . ' __ '
             else
-              let line = '_._ ' . line . ' _._'
+              let line = '_._ ' . line . ' _._ '
             endif
             if has_key(stacktraceline, 'lnum')
-              let line .= ' line ' . stacktraceline.lnum
+              let line .= 'line ' . stacktraceline.lnum
             endif
             call add(lines, '>              ' . line)
           endfor
@@ -171,6 +171,7 @@ function! OmniSharp#testrunner#SetTests(bufferTests) abort
   call s:Open()
   call win_gotoid(winid)
 endfunction
+
 
 function! s:UpdateState(bufnr, state, ...) abort
   let opts = a:0 ? a:1 : {}

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -213,6 +213,12 @@ function! OmniSharp#testrunner#StateSkipped(bufnr) abort
 endfunction
 
 
+function! OmniSharp#testrunner#toggleBanner() abort
+  let g:OmniSharp_testrunner_banner = 1 - get(g:, 'OmniSharp_testrunner_banner', 1)
+  call s:Paint()
+endfunction
+
+
 let s:spinner = {}
 let s:spinner.steps_ascii = [
 \ '<*---->',
@@ -237,7 +243,8 @@ function! s:spinner.spin(test, lnum, timer) abort
     call timer_stop(a:timer)
     return
   endif
-  let lines = getbufline(s:testrunner_bufnr, a:lnum)
+  let lnum = a:lnum + (get(g:, 'OmniSharp_testrunner_banner', 1) ? 8 : 0)
+  let lines = getbufline(s:testrunner_bufnr, lnum)
   if len(lines) == 0
     call timer_stop(a:timer)
     return
@@ -258,16 +265,17 @@ function! s:spinner.spin(test, lnum, timer) abort
     let line = substitute(line, '  -- \zs.*$', step, '')
   endif
   call setbufvar(s:testrunner_bufnr, '&modifiable', 1)
-  call setbufline(s:testrunner_bufnr, a:lnum, line)
+  call setbufline(s:testrunner_bufnr, lnum, line)
   call setbufvar(s:testrunner_bufnr, '&modifiable', 0)
   call setbufvar(s:testrunner_bufnr, '&modified', 0)
 endfunction
 
 function! s:spinner.start(test, lnum) abort
   if !get(g:, 'OmniSharp_testrunner_spinner', 1) | return | endif
+  let lnum = a:lnum - (get(g:, 'OmniSharp_testrunner_banner', 1) ? 8 : 0)
   let a:test.spinner = {}
   let a:test.spinner.timer = timer_start(300,
-  \ funcref('s:spinner.spin', [a:test, a:lnum], self),
+  \ funcref('s:spinner.spin', [a:test, lnum], self),
   \ {'repeat': -1})
 endfunction
 

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -68,8 +68,8 @@ endfunction
 
 function! s:Paint() abort
   let lines = []
+  let delimiter = get(g:, 'OmniSharp_testrunner_banner_delimeter', '─')
   if get(g:, 'OmniSharp_testrunner_banner', 1)
-    let delimiter = get(g:, 'OmniSharp_testrunner_banner_delimeter', '─')
     call add(lines, repeat(delimiter, 80))
     call add(lines, '    OmniSharp Test Runner')
     call add(lines, '  ' . repeat(delimiter, 76))
@@ -89,15 +89,18 @@ function! s:Paint() abort
       for errorline in errors
         call add(lines, '<  ' . trim(errorline, ' ', 2))
       endfor
-      " The diagnostic logs (build output) are only displayed when a single file
-      " is tested, otherwise multiple build outputs are intermingled
-      if OmniSharp#GetHost(s:current.singlebuffer).sln_or_dir ==# sln_or_dir
-        if len(errors) > 0 && len(s:current.log) > 1
-          call add(lines, '<  ' . repeat(delimiter, 10))
+      let loglevel = get(g:, 'OmniSharp_testrunner_loglevel', 'error')
+      if loglevel ==? 'all' || (loglevel ==? 'error' && len(errors))
+        " The diagnostic logs (build output) are only displayed when a single file
+        " is tested, otherwise multiple build outputs are intermingled
+        if OmniSharp#GetHost(s:current.singlebuffer).sln_or_dir ==# sln_or_dir
+          if len(errors) > 0 && len(s:current.log) > 1
+            call add(lines, '<  ' . repeat(delimiter, 10))
+          endif
+          for log in s:current.log
+            call add(lines, '<  ' . trim(log, ' ', 2))
+          endfor
         endif
-        for log in s:current.log
-          call add(lines, '<  ' . trim(log, ' ', 2))
-        endfor
       endif
       for testfile in sort(keys(job.tests[testproject]))
         call add(lines, '    ' . fnamemodify(testfile, ':.'))

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -219,8 +219,8 @@ function! s:Paint() abort
         endfor
         call add(lines, '__')
       endfor
+      call add(lines, '')
     endfor
-    call add(lines, '')
   endfor
 
   if bufnr() == s:runner.bufnr | let winview = winsaveview() | endif

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -421,6 +421,15 @@ function! s:buffer.repainttest(filename, testname, test) abort
 endfunction
 
 
+function! OmniSharp#testrunner#Reset() abort
+  let s:current = {}
+  let s:runner = {}
+  let s:tests = {}
+  call OmniSharp#actions#test#Reset()
+  call s:Open()
+endfunction
+
+
 function! OmniSharp#testrunner#SetBreakpoints() abort
   if !OmniSharp#util#HasVimspector()
     return s:utils.log.warn('Vimspector required to set breakpoints')

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
@@ -178,7 +179,7 @@ endfunction
 
 
 let s:spinner = {}
-let s:spinner.steps = get(g:, 'OmniSharp_testrunner_spinnersteps', [
+let s:spinner.steps_ascii = [
 \ '<*---->',
 \ '<-*--->',
 \ '<--*-->',
@@ -186,7 +187,14 @@ let s:spinner.steps = get(g:, 'OmniSharp_testrunner_spinnersteps', [
 \ '<----*>',
 \ '<---*->',
 \ '<--*-->',
-\ '<-*--->'])
+\ '<-*--->']
+let s:spinner.steps_utf8 = [
+\ '∙∙∙',
+\ '●∙∙',
+\ '∙●∙',
+\ '∙∙●',
+\ '∙∙∙'
+\]
 
 function! s:spinner.spin(test, lnum, timer) abort
   if s:utils.state2char[a:test.state] !=# '-'
@@ -199,15 +207,18 @@ function! s:spinner.spin(test, lnum, timer) abort
     return
   endif
   let line = lines[0]
+  let steps = get(g:, 'OmniSharp_testrunner_spinnersteps',
+  \ get(g:, 'OmniSharp_testrunner_spinner_ascii')
+  \   ? self.steps_ascii : self.steps_utf8)
   if !has_key(a:test.spinner, 'index')
-    let line .= '  -- ' . s:spinner.steps[0]
+    let line .= '  -- ' . steps[0]
     let a:test.spinner.index = 0
   else
     let a:test.spinner.index += 1
-    if a:test.spinner.index >= len(s:spinner.steps)
+    if a:test.spinner.index >= len(steps)
       let a:test.spinner.index = 0
     endif
-    let step = s:spinner.steps[a:test.spinner.index]
+    let step = steps[a:test.spinner.index]
     let line = substitute(line, '  -- \zs.*$', step, '')
   endif
   call setbufvar(s:testrunner_bufnr, '&modifiable', 1)

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -310,7 +310,7 @@ function! s:buffer.paintbanner() abort
   call add(lines, '`' . repeat(self.delimiter(), 80))
   call add(lines, '`                             OmniSharp Test Runner')
   call add(lines, '`  ' . repeat(self.delimiter(), 76))
-  call add(lines, '`    <F1> Toggle this menu (:help omnisharp-test-runner for more)')
+  call add(lines, '`    <F1> Toggle this menu (:help omnisharp-testrunner for more)')
   call add(lines, '`    <F5> Run test or tests in file under cursor')
   call add(lines, '`    <F6> Debug test under cursor')
   call add(lines, '`    <CR> Navigate to test or stack trace')

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -123,6 +123,7 @@ function! s:SpinnerSpin(test, lnum, timer) abort
   call setbufvar(s:testrunner_bufnr, '&modifiable', 1)
   call setbufline(s:testrunner_bufnr, a:lnum, line)
   call setbufvar(s:testrunner_bufnr, '&modifiable', 0)
+  call setbufvar(s:testrunner_bufnr, '&modified', 0)
 endfunction
 
 function! s:SpinnerStart(test, lnum) abort

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -241,6 +241,29 @@ function! s:Paint() abort
 endfunction
 
 
+function! OmniSharp#testrunner#SetBreakpoints() abort
+  if !OmniSharp#util#HasVimspector()
+    echohl WarningMsg
+    echomsg 'Vimspector required to set breakpoints'
+    echohl None
+    return
+  endif
+  let test = s:utils.findTest()
+  if !has_key(test, 'stacktrace')
+    echo 'No breakpoints added'
+    return
+  endif
+  let bps = filter(copy(test.stacktrace),
+  \ "has_key(v:val, 'filename') && has_key(v:val, 'lnum')")
+  for bp in bps
+    call vimspector#SetLineBreakpoint(bp.filename, bp.lnum)
+  endfor
+  let n = len(bps)
+  let message = printf('%d break point%s set', n, n == 1 ? '' : 's')
+  echomsg message
+endfunction
+
+
 function! OmniSharp#testrunner#SetTests(bufferTests) abort
   let winid = win_getid()
   for buffer in a:bufferTests

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -1,0 +1,80 @@
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+function! OmniSharp#testrunner#Open() abort
+  if !OmniSharp#actions#test#Validate() | return | endif
+  call s:Open()
+endfunction
+
+function s:Open() abort
+  let ft = 'omnisharptest'
+  let title = 'OmniSharp Test Runner'
+  " If the buffer is listed in a window in the current tab, then focus it
+  for winnr in range(1, winnr('$'))
+    if getbufvar(winbufnr(winnr), '&filetype') ==# ft
+      call win_gotoid(win_getid(winnr))
+      break
+    endif
+  endfor
+  if &filetype !=# ft
+    " If a buffer with filetype omnisharptest exists, open it in a new split
+    for buffer in getbufinfo()
+      if getbufvar(buffer.bufnr, '&filetype') ==# ft
+        botright split
+        execute 'buffer' buffer.bufnr
+        break
+      endif
+    endfor
+  endif
+  if &filetype !=# ft
+    botright new
+  endif
+
+  silent setlocal noswapfile signcolumn=no
+  set bufhidden=hide
+  let &filetype = ft
+  execute 'file' title
+  call s:Paint()
+endfunction
+
+function! s:Paint() abort
+  setlocal modifiable
+  let winview = winsaveview()
+  0,$delete _
+  put ='OmniSharp Test Runner'
+  0delete _
+  put =''
+
+  for sln_or_dir in OmniSharp#proc#ListRunningJobs()
+    put =fnamemodify(sln_or_dir, ':t')
+    let job = OmniSharp#proc#GetJob(sln_or_dir)
+    if !has_key(job, 'tests') | continue | endif
+    for testfile in keys(job.tests)
+      put ='  ' . fnamemodify(testfile, ':.')
+      for test in job.tests[testfile]
+        put ='    ' . test.name
+      endfor
+    endfor
+    put =''
+  endfor
+
+  call winrestview(winview)
+  setlocal nomodifiable nomodified
+endfunction
+
+function! OmniSharp#testrunner#SetTests(bufferTests) abort
+  let winid = win_getid()
+  for buffer in a:bufferTests
+    let job = OmniSharp#GetHost(buffer.bufnr).job
+    let job.tests = get(job, 'tests', {})
+    let filename = fnamemodify(bufname(buffer.bufnr), ':p')
+    let job.tests[filename] = buffer.tests
+  endfor
+  call s:Open()
+  call win_gotoid(winid)
+endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo
+
+" vim:et:sw=2:sts=2

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -248,6 +248,14 @@ function! OmniSharp#testrunner#SetBreakpoints() abort
     echohl None
     return
   endif
+  let line = getline('.')
+  " Stack trace with valid location (filename and possible line number)
+  let parsed = matchlist(line, '^> \+__ .* ___ \(.*\) __ \%(line \(\d\+\)\)\?$')
+  if len(parsed) && parsed[2] !=# ''
+    call vimspector#SetLineBreakpoint(parsed[1], str2nr(parsed[2]))
+    echomsg 'Break point set'
+    return
+  endif
   let test = s:utils.findTest()
   if !has_key(test, 'stacktrace')
     echo 'No breakpoints added'

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -235,6 +235,7 @@ function! s:buffer.paint() abort
     let lines = []
   endif
   for key in sort(keys(s:tests))
+    if !s:tests[key].visible | continue | endif
     call extend(lines, self.paintproject(key))
     for testfile in sort(keys(s:tests[key].files))
       if !s:tests[key].files[testfile].visible | continue | endif
@@ -276,9 +277,6 @@ endfunction
 
 function! s:buffer.paintproject(key) abort
   let [assembly, sln] = split(a:key, ';')
-  if !s:tests[a:key].visible
-    return []
-  endif
   let lines = []
   call add(lines, a:key . (len(s:tests[a:key].errors) ? ' ERROR' : ''))
   for errorline in s:tests[a:key].errors

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -391,6 +391,7 @@ function! OmniSharp#testrunner#SetTests(bufferTests) abort
       let test.lnum = buffertest.nameRange.Start.Line
     endfor
   endfor
+  if !get(g:, 'OmniSharp_testrunner', 1) | return | endif
   let winid = win_getid()
   if hasNew
     call s:Open()
@@ -439,6 +440,7 @@ function! s:UpdateState(bufnr, state, ...) abort
       let test.stacktrace = stacktrace
       let test.output = get(opts, 'output', [])
 
+      if !has_key(s:runner, 'bufnr') | continue | endif
       call setbufvar(s:runner.bufnr, '&modifiable', 1)
       let lines = getbufline(s:runner.bufnr, 1, '$')
       let pattern = '^    ' . substitute(filename, '/', '\\/', 'g')
@@ -460,6 +462,7 @@ function! s:UpdateState(bufnr, state, ...) abort
       call setbufvar(s:runner.bufnr, '&modified', 0)
     endif
   endfor
+  if !get(g:, 'OmniSharp_testrunner', 1) | return | endif
   let winid = win_getid()
   if s:buffer.focus()
     syn sync fromstart

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -55,10 +55,17 @@ endfunction
 
 function! s:Paint() abort
   let lines = []
-  call add(lines, repeat('=', 80))
-  call add(lines, '   OmniSharp Test Runner')
-  call add(lines, repeat('=', 80))
-  call add(lines, '')
+  if get(g:, 'OmniSharp_testrunner_banner', 1)
+    let delimiter = get(g:, 'OmniSharp_testrunner_banner_delimeter', '─')
+    call add(lines, repeat(delimiter, 80))
+    call add(lines, '    OmniSharp Test Runner')
+    call add(lines, '  ' . repeat(delimiter, 76))
+    call add(lines, '    <F1> Toggle this menu (:help omnisharp-test-runner for more)')
+    call add(lines, '    <F5> Run test or tests in file under cursor')
+    call add(lines, '    <F6> Debug test under cursor')
+    call add(lines, '    <CR> Navigate to test or stack trace')
+    call add(lines, repeat(delimiter, 80))
+  endif
 
   for sln_or_dir in OmniSharp#proc#ListRunningJobs()
     let job = OmniSharp#proc#GetJob(sln_or_dir)
@@ -215,7 +222,8 @@ let s:spinner.steps_ascii = [
 \ '<----*>',
 \ '<---*->',
 \ '<--*-->',
-\ '<-*--->']
+\ '<-*--->'
+\]
 let s:spinner.steps_utf8 = [
 \ '∙∙∙',
 \ '●∙∙',

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -264,7 +264,7 @@ endfunction
 function! s:buffer.paintbanner() abort
   let lines = []
   call add(lines, '`' . repeat(self.delimiter(), 80))
-  call add(lines, '`    OmniSharp Test Runner')
+  call add(lines, '`                             OmniSharp Test Runner')
   call add(lines, '`  ' . repeat(self.delimiter(), 76))
   call add(lines, '`    <F1> Toggle this menu (:help omnisharp-test-runner for more)')
   call add(lines, '`    <F5> Run test or tests in file under cursor')

--- a/autoload/OmniSharp/testrunner.vim
+++ b/autoload/OmniSharp/testrunner.vim
@@ -504,7 +504,7 @@ function! OmniSharp#testrunner#StateComplete(location) abort
   else
     let state = 'Passed'
   endif
-  call s:UpdateState(a:.location.bufnr, state, {
+  call s:UpdateState(a:location.bufnr, state, {
   \ 'testnames': [a:location.fullname],
   \ 'message': get(a:location, 'message', []),
   \ 'stacktrace': get(a:location, 'stacktrace', []),

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -68,9 +68,12 @@ function! OmniSharp#util#AwaitSequence(Funcs, OnAllComplete, ...) abort
     \}
   endif
 
-  let Func = remove(a:Funcs, 0)
+  " If the Func has been declared as a dictionary function, then it must be
+  " called as a dictionary function:
+  " function s:run.test()
+  let dict = { 'f': remove(a:Funcs, 0) }
   let state.OnComplete = function('OmniSharp#util#AwaitSequence', [a:Funcs, a:OnAllComplete])
-  call Func(function('s:AwaitFuncComplete', [state]))
+  call dict.f(function('s:AwaitFuncComplete', [state]))
 endfunction
 
 function! s:AwaitFuncComplete(state, ...) abort

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -46,7 +46,11 @@ function! OmniSharp#util#AwaitParallel(Funcs, OnAllComplete) abort
   \ 'OnAllComplete': a:OnAllComplete
   \}
   for Func in a:Funcs
-    call Func(function('s:AwaitFuncComplete', [state]))
+    " If the Func has been declared as a dictionary function, then it must be
+    " called as a dictionary function:
+    " function s:run.test()
+    let dict = { 'f': Func }
+    call dict.f(function('s:AwaitFuncComplete', [state]))
   endfor
 endfunction
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -416,6 +416,10 @@ failed test locations point to the failed assertion; successful test locations
 point to the test method declaration.
 Default: 0
 
+                                                         *g:OmniSharp_testrunner*
+Open the |omnisharp-testrunner| automatically when running tests.
+Default: 1
+
 -------------------------------------------------------------------------------
 3.6 INTEGRATIONS                                  *omnisharp-integration-options*
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -405,6 +405,17 @@ test files in sequence instead, resulting in readable output in the
 |message-history|.
 Default: 1
 
+                                                  *g:OmniSharp_runtests_quickfix*
+When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
+or from the |omnisharp-testrunner|, populate the quickfix list with test
+results.
+When a single test is run and an exception occurs, the quickfix will be
+populated with the exception stack trace.
+When multiple tests are run then each test will get a quickfix location:
+failed test locations point to the failed assertion; successful test locations
+point to the test method declaration.
+Default: 0
+
 -------------------------------------------------------------------------------
 3.6 INTEGRATIONS                                  *omnisharp-integration-options*
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -20,13 +20,14 @@ CONTENTS                                                     *omnisharp-contents
       3.2 Diagnostics ......................... |omnisharp-diagnostic-options|
       3.3 Highlights .......................... |omnisharp-highlight-options|
       3.4 Popups .............................. |omnisharp-popup-options|
-      3.5 Tests ............................... |omnisharp-test-options|
       3.6 Integrations ........................ |omnisharp-integration-options|
       3.7 Miscellaneous ....................... |omnisharp-miscellaneous-options|
-    4. Commands ............................... |omnisharp-commands|
+    4. General Commands ....................... |omnisharp-commands|
     5. Autocmds ............................... |omnisharp-autocmds|
     6. Test runner ............................ |omnisharp-testrunner|
-      6.1 Mappings ............................ |omnisharp-testrunner-mappings|
+      6.1 Options ............................. |omnisharp-test-options|
+      6.1 Commands ............................ |omnisharp-testrunner-commands|
+      6.2 Mappings ............................ |omnisharp-testrunner-mappings|
     7. Integrations ........................... |omnisharp-integrations|
 
 ===============================================================================
@@ -389,82 +390,7 @@ Default: atcursor >
     let g:OmniSharp_popup_position = 'peek'
 <
 -------------------------------------------------------------------------------
-3.5 TESTS                                                *omnisharp-test-options*
-
-                                               *g:OmniSharp_runtests_echo_output*
-When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
-or from the |omnisharp-testrunner|, echo all test runner output to the
-|message-history|, so it can be viewed with |:messages|.
-Default: 0
-
-                                                  *g:OmniSharp_runtests_parallel*
-When running multiple unit test files with |:OmniSharpRunTestsInFile|, run
-tests in all files simultaneously - this is the fastest way to run multiple
-test files. The disadvantage is that when |g:OmniSharp_runtests_echo_output|
-is set to 1, tests from multiple files will be interspersed, and therefore
-difficult to read. Set |g:OmniSharp_runtests_parallel| to 0 in order to run
-test files in sequence instead, resulting in readable output in the
-|message-history|.
-Default: 1
-
-                                                  *g:OmniSharp_runtests_quickfix*
-When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
-or from the |omnisharp-testrunner|, populate the quickfix list with test
-results.
-When a single test is run and an exception occurs, the quickfix will be
-populated with the exception stack trace.
-When multiple tests are run then each test will get a quickfix location:
-failed test locations point to the failed assertion; successful test locations
-point to the test method declaration.
-Default: 0
-
-                                                         *g:OmniSharp_testrunner*
-Open the |omnisharp-testrunner| automatically when running tests.
-Default: 1
-
-                                                  *g:OmniSharp_testrunner_banner*
-Display the |omnisharp-testrunner| help/introduction banner when opening the
-testrunner. When this option is set to 0, the banner may still be toggled with
-the <F1> (default) toggle mapping.
-Default: 1
-
-                                                   *g:OmniSharp_testrunner_glyph*
-Display a passed/failed "glyph" string beside completed test results in the
-|omnisharp-testrunner|.
-Default: 1
-
-                                            *g:OmniSharp_testrunner_glyph_failed*
-The "glyph" string to display beside failed completed tests in the testrunner.
-Default: ✘
-
-                                            *g:OmniSharp_testrunner_glyph_passed*
-The "glyph" string to display beside passed completed tests in the testrunner.
-Default: ✔
-
-                                                *g:OmniSharp_testrunner_loglevel*
-The type of build and test logs to output in the |omnisharp-testrunner|.
-
-           all      All build output and test runner output is displayed.
-
-           error    When a build error occurs, the error message and stack
-                    trace are output.
-
-           none     Only build error messages will be output.
-
-Default: error >
-    let g:OmniSharp_testrunner_loglevel = 'all'
-<
-                                                 *g:OmniSharp_testrunner_spinner*
-Display a "running" spinner animation when running tests in the testrunner.
-Default: 1
-
-                                            *g:OmniSharp_testrunner_spinnersteps*
-A list of "step" strings to be displayed as the |omnisharp-testrunner|
-"spinner" animation.
-Default: ['∙∙∙', '●∙∙', '∙●∙', '∙∙●', '∙∙∙']
-
--------------------------------------------------------------------------------
-3.6 INTEGRATIONS                                  *omnisharp-integration-options*
+3.5 INTEGRATIONS                                  *omnisharp-integration-options*
 
                                                         *g:OmniSharp_selector_ui*
 Use this option to specify a selector UI for choosing code actions and
@@ -525,7 +451,7 @@ Use this option to enable syntastic integration >
     let g:syntastic_cs_checkers = ['code_checker']
 <
 -------------------------------------------------------------------------------
-3.7 MISCELLANEOUS                               *omnisharp-miscellaneous-options*
+3.6 MISCELLANEOUS                               *omnisharp-miscellaneous-options*
 
                                                  *g:OmniSharp_filename_modifiers*
 File paths returned from the server are normalized using Vim
@@ -573,7 +499,7 @@ the |:OmniSharpDocumentation| command. Default: 1 >
     let g:omnicomplete_fetch_full_documentation = 1
 <
 ===============================================================================
-4. COMMANDS                                                  *omnisharp-commands*
+4. GENERAL COMMANDS                                          *omnisharp-commands*
 
 Most of the OmniSharp-vim commands have associated plug mappings defined, for
 convenient user re-mapping. These can be used like so: >
@@ -591,8 +517,8 @@ convenient user re-mapping. These can be used like so: >
     :OmniSharpGotoDefinition vsplit
     :OmniSharpGotoDefinition tabedit
 <
-                                                       *:OmniSharpGotoTypeDefinition*
-                                             *<Plug>(omnisharp_go_to_type_definition)*
+                                                   *:OmniSharpGotoTypeDefinition*
+                                        *<Plug>(omnisharp_go_to_type_definition)*
 :OmniSharpGotoTypeDefinition [{cmd}]
     Navigates to the type definition of the symbol under the cursor.
     By default the definition is opened in the current window. To open it in a
@@ -677,48 +603,6 @@ convenient user re-mapping. These can be used like so: >
 :OmniSharpNavigateDown
     Navigates to next method or class
 
-                                                              *:OmniSharpRunTest*
-                                                     *<Plug>(omnisharp_run_test)*
-                                            *<Plug>(omnisharp_run_test_no_build)*
-:OmniSharpRunTest[!]
-    Run the current unit test. The cursor can be anywhere in the test method.
-    The |omnisharp-testrunner| window will be opened to display the test
-    status and results.
-    If the test fails, the failure message and location will be displayed in
-    the testrunner, or optionally (see |g:OmniSharp_runtests_quickfix|) in the
-    quickfix list, along with the error stack trace if one exists.
-
-    When called with ! or the |<Plug>(omnisharp_run_test_no_build)| mapping, the
-    project is not built before running the test.
-
-                                                            *:OmniSharpDebugTest*
-                                                   *<Plug>(omnisharp_debug_test)*
-                                          *<Plug>(omnisharp_debug_test_no_build)*
-:OmniSharpDebugTest[!]
-    Debug the current unit test with Vimspector. The cursor can be anywhere in
-    the test method.
-
-    When called with ! or the |<Plug>(omnisharp_debug_test_no_build)| mapping,
-    the project is not built before starting the debugger.
-
-                                                       *:OmniSharpRunTestsInFile*
-                                            *<Plug>(omnisharp_run_tests_in_file)*
-                                   *<Plug>(omnisharp_run_tests_in_file_no_build)*
-:OmniSharpRunTestsInFile[!]
-    Run all unit tests in the current file. When |g:OmniSharp_runtests_quickfix|
-    is enabled, the quickfix list will be populated with the results of all
-    tests.
-    Optionally accepts one or more filenames of files to run tests for.
->
-    " Run all unit tests in the current file
-    :OmniSharpRunTestsInFile
-
-    " Run all unit tests in the current file, and file `tests/test1.cs`
-    :OmniSharpRunTestsInFile % tests/test1.cs
-<
-    When called with ! or the |<Plug>(omnisharp_run_tests_in_file_no_build)|
-    mapping, the project is not built before running the tests.
-
                                                               *:OmniSharpOpenLog*
                                                      *<Plug>(omnisharp_open_log)*
 :OmniSharpOpenLog [{cmd}]
@@ -731,9 +615,6 @@ convenient user re-mapping. These can be used like so: >
     :OmniSharpOpenLog vsplit
     :OmniSharpOpenLog tabedit
 <
-                                                       *:OmniSharpOpenTestRunner*
-    Open the |omnisharp-testrunner| window
-
                                                        *:OmniSharpGetCodeActions*
                                                  *<Plug>(omnisharp_code_actions)*
 :OmniSharpGetCodeActions
@@ -882,7 +763,7 @@ with the test status (running/passed/failed/not run) and any outputs that may
 be produced (exceptions and Console output).
 
 Open the test runner window by either running a test (with e.g.
-|:OmniSharpRunTest|) or with the |:OmniSharpOpenTestRunner| command.
+|:OmniSharpRunTest|) or with the |:OmniSharpTestRunner| command.
 
 Any time a new test is run, it (along with all other tests in the same file)
 is added to the runner. Tests remain visible in the test runner window until
@@ -899,7 +780,133 @@ display test results, use the following settings: >
     let g:OmniSharp_runtests_quickfix = 1
 <
 -------------------------------------------------------------------------------
-6.1 MAPPINGS                                      *omnisharp-testrunner-mappings*
+6.1 OPTIONS                                              *omnisharp-test-options*
+
+                                               *g:OmniSharp_runtests_echo_output*
+When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
+or from the |omnisharp-testrunner|, echo all test runner output to the
+|message-history|, so it can be viewed with |:messages|.
+Default: 0
+
+                                                  *g:OmniSharp_runtests_parallel*
+When running multiple unit test files with |:OmniSharpRunTestsInFile|, run
+tests in all files simultaneously - this is the fastest way to run multiple
+test files. The disadvantage is that when |g:OmniSharp_runtests_echo_output|
+is set to 1, tests from multiple files will be interspersed, and therefore
+difficult to read. Set |g:OmniSharp_runtests_parallel| to 0 in order to run
+test files in sequence instead, resulting in readable output in the
+|message-history|.
+Default: 1
+
+                                                  *g:OmniSharp_runtests_quickfix*
+When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
+or from the |omnisharp-testrunner|, populate the quickfix list with test
+results.
+When a single test is run and an exception occurs, the quickfix will be
+populated with the exception stack trace.
+When multiple tests are run then each test will get a quickfix location:
+failed test locations point to the failed assertion; successful test locations
+point to the test method declaration.
+Default: 0
+
+                                                         *g:OmniSharp_testrunner*
+Open the |omnisharp-testrunner| automatically when running tests.
+Default: 1
+
+                                                  *g:OmniSharp_testrunner_banner*
+Display the |omnisharp-testrunner| help/introduction banner when opening the
+testrunner. When this option is set to 0, the banner may still be toggled with
+the <F1> (default) toggle mapping.
+Default: 1
+
+                                                   *g:OmniSharp_testrunner_glyph*
+Display a passed/failed "glyph" string beside completed test results in the
+|omnisharp-testrunner|.
+Default: 1
+
+                                            *g:OmniSharp_testrunner_glyph_failed*
+The "glyph" string to display beside failed completed tests in the testrunner.
+Default: ✘
+
+                                            *g:OmniSharp_testrunner_glyph_passed*
+The "glyph" string to display beside passed completed tests in the testrunner.
+Default: ✔
+
+                                                *g:OmniSharp_testrunner_loglevel*
+The type of build and test logs to output in the |omnisharp-testrunner|.
+
+           all      All build output and test runner output is displayed.
+
+           error    When a build error occurs, the error message and stack
+                    trace are output.
+
+           none     Only build error messages will be output.
+
+Default: error >
+    let g:OmniSharp_testrunner_loglevel = 'all'
+<
+                                                 *g:OmniSharp_testrunner_spinner*
+Display a "running" spinner animation when running tests in the testrunner.
+Default: 1
+
+                                            *g:OmniSharp_testrunner_spinnersteps*
+A list of "step" strings to be displayed as the |omnisharp-testrunner|
+"spinner" animation.
+Default: ['∙∙∙', '●∙∙', '∙●∙', '∙∙●', '∙∙∙']
+
+-------------------------------------------------------------------------------
+6.2 COMMANDS                                      *omnisharp-testrunner-commands*
+
+                                                              *:OmniSharpRunTest*
+                                                     *<Plug>(omnisharp_run_test)*
+                                            *<Plug>(omnisharp_run_test_no_build)*
+:OmniSharpRunTest[!]
+    Run the current unit test. The cursor can be anywhere in the test method.
+    The |omnisharp-testrunner| window will be opened to display the test
+    status and results.
+    If the test fails, the failure message and location will be displayed in
+    the testrunner, or optionally (see |g:OmniSharp_runtests_quickfix|) in the
+    quickfix list, along with the error stack trace if one exists.
+
+    When called with ! or the |<Plug>(omnisharp_run_test_no_build)| mapping, the
+    project is not built before running the test.
+
+                                                            *:OmniSharpDebugTest*
+                                                   *<Plug>(omnisharp_debug_test)*
+                                          *<Plug>(omnisharp_debug_test_no_build)*
+:OmniSharpDebugTest[!]
+    Debug the current unit test with Vimspector. The cursor can be anywhere in
+    the test method.
+
+    When called with ! or the |<Plug>(omnisharp_debug_test_no_build)| mapping,
+    the project is not built before starting the debugger.
+
+                                                       *:OmniSharpRunTestsInFile*
+                                            *<Plug>(omnisharp_run_tests_in_file)*
+                                   *<Plug>(omnisharp_run_tests_in_file_no_build)*
+:OmniSharpRunTestsInFile[!]
+    Run all unit tests in the current file. When |g:OmniSharp_runtests_quickfix|
+    is enabled, the quickfix list will be populated with the results of all
+    tests.
+    Optionally accepts one or more filenames of files to run tests for.
+>
+    " Run all unit tests in the current file
+    :OmniSharpRunTestsInFile
+
+    " Run all unit tests in the current file, and file `tests/test1.cs`
+    :OmniSharpRunTestsInFile % tests/test1.cs
+<
+    When called with ! or the |<Plug>(omnisharp_run_tests_in_file_no_build)|
+    mapping, the project is not built before running the tests.
+
+                                                           *:OmniSharpTestRunner*
+    Open the |omnisharp-testrunner| window
+
+                                                      *:OmniSharpTestRunnerReset*
+    Forget all test history and clear the test runner window
+
+-------------------------------------------------------------------------------
+6.3 MAPPINGS                                      *omnisharp-testrunner-mappings*
 
 The following |<Plug>| mappings and associated default recursive mappings are
 provided in the test runner window.

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -25,7 +25,9 @@ CONTENTS                                                     *omnisharp-contents
       3.7 Miscellaneous ....................... |omnisharp-miscellaneous-options|
     4. Commands ............................... |omnisharp-commands|
     5. Autocmds ............................... |omnisharp-autocmds|
-    6. Integrations ........................... |omnisharp-integrations|
+    6. Test runner ............................ |omnisharp-testrunner|
+      6.1 Mappings ............................ |omnisharp-testrunner-mappings|
+    7. Integrations ........................... |omnisharp-integrations|
 
 ===============================================================================
 1. DEPENDENCIES                                          *omnisharp-dependencies*
@@ -43,7 +45,7 @@ Optional:~
 2. USAGE                                                        *omnisharp-usage*
 
 Opening a `*.cs` file will automatically start an instance of omnisharp-server
-(if using vim 8.0+, neovim or vim-dispatch). Symantic completions are triggered
+(if using vim 8.0+, neovim or vim-dispatch). Semantic completions are triggered
 using omni-completion (CTRL-X_CTRL-O in insert mode), or using an
 autocompletion plugin such as asyncomplete or Deoplete.
 
@@ -391,8 +393,8 @@ Default: atcursor >
 
                                                *g:OmniSharp_runtests_echo_output*
 When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
-or from the test runner, echo all test runner output to the |message-history|,
-so it can be viewed with |:messages|.
+or from the |omnisharp-testrunner|, echo all test runner output to the
+|message-history|, so it can be viewed with |:messages|.
 Default: 0
 
                                                   *g:OmniSharp_runtests_parallel*
@@ -419,6 +421,47 @@ Default: 0
                                                          *g:OmniSharp_testrunner*
 Open the |omnisharp-testrunner| automatically when running tests.
 Default: 1
+
+                                                  *g:OmniSharp_testrunner_banner*
+Display the |omnisharp-testrunner| help/introduction banner when opening the
+testrunner. When this option is set to 0, the banner may still be toggled with
+the <F1> (default) toggle mapping.
+Default: 1
+
+                                                   *g:OmniSharp_testrunner_glyph*
+Display a passed/failed "glyph" string beside completed test results in the
+|omnisharp-testrunner|.
+Default: 1
+
+                                            *g:OmniSharp_testrunner_glyph_failed*
+The "glyph" string to display beside failed completed tests in the testrunner.
+Default: ✘
+
+                                            *g:OmniSharp_testrunner_glyph_passed*
+The "glyph" string to display beside passed completed tests in the testrunner.
+Default: ✔
+
+                                                *g:OmniSharp_testrunner_loglevel*
+The type of build and test logs to output in the |omnisharp-testrunner|.
+
+           all      All build output and test runner output is displayed.
+
+           error    When a build error occurs, the error message and stack
+                    trace are output.
+
+           none     Only build error messages will be output.
+
+Default: error >
+    let g:OmniSharp_testrunner_loglevel = 'all'
+<
+                                                 *g:OmniSharp_testrunner_spinner*
+Display a "running" spinner animation when running tests in the testrunner.
+Default: 1
+
+                                            *g:OmniSharp_testrunner_spinnersteps*
+A list of "step" strings to be displayed as the |omnisharp-testrunner|
+"spinner" animation.
+Default: ['∙∙∙', '●∙∙', '∙●∙', '∙∙●', '∙∙∙']
 
 -------------------------------------------------------------------------------
 3.6 INTEGRATIONS                                  *omnisharp-integration-options*
@@ -639,18 +682,21 @@ convenient user re-mapping. These can be used like so: >
                                             *<Plug>(omnisharp_run_test_no_build)*
 :OmniSharpRunTest[!]
     Run the current unit test. The cursor can be anywhere in the test method.
+    The |omnisharp-testrunner| window will be opened to display the test
+    status and results.
     If the test fails, the failure message and location will be displayed in
-    the quickfix list, along with the error stack trace, if one exists.
+    the testrunner, or optionally (see |g:OmniSharp_runtests_quickfix|) in the
+    quickfix list, along with the error stack trace if one exists.
 
     When called with ! or the |<Plug>(omnisharp_run_test_no_build)| mapping, the
     project is not built before running the test.
 
-                                                              *:OmniSharpDebugTest*
-                                                     *<Plug>(omnisharp_debug_test)*
-                                            *<Plug>(omnisharp_debug_test_no_build)*
+                                                            *:OmniSharpDebugTest*
+                                                   *<Plug>(omnisharp_debug_test)*
+                                          *<Plug>(omnisharp_debug_test_no_build)*
 :OmniSharpDebugTest[!]
     Debug the current unit test with Vimspector. The cursor can be anywhere in
-    the test method. The quickfix list is not populated with the test result.
+    the test method.
 
     When called with ! or the |<Plug>(omnisharp_debug_test_no_build)| mapping,
     the project is not built before starting the debugger.
@@ -659,8 +705,9 @@ convenient user re-mapping. These can be used like so: >
                                             *<Plug>(omnisharp_run_tests_in_file)*
                                    *<Plug>(omnisharp_run_tests_in_file_no_build)*
 :OmniSharpRunTestsInFile[!]
-    Run all unit tests in the current file. The quickfix list will be
-    populated with the test results of all tests.
+    Run all unit tests in the current file. When |g:OmniSharp_runtests_quickfix|
+    is enabled, the quickfix list will be populated with the results of all
+    tests.
     Optionally accepts one or more filenames of files to run tests for.
 >
     " Run all unit tests in the current file
@@ -684,6 +731,9 @@ convenient user re-mapping. These can be used like so: >
     :OmniSharpOpenLog vsplit
     :OmniSharpOpenLog tabedit
 <
+                                                       *:OmniSharpOpenTestRunner*
+    Open the |omnisharp-testrunner| window
+
                                                        *:OmniSharpGetCodeActions*
                                                  *<Plug>(omnisharp_code_actions)*
 :OmniSharpGetCodeActions
@@ -825,7 +875,73 @@ OmniSharpStopped
     Fired when the server process is stopped.
 
 ===============================================================================
-6. INTEGRATIONS                                          *omnisharp-integrations*
+6. TEST RUNNER                                             *omnisharp-testrunner*
+
+The test runner provides an overview of unit tests which have been run, along
+with the test status (running/passed/failed/not run) and any outputs that may
+be produced (exceptions and Console output).
+
+Open the test runner window by either running a test (with e.g.
+|:OmniSharpRunTest|) or with the |:OmniSharpOpenTestRunner| command.
+
+Any time a new test is run, it (along with all other tests in the same file)
+is added to the runner. Tests remain visible in the test runner window until
+they are manually removed.
+
+Tests are grouped under the files they are contained in, which are in turn
+grouped by project. Folds are used to collapse and expand sections, so a
+project/file/output section can be hidden or displayed using standard vim
+|folding-commands|.
+
+To disable the testrunner and instead use the quickfix list to navigate and
+display test results, use the following settings: >
+    let g:OmniSharp_testrunner = 0
+    let g:OmniSharp_runtests_quickfix = 1
+<
+-------------------------------------------------------------------------------
+6.1 MAPPINGS                                      *omnisharp-testrunner-mappings*
+
+The following |<Plug>| mappings and associated default recursive mappings are
+provided in the test runner window.
+
+                                          *<Plug>(omnisharp_testrunner_navigate)*
+                                                                  Default: <CR>
+Navigate to the test under the cursor. When the used on a error stack trace
+location in a failed test result, navigate to the stack location.
+
+                                      *<Plug>(omnisharp_testrunner_togglebanner)*
+                                                                  Default: <F1>
+Toggle display of the help/intro banner. Note that the banner can be hidden
+initially using the |g:OmniSharp_testrunner_banner| setting.
+
+                                               *<Plug>(omnisharp_testrunner_run)*
+                                                                  Default: <F5>
+Run the test(s) under the cursor. When the cursor is on a line representing a
+single test (the test itself or part of its output) then just that single test
+is run. When the cursor is on a file name, then all tests in the file are run.
+When the cursor is on a project name, all previously run tests in the project
+will be run.
+Note: Running tests in a project only runs previous run tests. This command
+does not automatically discover tests in the project.
+
+                                             *<Plug>(omnisharp_testrunner_debug)*
+                                                                  Default: <F6>
+Debug the test under the cursor in Vimspector.
+
+                                   *<Plug>(omnisharp_testrunner_set_breakpoints)*
+                                                                  Default: <F9>
+When used on a failed test resulting in an error stack, the stack trace
+locations are set in Vimspector as breakpoints.
+
+                                            *<Plug>(omnisharp_testrunner_remove)*
+                                                                    Default: dd
+Remove the item under the cursor from the test runner. Can be used at the
+test, file or project level. Note however that individual tests cannot be
+completely removed: subsequent runs of tests in the containing file/project
+will still run the removed test.
+
+===============================================================================
+7. INTEGRATIONS                                          *omnisharp-integrations*
 
 6.1 fzf, vim-clap, CtrlP, unite.vim~
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -390,10 +390,10 @@ Default: atcursor >
 3.5 TESTS                                                *omnisharp-test-options*
 
                                                *g:OmniSharp_runtests_echo_output*
-When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|,
-echo all test runner output to the |message-history|, so it can be viewed with
-|:messages|.
-Default: 1
+When running unit tests with |:OmniSharpRunTest| and |:OmniSharpRunTestsInFile|
+or from the test runner, echo all test runner output to the |message-history|,
+so it can be viewed with |:messages|.
+Default: 0
 
                                                   *g:OmniSharp_runtests_parallel*
 When running multiple unit test files with |:OmniSharpRunTestsInFile|, run

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -6,4 +6,19 @@ set foldlevel=2
 set foldmethod=syntax
 set signcolumn=no
 
-nnoremap <silent> <buffer> <F1> :call OmniSharp#testrunner#ToggleBanner()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_togglebanner) :call OmniSharp#testrunner#ToggleBanner()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_run) :call OmniSharp#testrunner#Run()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_debug) :call OmniSharp#testrunner#Debug()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_navigate) :call OmniSharp#testrunner#Navigate()<CR>
+
+function! s:map(mode, lhs, plug) abort
+  let l:rhs = '<Plug>(' . a:plug . ')'
+  if !hasmapto(l:rhs, substitute(a:mode, 'x', 'v', ''))
+    execute a:mode . 'map <silent> <buffer>' a:lhs l:rhs
+  endif
+endfunction
+
+call s:map('n', '<F1>', 'omnisharp_testrunner_togglebanner')
+call s:map('n', '<F5>', 'omnisharp_testrunner_run')
+call s:map('n', '<F6>', 'omnisharp_testrunner_debug')
+call s:map('n', '<CR>', 'omnisharp_testrunner_navigate')

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -26,3 +26,5 @@ call s:map('n', '<F6>', 'omnisharp_testrunner_debug')
 call s:map('n', '<F9>', 'omnisharp_testrunner_set_breakpoints')
 call s:map('n', '<CR>', 'omnisharp_testrunner_navigate')
 call s:map('n', 'dd', 'omnisharp_testrunner_remove')
+
+set foldtext=OmniSharp#testrunner#FoldText()

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -5,3 +5,5 @@ set concealcursor=nv
 set foldlevel=2
 set foldmethod=syntax
 set signcolumn=no
+
+nnoremap <silent> <buffer> <F1> :call OmniSharp#testrunner#toggleBanner()<CR>

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -9,6 +9,7 @@ set signcolumn=no
 nnoremap <buffer> <Plug>(omnisharp_testrunner_togglebanner) :call OmniSharp#testrunner#ToggleBanner()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_run) :call OmniSharp#testrunner#Run()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_debug) :call OmniSharp#testrunner#Debug()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_set_breakpoints) :call OmniSharp#testrunner#SetBreakpoints()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_navigate) :call OmniSharp#testrunner#Navigate()<CR>
 
 function! s:map(mode, lhs, plug) abort
@@ -21,4 +22,5 @@ endfunction
 call s:map('n', '<F1>', 'omnisharp_testrunner_togglebanner')
 call s:map('n', '<F5>', 'omnisharp_testrunner_run')
 call s:map('n', '<F6>', 'omnisharp_testrunner_debug')
+call s:map('n', '<F9>', 'omnisharp_testrunner_set_breakpoints')
 call s:map('n', '<CR>', 'omnisharp_testrunner_navigate')

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -11,6 +11,7 @@ nnoremap <buffer> <Plug>(omnisharp_testrunner_run) :call OmniSharp#testrunner#Ru
 nnoremap <buffer> <Plug>(omnisharp_testrunner_debug) :call OmniSharp#testrunner#Debug()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_set_breakpoints) :call OmniSharp#testrunner#SetBreakpoints()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_navigate) :call OmniSharp#testrunner#Navigate()<CR>
+nnoremap <buffer> <Plug>(omnisharp_testrunner_remove) :call OmniSharp#testrunner#Remove()<CR>
 
 function! s:map(mode, lhs, plug) abort
   let l:rhs = '<Plug>(' . a:plug . ')'
@@ -24,3 +25,4 @@ call s:map('n', '<F5>', 'omnisharp_testrunner_run')
 call s:map('n', '<F6>', 'omnisharp_testrunner_debug')
 call s:map('n', '<F9>', 'omnisharp_testrunner_set_breakpoints')
 call s:map('n', '<CR>', 'omnisharp_testrunner_navigate')
+call s:map('n', 'dd', 'omnisharp_testrunner_remove')

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -5,6 +5,7 @@ set concealcursor=nv
 set foldlevel=2
 set foldmethod=syntax
 set signcolumn=no
+set synmaxcol=3000
 
 nnoremap <buffer> <Plug>(omnisharp_testrunner_togglebanner) :call OmniSharp#testrunner#ToggleBanner()<CR>
 nnoremap <buffer> <Plug>(omnisharp_testrunner_run) :call OmniSharp#testrunner#Run()<CR>

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -1,0 +1,7 @@
+set bufhidden=hide
+set noswapfile
+set conceallevel=3
+set concealcursor=nv
+set foldlevel=2
+set foldmethod=syntax
+set signcolumn=no

--- a/ftplugin/omnisharptest/OmniSharp.vim
+++ b/ftplugin/omnisharptest/OmniSharp.vim
@@ -6,4 +6,4 @@ set foldlevel=2
 set foldmethod=syntax
 set signcolumn=no
 
-nnoremap <silent> <buffer> <F1> :call OmniSharp#testrunner#toggleBanner()<CR>
+nnoremap <silent> <buffer> <F1> :call OmniSharp#testrunner#ToggleBanner()<CR>

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -54,6 +54,7 @@ let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_d
 
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
 command! -bar -nargs=? OmniSharpOpenLog call OmniSharp#log#Open(<q-args>)
+command! -bar -nargs=? OmniSharpOpenTestRunner call OmniSharp#testrunner#Open()
 command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)
 
 " Preserve backwards compatibility with older version g:OmniSharp_highlight_types

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -39,7 +39,7 @@ let g:OmniSharp_loglevel = get(g:, 'OmniSharp_loglevel', defaultlevel)
 let g:OmniSharp_diagnostic_listen = get(g:, 'OmniSharp_diagnostic_listen', 2)
 
 let g:OmniSharp_runtests_parallel = get(g:, 'OmniSharp_runtests_parallel', 1)
-let g:OmniSharp_runtests_echo_output = get(g:, 'OmniSharp_runtests_echo_output', 1)
+let g:OmniSharp_runtests_echo_output = get(g:, 'OmniSharp_runtests_echo_output', 0)
 
 " Set to 1 when ultisnips is installed
 let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -54,8 +54,9 @@ let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_d
 
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
 command! -bar -nargs=? OmniSharpOpenLog call OmniSharp#log#Open(<q-args>)
-command! -bar -nargs=? OmniSharpOpenTestRunner call OmniSharp#testrunner#Open()
 command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)
+command! -bar OmniSharpTestRunner call OmniSharp#testrunner#Open()
+command! -bar OmniSharpTestRunnerReset call OmniSharp#testrunner#Reset()
 
 " Preserve backwards compatibility with older version g:OmniSharp_highlight_types
 let g:OmniSharp_highlighting = get(g:, 'OmniSharp_highlighting', get(g:, 'OmniSharp_highlight_types', 2))

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -5,11 +5,16 @@ endif
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+syn region ostIntro start="\%1l" end="^$" contains=ostIntroDelim transparent
+syn match ostIntroDelim "^=\+$" contained
+
 syn match ostStateNotRun "^|.*" contains=ostStateChar
 syn match ostStateRunning "^-.*" contains=ostStateChar
 syn match ostStatePassed "^\*.*" contains=ostStateChar
-syn match ostStateFailed "^#.*" contains=ostStateChar
-syn match ostStateChar "^[|\*#-]" conceal contained
+syn match ostStateFailed "^!.*" contains=ostStateChar
+syn match ostStateChar "^[|\*!-]" conceal contained
+
+hi def link ostIntroDelim PreProc
 
 hi def link ostStateNotRun Comment
 hi def link ostStateRunning Identifier

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -14,14 +14,18 @@ syn match ostBannerDelim "\%1l^.*$" contained
 syn match ostBannerDelim "\%3l^.*$" contained
 syn match ostBannerDelim "\%8l^.*$" contained
 
-syn match ostProjectName "^\a.*" contains=ostProjectError
-syn match ostProjectError " - ERROR$"hs=s+2 contained
-syn region ostProject start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
+syn match ostProjectKey ";[^;]*;[^;]*;.*" contains=ostSolution,ostAssembly,ostProjectDelimiter,ostProjectError
+syn match ostSolution "\%(^;[^;]\+;\)\@<=[^;]\+" contained conceal
+syn match ostAssembly "\%(^;\)\@<=[^;]\+\ze;[^;]\+;" contained
+syn match ostProjectDelimiter ";" contained conceal
+syn match ostProjectError "ERROR$" contained
+syn region ostProject start="^;" end="^$"me=s-1 contains=TOP transparent fold
+
 syn region ostError start="^<" end="^[^<]"me=s-1 contains=ostErrorPrefix,ostStackFile,ostStackFileNoLoc fold
 syn match ostErrorPrefix "^<" conceal contained
 syn match ostFileName "^    \S.*" contains=ostFilePath,ostFileExt
-syn match ostFilePath "^    \zs\%(\%(\f\+\.\)*\f\+\/\)*\ze\f\+\." conceal contained
-syn match ostFileExt "\%(\.\w\+\)\+" conceal contained
+syn match ostFilePath "\%(^    \)\@<=\f\{-}\ze[^/\\]\+\.csx\?$" conceal contained
+syn match ostFileExt "\.csx\?$" conceal contained
 syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
 syn match ostFileDivider "^__$" conceal
 
@@ -53,7 +57,8 @@ hi def link ostBannerTitle Normal
 hi def link ostBannerHelp Comment
 hi def link ostBannerMap PreProc
 hi def link ostBannerLink Identifier
-hi def link ostProjectName Identifier
+hi def link ostAssembly Identifier
+hi def link ostSolution Normal
 hi def link ostProjectError WarningMsg
 hi def link ostFileName TypeDef
 hi def link ostStateNotRun Comment
@@ -65,6 +70,7 @@ hi def link ostStackLoc Identifier
 hi def link ostOutput Comment
 
 " Highlights for normally concealed elements
+hi def link ostProjectDelimiter NonText
 hi def link ostErrorPrefix NonText
 hi def link ostFileDivider NonText
 hi def link ostStatePrefix NonText

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -1,0 +1,24 @@
+if exists('b:current_syntax')
+  finish
+endif
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+syn match ostStateNotRun "^|.*" contains=ostStateChar
+syn match ostStateRunning "^-.*" contains=ostStateChar
+syn match ostStatePassed "^\*.*" contains=ostStateChar
+syn match ostStateFailed "^#.*" contains=ostStateChar
+syn match ostStateChar "^[|\*#-]" conceal contained
+
+hi def link ostStateNotRun Comment
+hi def link ostStateRunning Identifier
+hi def link ostStatePassed Title
+hi def link ostStateFailed WarningMsg
+
+let b:current_syntax = 'omnisharptest'
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo
+
+" vim:et:sw=2:sts=2

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -32,14 +32,18 @@ syn match ostFileDivider "^__$" conceal
 
 syn match ostStateNotRun "^|.*" contains=ostStatePrefix,ostTestNamespace
 syn match ostStateRunning "^-.*" contains=ostStatePrefix,ostTestNamespace,ostRunningSuffix
-syn match ostStatePassed "^\*.*" contains=ostStatePrefix,ostTestNamespace
-syn match ostStateFailed "^!.*" contains=ostStatePrefix,ostTestNamespace
+syn match ostStatePassed "^\*.*" contains=ostStatePrefix,ostTestNamespace,ostStatePassedGlyph,ostCompletePrefixDivider
+syn match ostStateFailed "^!.*" contains=ostStatePrefix,ostTestNamespace,ostStateFailedGlyph,ostCompletePrefixDivider
 syn match ostStatePrefix "^[|\*!-]" conceal contained
 syn match ostTestNamespace "\%(\w\+\.\)*\ze\w\+" conceal contained
 
 syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRunningSuffixDivider
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
+
+syn match ostStatePassedGlyph "\%(|| \)\@<=.\{-}\ze || " contained
+syn match ostStateFailedGlyph "\%(|| \)\@<=.\{-}\ze || " contained
+syn match ostCompletePrefixDivider "|| " conceal contained
 
 syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackLoc,ostStackNoLoc fold
 syn match ostFailurePrefix "^>" conceal contained
@@ -66,7 +70,9 @@ hi def link ostStateNotRun Comment
 hi def link ostStateRunning Identifier
 hi def link ostRunningSpinner Normal
 hi def link ostStatePassed Title
+hi def link ostStatePassedGlyph Title
 hi def link ostStateFailed WarningMsg
+hi def link ostStateFailedGlyph WarningMsg
 hi def link ostStackLoc Identifier
 hi def link ostOutput Comment
 
@@ -78,6 +84,7 @@ hi def link ostFileDivider NonText
 hi def link ostStatePrefix NonText
 hi def link ostFailurePrefix NonText
 hi def link ostRunningSuffixDivider NonText
+hi def link ostCompletePrefixDivider NonText
 hi def link ostStackDelimiter NonText
 hi def link ostStackFileDelimiter NonText
 hi def link ostStackNoLocDelimiter NonText

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -5,8 +5,14 @@ endif
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-syn region ostIntro start="\%1l" end="^$" contains=ostIntroDelim transparent
-syn match ostIntroDelim "^=\+$" contained
+syn region ostBanner start="\%1l" end="\%8l$" contains=ostBannerDelim,ostBannerTitle,ostBannerHelp transparent keepend
+syn match ostBannerHelp "^   .\+$" contained contains=ostBannerMap,ostBannerLink
+syn match ostBannerMap "^    \S\+" contained
+syn match ostBannerLink ":help [[:alnum:]-]\+" contained
+syn match ostBannerTitle "\%2l^.\+$" contained
+syn match ostBannerDelim "\%1l^.*$" contained
+syn match ostBannerDelim "\%3l^.*$" contained
+syn match ostBannerDelim "\%8l^.*$" contained
 
 syn region ostProject matchgroup=ostProjectName start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
 syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
@@ -36,7 +42,11 @@ syn match ostStackFileNamespace "\%(\w\+\.\)*\ze\w\+\.\w\+(" conceal contained
 syn region ostOutput start="^//" end="^[^/]"me=s-1 contains=ostOutputPrefix fold
 syn match ostOutputPrefix "^//" conceal contained
 
-hi def link ostIntroDelim PreProc
+hi def link ostBannerDelim PreProc
+hi def link ostBannerTitle Normal
+hi def link ostBannerHelp Comment
+hi def link ostBannerMap PreProc
+hi def link ostBannerLink helpHyperTextJump
 hi def link ostProjectName Identifier
 hi def link ostFileName TypeDef
 hi def link ostStateNotRun Comment

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -14,13 +14,15 @@ syn match ostBannerDelim "\%1l^.*$" contained
 syn match ostBannerDelim "\%3l^.*$" contained
 syn match ostBannerDelim "\%8l^.*$" contained
 
-syn region ostProject start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
 syn match ostProjectName "^\a.*" contains=ostProjectError
 syn match ostProjectError " - ERROR$"hs=s+2 contained
-syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
+syn region ostProject start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
+syn region ostError start="^<" end="^[^<]"me=s-1 contains=ostErrorPrefix,ostStackFile,ostStackFileNoLoc fold
+syn match ostErrorPrefix "^<" conceal contained
 syn match ostFileName "^    \S.*" contains=ostFilePath,ostFileExt
 syn match ostFilePath "^    \zs\%(\%(\f\+\.\)*\f\+\/\)*\ze\f\+\." conceal contained
 syn match ostFileExt "\%(\.\w\+\)\+" conceal contained
+syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
 syn match ostFileDivider "^__$" conceal
 
 syn match ostStateNotRun "^|.*" contains=ostStatePrefix,ostTestNamespace
@@ -34,8 +36,6 @@ syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRun
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
-syn region ostError start="^<" end="^[^<]"me=s-1 contains=ostErrorPrefix,ostStackFile,ostStackFileNoLoc
-syn match ostErrorPrefix "^<" conceal contained
 syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackFile,ostStackFileNoLoc fold
 syn match ostFailurePrefix "^>" conceal contained
 syn region ostStackFile start=" __ "hs=e+1 end=" __" contains=ostStackFileDelimiter,ostStackFileNamespace contained keepend

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -71,6 +71,7 @@ hi def link ostStackLoc Identifier
 hi def link ostOutput Comment
 
 " Highlights for normally concealed elements
+hi def link ostBannerPrefix NonText
 hi def link ostProjectDelimiter NonText
 hi def link ostErrorPrefix NonText
 hi def link ostFileDivider NonText

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -36,13 +36,15 @@ syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRun
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
-syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackFile,ostStackFileNoLoc fold
+syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackLoc,ostStackNoLoc fold
 syn match ostFailurePrefix "^>" conceal contained
-syn region ostStackFile start=" __ "hs=e+1 end=" __" contains=ostStackFileDelimiter,ostStackFileNamespace contained keepend
-syn match ostStackFileDelimiter " __" conceal contained
-syn region ostStackFileNoLoc start=" _._ "hs=e+1 end=" _._" contains=ostStackFileNoLocDelimiter,ostStackFileNamespace contained keepend
-syn match ostStackFileNoLocDelimiter " _._" conceal contained
-syn match ostStackFileNamespace "\%(\w\+\.\)*\ze\w\+\.\w\+(" conceal contained
+syn region ostStackLoc start=" __ "hs=e+1 end=" __ "he=e-1 contains=ostStackFile,ostStackDelimiter,ostStackNamespace contained keepend
+syn region ostStackFile start=" ___ " end=" __ "he=e-1 contains=ostStackFileDelimiter,ostStackDelimiter conceal contained
+syn match ostStackDelimiter " __ "he=e-1 conceal contained
+syn match ostStackFileDelimiter " ___ " conceal contained
+syn region ostStackNoLoc start=" _._ "hs=e+1 end=" _._" contains=ostStackNoLocDelimiter,ostStackNamespace contained keepend
+syn match ostStackNoLocDelimiter " _._" conceal contained
+syn match ostStackNamespace "\%(\w\+\.\)*\ze\w\+\.\w\+(" conceal contained
 syn region ostOutput start="^//" end="^[^/]"me=s-1 contains=ostOutputPrefix fold
 syn match ostOutputPrefix "^//" conceal contained
 
@@ -59,8 +61,20 @@ hi def link ostStateRunning Identifier
 hi def link ostRunningSpinner Normal
 hi def link ostStatePassed Title
 hi def link ostStateFailed WarningMsg
-hi def link ostStackFile Underlined
+hi def link ostStackLoc Identifier
 hi def link ostOutput Comment
+
+" Highlights for normally concealed elements
+hi def link ostErrorPrefix NonText
+hi def link ostFileDivider NonText
+hi def link ostStatePrefix NonText
+hi def link ostFailurePrefix NonText
+hi def link ostRunningSuffixDivider NonText
+hi def link ostStackDelimiter NonText
+hi def link ostStackFileDelimiter NonText
+hi def link ostStackNoLocDelimiter NonText
+hi def link ostOutputPrefix NonText
+hi def link ostStackFile WarningMsg
 
 let b:current_syntax = 'omnisharptest'
 

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -9,15 +9,19 @@ syn region ostIntro start="\%1l" end="^$" contains=ostIntroDelim transparent
 syn match ostIntroDelim "^=\+$" contained
 
 syn match ostStateNotRun "^|.*" contains=ostStateChar
-syn match ostStateRunning "^-.*" contains=ostStateChar
+syn match ostStateRunning "^-.*" contains=ostStateChar,ostRunningSuffix
 syn match ostStatePassed "^\*.*" contains=ostStateChar
 syn match ostStateFailed "^!.*" contains=ostStateChar
 syn match ostStateChar "^[|\*!-]" conceal contained
+syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRunningSuffixDivider
+syn match ostRunningSuffixDivider "  \zs--" conceal contained
+syn match ostRunningSpinner "  -- \zs.*" contained
 
 hi def link ostIntroDelim PreProc
 
 hi def link ostStateNotRun Comment
 hi def link ostStateRunning Identifier
+hi def link ostRunningSpinner Normal
 hi def link ostStatePassed Title
 hi def link ostStateFailed WarningMsg
 

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -6,8 +6,8 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 syn region ostBanner start="\%1l" end="\%8l$" contains=ostBannerDelim,ostBannerTitle,ostBannerHelp transparent keepend
-syn match ostBannerHelp "^   .\+$" contained contains=ostBannerMap,ostBannerLink
-syn match ostBannerMap "^    \S\+" contained
+syn match ostBannerHelp "^    .*$" contained contains=ostBannerMap,ostBannerLink
+syn match ostBannerMap  "^    \S\+" contained
 syn match ostBannerLink ":help [[:alnum:]-]\+" contained
 syn match ostBannerTitle "\%2l^.\+$" contained
 syn match ostBannerDelim "\%1l^.*$" contained
@@ -46,7 +46,7 @@ hi def link ostBannerDelim PreProc
 hi def link ostBannerTitle Normal
 hi def link ostBannerHelp Comment
 hi def link ostBannerMap PreProc
-hi def link ostBannerLink helpHyperTextJump
+hi def link ostBannerLink Identifier
 hi def link ostProjectName Identifier
 hi def link ostFileName TypeDef
 hi def link ostStateNotRun Comment

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -8,22 +8,32 @@ set cpoptions&vim
 syn region ostIntro start="\%1l" end="^$" contains=ostIntroDelim transparent
 syn match ostIntroDelim "^=\+$" contained
 
-syn match ostStateNotRun "^|.*" contains=ostStateChar
-syn match ostStateRunning "^-.*" contains=ostStateChar,ostRunningSuffix
-syn match ostStatePassed "^\*.*" contains=ostStateChar
-syn match ostStateFailed "^!.*" contains=ostStateChar
-syn match ostStateChar "^[|\*!-]" conceal contained
+syn region ostProject matchgroup=ostProjectName start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
+syn region ostFile matchgroup=ostFileName start="^  \S.*" end="^__$"me=s-1 contains=TOP transparent fold
+syn match ostFileDivider "^__$" conceal
+
+syn match ostStateNotRun "^|.*" contains=ostStatePrefix
+syn match ostStateRunning "^-.*" contains=ostStatePrefix,ostRunningSuffix
+syn match ostStatePassed "^\*.*" contains=ostStatePrefix
+syn match ostStateFailed "^!.*" contains=ostStatePrefix
+syn match ostStatePrefix "^[|\*!-]" conceal contained
+
 syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRunningSuffixDivider
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
-hi def link ostIntroDelim PreProc
+syn region ostOutput start="^//" end="^[^/]"me=s-1 contains=ostOutputPrefix fold
+syn match ostOutputPrefix "^//" conceal contained
 
+hi def link ostIntroDelim PreProc
+hi def link ostProjectName Identifier
+hi def link ostFileName TypeDef
 hi def link ostStateNotRun Comment
 hi def link ostStateRunning Identifier
 hi def link ostRunningSpinner Normal
 hi def link ostStatePassed Title
 hi def link ostStateFailed WarningMsg
+hi def link ostOutput Comment
 
 let b:current_syntax = 'omnisharptest'
 

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -22,6 +22,8 @@ syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRun
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
+syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix fold
+syn match ostFailurePrefix "^>" conceal contained
 syn region ostOutput start="^//" end="^[^/]"me=s-1 contains=ostOutputPrefix fold
 syn match ostOutputPrefix "^//" conceal contained
 

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -6,13 +6,14 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 syn region ostBanner start="\%1l" end="\%8l$" contains=ostBannerDelim,ostBannerTitle,ostBannerHelp transparent keepend
-syn match ostBannerHelp "^    .*$" contained contains=ostBannerMap,ostBannerLink
-syn match ostBannerMap  "^    \S\+" contained
+syn match ostBannerHelp "^`    .*$" contained contains=ostBannerMap,ostBannerLink,ostBannerPrefix
+syn match ostBannerMap  "^`    \S\+" contained contains=ostBannerPrefix
 syn match ostBannerLink ":help [[:alnum:]-]\+" contained
-syn match ostBannerTitle "\%2l^.\+$" contained
-syn match ostBannerDelim "\%1l^.*$" contained
-syn match ostBannerDelim "\%3l^.*$" contained
-syn match ostBannerDelim "\%8l^.*$" contained
+syn match ostBannerTitle "\%2l^`.\+$" contained contains=ostBannerPrefix
+syn match ostBannerDelim "\%1l^`.*$" contained contains=ostBannerPrefix
+syn match ostBannerDelim "\%3l^`.*$" contained contains=ostBannerPrefix
+syn match ostBannerDelim "\%8l^`.*$" contained contains=ostBannerPrefix
+syn match ostBannerPrefix "^`" conceal contained
 
 syn match ostProjectKey ";[^;]*;[^;]*;.*" contains=ostSolution,ostAssembly,ostProjectDelimiter,ostProjectError
 syn match ostSolution "\%(^;[^;]\+;\)\@<=[^;]\+" contained conceal

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -9,21 +9,30 @@ syn region ostIntro start="\%1l" end="^$" contains=ostIntroDelim transparent
 syn match ostIntroDelim "^=\+$" contained
 
 syn region ostProject matchgroup=ostProjectName start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
-syn region ostFile matchgroup=ostFileName start="^  \S.*" end="^__$"me=s-1 contains=TOP transparent fold
+syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
+syn match ostFileName "^    \S.*" contains=ostFilePath,ostFileExt
+syn match ostFilePath "^    \zs\%(\%(\w\+\.\)*\w\+\/\)*\ze\w\+\." conceal contained
+syn match ostFileExt "\%(\.\w\+\)\+" conceal contained
 syn match ostFileDivider "^__$" conceal
 
-syn match ostStateNotRun "^|.*" contains=ostStatePrefix
-syn match ostStateRunning "^-.*" contains=ostStatePrefix,ostRunningSuffix
-syn match ostStatePassed "^\*.*" contains=ostStatePrefix
-syn match ostStateFailed "^!.*" contains=ostStatePrefix
+syn match ostStateNotRun "^|.*" contains=ostStatePrefix,ostTestNamespace
+syn match ostStateRunning "^-.*" contains=ostStatePrefix,ostTestNamespace,ostRunningSuffix
+syn match ostStatePassed "^\*.*" contains=ostStatePrefix,ostTestNamespace
+syn match ostStateFailed "^!.*" contains=ostStatePrefix,ostTestNamespace
 syn match ostStatePrefix "^[|\*!-]" conceal contained
+syn match ostTestNamespace "\%(\w\+\.\)*\ze\w\+" conceal contained
 
 syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRunningSuffixDivider
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
-syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix fold
+syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackFile,ostStackFileNoLoc fold
 syn match ostFailurePrefix "^>" conceal contained
+syn region ostStackFile start=" __ "hs=e+1 end=" __" contains=ostStackFileDelimiter,ostStackFileNamespace contained keepend
+syn match ostStackFileDelimiter " __" conceal contained
+syn region ostStackFileNoLoc start=" _._ "hs=e+1 end=" _._" contains=ostStackFileNoLocDelimiter,ostStackFileNamespace contained keepend
+syn match ostStackFileNoLocDelimiter " _._" conceal contained
+syn match ostStackFileNamespace "\%(\w\+\.\)*\ze\w\+\.\w\+(" conceal contained
 syn region ostOutput start="^//" end="^[^/]"me=s-1 contains=ostOutputPrefix fold
 syn match ostOutputPrefix "^//" conceal contained
 
@@ -35,6 +44,7 @@ hi def link ostStateRunning Identifier
 hi def link ostRunningSpinner Normal
 hi def link ostStatePassed Title
 hi def link ostStateFailed WarningMsg
+hi def link ostStackFile Underlined
 hi def link ostOutput Comment
 
 let b:current_syntax = 'omnisharptest'

--- a/syntax/omnisharptest.vim
+++ b/syntax/omnisharptest.vim
@@ -14,10 +14,12 @@ syn match ostBannerDelim "\%1l^.*$" contained
 syn match ostBannerDelim "\%3l^.*$" contained
 syn match ostBannerDelim "\%8l^.*$" contained
 
-syn region ostProject matchgroup=ostProjectName start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
+syn region ostProject start="^\a.*" end="^$"me=s-1 contains=TOP transparent fold
+syn match ostProjectName "^\a.*" contains=ostProjectError
+syn match ostProjectError " - ERROR$"hs=s+2 contained
 syn region ostFile start="^    \S.*" end="^__$"me=s-1 contains=TOP transparent fold
 syn match ostFileName "^    \S.*" contains=ostFilePath,ostFileExt
-syn match ostFilePath "^    \zs\%(\%(\w\+\.\)*\w\+\/\)*\ze\w\+\." conceal contained
+syn match ostFilePath "^    \zs\%(\%(\f\+\.\)*\f\+\/\)*\ze\f\+\." conceal contained
 syn match ostFileExt "\%(\.\w\+\)\+" conceal contained
 syn match ostFileDivider "^__$" conceal
 
@@ -32,6 +34,8 @@ syn match ostRunningSuffix "  -- .*" contained contains=ostRunningSpinner,ostRun
 syn match ostRunningSuffixDivider "  \zs--" conceal contained
 syn match ostRunningSpinner "  -- \zs.*" contained
 
+syn region ostError start="^<" end="^[^<]"me=s-1 contains=ostErrorPrefix,ostStackFile,ostStackFileNoLoc
+syn match ostErrorPrefix "^<" conceal contained
 syn region ostFailure start="^>" end="^[^>]"me=s-1 contains=ostFailurePrefix,ostStackFile,ostStackFileNoLoc fold
 syn match ostFailurePrefix "^>" conceal contained
 syn region ostStackFile start=" __ "hs=e+1 end=" __" contains=ostStackFileDelimiter,ostStackFileNamespace contained keepend
@@ -48,6 +52,7 @@ hi def link ostBannerHelp Comment
 hi def link ostBannerMap PreProc
 hi def link ostBannerLink Identifier
 hi def link ostProjectName Identifier
+hi def link ostProjectError WarningMsg
 hi def link ostFileName TypeDef
 hi def link ostStateNotRun Comment
 hi def link ostStateRunning Identifier


### PR DESCRIPTION
This PR introduces a new test runner window. It displays the tests and their state ("not run", "running", "passed" and "failed") using syntax highlighting, leaving previously run tests in the test runner window for reference, and to easily re-run tests or test files.

Under each test, any error and stacktrace information is displayed, as well as any console output. Each of these sections is enclosed in a fold.

Any new tests run are added to the test runner, which groups tests by project/solution, then file.

![testrunner_demo](https://user-images.githubusercontent.com/5274565/174435100-e2c4e226-1e2a-496e-9e72-359fdc5377cc.gif)

Partially complete feature list:

- [X] Display tests and state
- [X] Display (user configurable) test spinner to show running tests
- [X] Navigate to tests
- [X] Navigate to failed test stack trace locations
- [X] Add stack trace locations as vimspector break points
- [X] Run test from test runner
- [x] Debug test from test runner
- [X] Run all displayed tests in file or project from test runner
- [x] Delete tests from test runner
- [x] Configurable glyph to display beside completed tests, e.g. 
- [x] Custom fold text for build failure, test failure and console output sections
- [x] Documentation
- [ ] Discover tests (search for tests in solution)

There are already some customisation options, including whether to display a "running" spinner and what characters to use for the spinner, whether to display the intro banner, whether to display build output (or only build error output), whether the quickfix list should still be used as well. These will be documented but have not been yet.