### PR TITLE
Reload project

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -440,12 +440,13 @@ function! OmniSharp#Install(...) abort
     let l:logfile = OmniSharp#log#GetLogDir() . '/install.log'
     let l:script = shellescape(
     \ s:plugin_root_dir . '/installer/omnisharp-manager.sh')
-    let l:mono = g:OmniSharp_server_use_mono ? '-M' : ''
-    let l:net6 = g:OmniSharp_server_use_net6 ? '-6' : ''
+    let l:use =
+    \ g:OmniSharp_server_use_net6 ? '-6' :
+    \ g:OmniSharp_server_use_mono ? '-M' : ''
     let l:version_file_location = l:location . '/OmniSharpInstall-version.txt'
 
-    let l:command = printf('/bin/sh %s %s %s %s -l %s %s',
-    \ l:script, l:http, l:mono, l:net6, l:location, l:version)
+    let l:command = printf('/bin/sh %s %s %s -l %s %s',
+    \ l:script, l:http, l:use, l:location, l:version)
 
     if g:OmniSharp_translate_cygwin_wsl
       let l:command .= ' -W'

--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -100,6 +100,24 @@ function! OmniSharp#actions#project#CreateDebugConfig(stopAtEntry, ...) abort
   call OmniSharp#actions#project#Get(bufnr, function('CreateDebugConfigCb', [bufnr, a:stopAtEntry, a:000]))
 endfunction
 
+function! OmniSharp#actions#project#Reload(bufnr) abort
+  call OmniSharp#actions#project#Get(a:bufnr, function('s:ReloadCB', [a:bufnr]))
+endfunction
+
+function! s:ReloadCB(bufnr) abort
+  let project = OmniSharp#GetHost(a:bufnr).project
+  let projectFile = project.MsBuildProject.Path
+  let opts = {
+  \ 'BufNum': a:bufnr,
+  \ 'SendBuffer': 0,
+  \ 'Arguments': [{
+  \   'FileName': projectFile,
+  \   'ChangeType': 'Change'
+  \ }]
+  \}
+  call OmniSharp#stdio#Request('/filesChanged', opts)
+endfunction
+
 let &cpoptions = s:save_cpo
 unlet s:save_cpo
 

--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -129,6 +129,11 @@ function! OmniSharp#actions#project#Reload(projectFile) abort
   \   'ChangeType': 'Change'
   \ }]
   \}
+  let job = OmniSharp#GetHost(bufnr()).job
+  let job.loaded = 0
+  let job.projects_loaded -= 1
+  let job.restart_time = reltime()
+  let job.restart_project = fnamemodify(a:projectFile, ':t')
   call OmniSharp#stdio#Request('/filesChanged', opts)
 endfunction
 

--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -103,6 +103,13 @@ function! OmniSharp#actions#project#CreateDebugConfig(stopAtEntry, ...) abort
   call OmniSharp#actions#project#Get(bufnr, function('CreateDebugConfigCb', [bufnr, a:stopAtEntry, a:000]))
 endfunction
 
+function! OmniSharp#actions#project#Complete(arglead, cmdline, cursorpos) abort
+  let job = OmniSharp#GetHost(bufnr()).job
+  if !has_key(job, 'projects') | return [] | endif
+  let projectPaths = map(copy(job.projects), {_,p -> fnamemodify(p.path, ':.')})
+  return filter(projectPaths, {_,path -> path =~? a:arglead})
+endfunction
+
 function! OmniSharp#actions#project#Reload(projectFile) abort
   if len(a:projectFile) == 0
     call s:ReloadProjectForBuffer(bufnr())

--- a/autoload/OmniSharp/actions/project.vim
+++ b/autoload/OmniSharp/actions/project.vim
@@ -115,6 +115,10 @@ function! OmniSharp#actions#project#Reload(projectFile) abort
     call s:ReloadProjectForBuffer(bufnr())
     return
   endif
+  if !filereadable(a:projectFile)
+    call OmniSharp#util#EchoErr('File ' . a:projectFile . ' cannot be read')
+    return
+  endif
   echohl Title
   echomsg 'Reloading ' . fnamemodify(a:projectFile, ':t')
   echohl None

--- a/autoload/OmniSharp/project.vim
+++ b/autoload/OmniSharp/project.vim
@@ -16,9 +16,17 @@ endfunction
 function! OmniSharp#project#RegisterLoaded(job) abort
   if a:job.loaded | return | endif
   if g:OmniSharp_server_display_loading
-    let elapsed = reltimefloat(reltime(a:job.start_time))
-    echomsg printf('Loaded server for %s in %.1fs',
-    \ a:job.sln_or_dir, elapsed)
+    if has_key(a:job, 'restart_time')
+      let elapsed = reltimefloat(reltime(a:job.restart_time))
+      echomsg printf('Reloaded %s in %.1fs',
+      \ a:job.restart_project, elapsed)
+      unlet a:job.restart_time
+      unlet a:job.restart_project
+    else
+      let elapsed = reltimefloat(reltime(a:job.start_time))
+      echomsg printf('Loaded server for %s in %.1fs',
+      \ a:job.sln_or_dir, elapsed)
+    endif
   endif
   let a:job.loaded = 1
   silent doautocmd <nomodeline> User OmniSharpReady

--- a/autoload/OmniSharp/stdio.vim
+++ b/autoload/OmniSharp/stdio.vim
@@ -175,13 +175,19 @@ function! OmniSharp#stdio#Request(command, opts) abort
     let send_buffer = get(a:opts, 'SendBuffer', 1)
   endif
 
-  let body = {
-  \ 'Arguments': {
-  \   'FileName': filename,
-  \   'Line': lnum,
-  \   'Column': cnum,
-  \ }
-  \}
+  if has_key(a:opts, 'Arguments')
+    let body = {
+    \ 'Arguments': a:opts.Arguments
+    \}
+  else
+    let body = {
+    \ 'Arguments': {
+    \   'FileName': filename,
+    \   'Line': lnum,
+    \   'Column': cnum,
+    \ }
+    \}
+  endif
   if has_key(a:opts, 'EmptyBuffer')
     let body.Arguments.Buffer = ''
     let sep = ''

--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -151,12 +151,12 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
     let s:server_path = g:OmniSharp_server_path
   else
     let parts = [OmniSharp#util#ServerDir()]
-    if has('win32')
+    if g:OmniSharp_server_use_net6 && !has('win32')
+      let parts += ['OmniSharp']
+    elseif has('win32')
     \ || g:OmniSharp_translate_cygwin_wsl
     \ || g:OmniSharp_server_use_mono
       let parts += ['OmniSharp.exe']
-    elseif g:OmniSharp_server_use_net6
-      let parts += ['OmniSharp']
     else
       let parts += ['run']
     endif
@@ -185,7 +185,7 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
     let command += ['-l', g:OmniSharp_loglevel]
   endif
 
-  if !has('win32') && !s:is_cygwin() && g:OmniSharp_server_use_mono
+  if !has('win32') && !s:is_cygwin() && g:OmniSharp_server_use_mono && !g:OmniSharp_server_use_net6
     let command = insert(command, '--assembly-loader=strict')
     let command = insert(command, 'mono')
   endif

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -85,6 +85,7 @@ By default, the roslyn server is run with mono on Linux and OSX. The roslyn
 server binaries usually come with an embedded mono, but this can be overridden
 to use the installed mono with this option. Note that mono must be in the
 $PATH.
+Note: overridden by |g:OmniSharp_server_use_net6|
 Note: changes require server reinstall: |:OmniSharpInstall|
 Default: 0 >
     let g:OmniSharp_server_use_mono = 1
@@ -92,7 +93,7 @@ Default: 0 >
                                                     *g:OmniSharp_server_use_net6*
 This variable tells OmniSharp-vim to use the new native dotnet net6.0 version
 of OmniSharp-roslyn, which does not require mono.
-Note: |g:OmniSharp_server_use_mono| must be set to 0
+Note: overrides |g:OmniSharp_server_use_mono|
 Note: changes require server reinstall: |:OmniSharpInstall|
 Default: 0 >
     let g:OmniSharp_server_use_net6 = 1

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -678,6 +678,13 @@ convenient user re-mapping. These can be used like so: >
     The command takes optional arguments that will be inserted into the generated
     config as args.
 
+                                                        *:OmniSharpReloadProject*
+                                               *<Plug>(omnisharp_reload_project)*
+:OmniSharpReloadProject [{project}]
+    Causes the .csproj {project}, or the current project if no argument is
+    given, to be re-read by the server. This can be particularly useful in
+    older style projects where all .cs files are listed in the .csproj.
+
                                                     *:OmniSharpRestartAllServers*
                                           *<Plug>(omnisharp_restart_all_servers)*
 :OmniSharpRestartAllServers

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -51,7 +51,7 @@ augroup END
 
 setlocal omnifunc=OmniSharp#Complete
 
-command! -buffer -bar -nargs=? -complete=file OmniSharpReloadProject call OmniSharp#actions#project#Reload(<q-args>)
+command! -buffer -bar -nargs=? -complete=customlist,OmniSharp#actions#project#Complete OmniSharpReloadProject call OmniSharp#actions#project#Reload(<q-args>)
 command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()
 command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniSharp#StartServer(<q-args>)

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -51,6 +51,7 @@ augroup END
 
 setlocal omnifunc=OmniSharp#Complete
 
+command! -buffer -bar OmniSharpReloadProject call OmniSharp#actions#project#Reload(bufnr())
 command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()
 command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniSharp#StartServer(<q-args>)
@@ -104,6 +105,7 @@ nnoremap <buffer> <Plug>(omnisharp_navigate_up) :OmniSharpNavigateUp<CR>
 nnoremap <buffer> <Plug>(omnisharp_navigate_down) :OmniSharpNavigateDown<CR>
 nnoremap <buffer> <Plug>(omnisharp_preview_definition) :OmniSharpPreviewDefinition<CR>
 nnoremap <buffer> <Plug>(omnisharp_preview_implementation) :OmniSharpPreviewImplementation<CR>
+nnoremap <buffer> <Plug>(omnisharp_reload_project) :OmniSharpReloadProject<CR>
 nnoremap <buffer> <Plug>(omnisharp_rename) :OmniSharpRename<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_server) :OmniSharpRestartServer<CR>
 nnoremap <buffer> <Plug>(omnisharp_restart_all_servers) :OmniSharpRestartAllServers<CR>
@@ -156,6 +158,7 @@ let b:undo_ftplugin .= '
 \| delcommand OmniSharpNavigateDown
 \| delcommand OmniSharpPreviewDefinition
 \| delcommand OmniSharpPreviewImplementation
+\| delcommand OmniSharpReloadProject
 \| delcommand OmniSharpRename
 \| delcommand OmniSharpRenameTo
 \| delcommand OmniSharpRepeatCodeAction

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -51,7 +51,7 @@ augroup END
 
 setlocal omnifunc=OmniSharp#Complete
 
-command! -buffer -bar OmniSharpReloadProject call OmniSharp#actions#project#Reload(bufnr())
+command! -buffer -bar -nargs=? -complete=file OmniSharpReloadProject call OmniSharp#actions#project#Reload(<q-args>)
 command! -buffer -bar OmniSharpRestartAllServers call OmniSharp#RestartAllServers()
 command! -buffer -bar OmniSharpRestartServer call OmniSharp#RestartServer()
 command! -buffer -bar -nargs=? -complete=file OmniSharpStartServer call OmniSharp#StartServer(<q-args>)


### PR DESCRIPTION
Add new command `:OmniSharpReloadProject`, which asks omnisharp-roslyn to re-read a .csproj file and reload it, without requiring a full server restart.

The command can be used with no arguments from a .cs file. However, if the file is not currently recognised as being part of a project (e.g. it is a new, unlisted file in a .NET Framework project, perhaps having been added to the .csproj file by Unity) then omnisharp-roslyn will not know which project to reload. In this case the project should be reloaded by name.

The command accepts a project name as an argument, and provides completion for all of the projects included in the solution.

Closes #813