### PR TITLE
Added option to enable snippet support for coc completion source. (STDIO only for now)

### DIFF
--- a/autoload/OmniSharp/actions/complete.vim
+++ b/autoload/OmniSharp/actions/complete.vim
@@ -69,7 +69,7 @@ function! s:StdioGetCompletions(partial, opts, Callback) abort
   \ && &completeopt =~# 'popup'
   let wantDoc = wantDocPopup ? 'false'
   \ : g:omnicomplete_fetch_full_documentation ? 'true' : 'false'
-  let wantSnippet = g:OmniSharp_want_snippet ? 'true' : 'false'
+  let wantSnippet = g:OmniSharp_want_snippet ? 'true' : g:OmniSharp_coc_snippet ? 'true' : 'false'
   let s:last_startcol = has_key(a:opts, 'startcol')
   \ ? a:opts.startcol
   \ : col('.') - len(a:partial) - 1
@@ -94,7 +94,7 @@ function! s:StdioGetCompletionsRH(Callback, wantDocPopup, response) abort
     if g:OmniSharp_want_snippet
       let word = cmp.MethodHeader != v:null ? cmp.MethodHeader : cmp.CompletionText
       let menu = cmp.ReturnType != v:null ? cmp.ReturnType : cmp.DisplayText
-    elseif g:OmniSharp_completion_without_overloads
+    elseif g:OmniSharp_completion_without_overloads && !g:OmniSharp_coc_snippet
       let word = cmp.CompletionText
       let menu = ''
     else
@@ -105,8 +105,15 @@ function! s:StdioGetCompletionsRH(Callback, wantDocPopup, response) abort
     if word == v:null
       continue
     endif
+    let snipCompletionText = get(cmp, 'Snippet', '')
+    let isSnippet = (snipCompletionText != cmp.CompletionText .. '$0')
+          \ && (snipCompletionText != cmp.CompletionText)
+          \ && (!empty(snipCompletionText))
+
     let completion = {
-    \ 'snip': get(cmp, 'Snippet', ''),
+    \ 'snip': snipCompletionText,
+    \ 'insertText': isSnippet ? snipCompletionText : '',
+    \ 'isSnippet': isSnippet,
     \ 'word': word,
     \ 'menu': menu,
     \ 'icase': 1,

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -430,6 +430,13 @@ Use this option to enable snippet completion, when ultisnips is available.
 Default: 0 >
     let g:OmniSharp_want_snippet = 0
 <
+                                                        *g:OmniSharp_coc_snippet*
+Use this option to enable snippet completion for coc source. For this feature
+to be enabled it is required that g:OmniSharp_want_snippet is set to 0. Only
+supports stdio server.
+Default: 0 >
+    let g:OmniSharp_coc_snippet = 0
+<
                                        *g:OmniSharp_completion_without_overloads*
 Use this option to get completion results without method arguments.
 Consequently, overloads will not be part of the completion results. For this

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -47,6 +47,9 @@ let g:OmniSharp_want_snippet = get(g:, 'OmniSharp_want_snippet', 0)
 " Only has effect if OmniSharp_want_snippet is 0.
 let g:OmniSharp_completion_without_overloads = get(g:, 'OmniSharp_completion_without_overloads', 0)
 
+" Does not work well when OmniSharp_want_snippet is 1.
+let g:OmniSharp_coc_snippet = get(g:, 'OmniSharp_coc_snippet', 0)
+
 let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_documentation', 1)
 
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)


### PR DESCRIPTION
Hi! First of all, thanks for the amazing plugin! It has helped me a ton in my daily work.

Three months ago, I submitted an issue: #808 on omnisharp-vim not supporting snippet when used with coc. And it seems like that's because coc does not support vim source having snippets back then. But now it has added this feature with this commit: [snippet support for vim source](https://github.com/neoclide/coc.nvim/commit/e7dce3ab3e2ddf718049260690ba8686045ed1c2), and I have been playing around with omnisharp-vim's completion methods to try to add snippet support.  So far, it is working great for me, which is why I have created a pull request other people can try as well. Could you please take a look and let me know if you would be interested in adding this support and if you have any comments or suggestions for my pull request?

I have also made a gif to show what it looks like after the change:
![coc_snippet_demo](https://user-images.githubusercontent.com/16534505/214108801-411ce758-738d-4d9a-af94-fa50712c1f14.gif)

