### PR TITLE
Updated the clone urls from git to https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Install the Vim plugin using your preferred plugin manager:
 
 | ['runtimepath'](http://vimhelp.appspot.com/options.txt.html#%27runtimepath%27) handler | Command                                            |
 |------------------------------------------------------|--------------------------------------------------------------------------------------|
-| [Vim 8.0+ Native packages](http://vimhelp.appspot.com/repeat.txt.html#packages) | `$ git clone git://github.com/OmniSharp/omnisharp-vim ~/.vim/pack/plugins/start/omnisharp-vim` |
-| [Pathogen](https://github.com/tpope/vim-pathogen)    | `$ git clone git://github.com/OmniSharp/omnisharp-vim ~/.vim/bundle/omnisharp-vim`     |
+| [Vim 8.0+ Native packages](http://vimhelp.appspot.com/repeat.txt.html#packages) | `$ git clone https://github.com/OmniSharp/omnisharp-vim ~/.vim/pack/plugins/start/omnisharp-vim` |
+| [Pathogen](https://github.com/tpope/vim-pathogen)    | `$ git clone https://github.com/OmniSharp/omnisharp-vim ~/.vim/bundle/omnisharp-vim`     |
 
 If not using a plugin manager such as Vim-plug (which does this automatically), make sure your .vimrc contains these lines:
 


### PR DESCRIPTION
Github dropped supported for the unauthenticated git protocol, see: https://github.blog/2021-09-01-improving-git-protocol-security-github/