### PR TITLE
Add GotoTypeDefinition

### DIFF
--- a/autoload/OmniSharp/actions/typedefinition.vim
+++ b/autoload/OmniSharp/actions/typedefinition.vim
@@ -1,0 +1,105 @@
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+" Navigate to the definition of the symbol under the cursor.
+" Optional arguments:
+" Callback: When a callback is passed in, it is called after the response is
+"           returned (synchronously or asynchronously) with the found
+"           location and a flag for whether it is in a file in the project or
+"           from the metadata. This is done instead of navigating to the found
+"           location.
+" editcommand: The command to use to open buffers, e.g. 'split', 'vsplit',
+"              'tabedit' or 'edit' (default).
+function! OmniSharp#actions#typedefinition#Find(...) abort
+  let opts = { 'editcommand': 'edit' }
+  if a:0 && type(a:1) == type('') && a:1 !=# ''
+    let opts.editcommand = a:1
+  endif
+
+  let Callback = function('s:CBGotoDefinition', [opts])
+
+  call s:StdioFind(Callback)
+endfunction
+
+function! s:StdioFind(Callback) abort
+  let opts = {
+  \ 'ResponseHandler': function('s:StdioFindRH', [a:Callback]),
+  \ 'Parameters': {
+  \   'WantMetadata': v:true,
+  \ }
+  \}
+  call OmniSharp#stdio#Request('/gototypedefinition', opts)
+endfunction
+
+function! s:StdioFindRH(Callback, response) abort
+  if !a:response.Success | return | endif
+  let body = a:response.Body
+  if type(body) == type({}) && get(body, 'Definitions', v:null) != v:null
+    let definition = body.Definitions[0]
+
+    if g:OmniSharp_lookup_metadata
+          \ && type(definition) == type({})
+          \ && type(definition.MetadataSource) == type({})
+      let Callback = function('s:CBMetadataFind', [a:Callback])
+      call s:StdioMetadataFind(Callback, definition)
+    else
+      let location = OmniSharp#locations#ParseLocation(definition.Location)
+
+      call a:Callback(location, 0)
+    endif
+  endif
+endfunction
+
+function! s:StdioMetadataFind(Callback, definition) abort
+  let metadataSource = a:definition.MetadataSource
+  let metadataSource.TypeName = substitute(metadataSource.TypeName, '?', '', 'g')
+
+  let opts = {
+  \ 'ResponseHandler': function('s:StdioMetadataFindRH', [a:Callback, a:definition]),
+  \ 'Parameters': metadataSource
+  \}
+  call OmniSharp#stdio#Request('/metadata', opts)
+endfunction
+
+function! s:StdioMetadataFindRH(Callback, metadata, response) abort
+  if !a:response.Success || a:response.Body.Source == v:null | return 0 | endif
+  call a:Callback(a:response.Body, a:metadata)
+endfunction
+
+function! s:CBMetadataFind(Callback, response, definition) abort
+  let host = OmniSharp#GetHost()
+  let metadata_filename = fnamemodify(
+  \ OmniSharp#util#TranslatePathForClient(a:response.SourceName), ':t')
+  let temp_file = OmniSharp#util#TempDir() . '/' . metadata_filename
+  let lines = split(a:response.Source, "\n", 1)
+  let lines = map(lines, {i,v -> substitute(v, '\r', '', 'g')})
+  call writefile(lines, temp_file, 'b')
+  let bufnr = bufadd(temp_file)
+  call setbufvar(bufnr, 'OmniSharp_host', host)
+  call setbufvar(bufnr, 'OmniSharp_metadata_filename', a:response.SourceName)
+  let location = {
+  \ 'filename': temp_file,
+  \ 'lnum': a:definition.Location.Range.Start.Line,
+  \ 'col': a:definition.Location.Range.Start.Column
+  \}
+  call a:Callback(location, 1)
+endfunction
+
+function! s:CBGotoDefinition(opts, location, fromMetadata) abort
+  if type(a:location) != type({}) " Check whether a dict was returned
+    echo 'Not found'
+
+    let found = 0
+  else
+    let found = OmniSharp#locations#Navigate(a:location, get(a:opts, 'editcommand', 'edit'))
+    if found && a:fromMetadata
+      setlocal nomodifiable readonly
+    endif
+  endif
+  return found
+endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo
+
+" vim:et:sw=2:sts=2

--- a/autoload/OmniSharp/locations.vim
+++ b/autoload/OmniSharp/locations.vim
@@ -85,24 +85,39 @@ function! OmniSharp#locations#Navigate(location, ...) abort
   return navigated
 endfunction
 
+function! OmniSharp#locations#ParseLocation(value) abort
+  return {
+        \ 'filename': has_key(a:value, 'FileName')
+        \   ? OmniSharp#util#TranslatePathForClient(a:value.FileName)
+        \   : expand('%:p'),
+        \ 'lnum': a:value.Range.Start.Line,
+        \ 'col': a:value.Range.Start.Column,
+        \ 'end_lnum': a:value.Range.End.Line,
+        \ 'end_col': a:value.Range.End.Column - 1,
+        \ 'vcol': 1
+        \}
+endfunction
+
 function! OmniSharp#locations#Parse(quickfixes) abort
   let locations = []
   for quickfix in a:quickfixes
     let location = {
-    \ 'filename': has_key(quickfix, 'FileName')
-    \   ? OmniSharp#util#TranslatePathForClient(quickfix.FileName)
-    \   : expand('%:p'),
-    \ 'text': get(quickfix, 'Text', get(quickfix, 'Message', '')),
-    \ 'lnum': quickfix.Line,
-    \ 'col': quickfix.Column,
-    \ 'vcol': 1
-    \}
+          \ 'filename': has_key(quickfix, 'FileName')
+          \   ? OmniSharp#util#TranslatePathForClient(quickfix.FileName)
+          \   : expand('%:p'),
+          \ 'text': get(quickfix, 'Text', get(quickfix, 'Message', '')),
+          \ 'lnum': quickfix.Line,
+          \ 'col': quickfix.Column,
+          \ 'vcol': 1
+          \}
     if has_key(quickfix, 'EndLine') && has_key(quickfix, 'EndColumn')
       let location.end_lnum = quickfix.EndLine
       let location.end_col = quickfix.EndColumn - 1
     endif
+
     call add(locations, location)
   endfor
+
   return locations
 endfunction
 

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -517,6 +517,19 @@ convenient user re-mapping. These can be used like so: >
     :OmniSharpGotoDefinition vsplit
     :OmniSharpGotoDefinition tabedit
 <
+                                                       *:OmniSharpGotoTypeDefinition*
+                                             *<Plug>(omnisharp_go_to_type_definition)*
+:OmniSharpGotoTypeDefinition [{cmd}]
+    Navigates to the type definition of the symbol under the cursor.
+    By default the definition is opened in the current window. To open it in a
+    new window or tab, pass a relevant command to use to open the buffer: >
+
+    :OmniSharpGotoTypeDefinition
+    :OmniSharpGotoTypeDefinition split
+    :OmniSharpGotoTypeDefinition vsplit
+    :OmniSharpGotoTypeDefinition tabedit
+<
+
                                                   *:OmniSharpFindImplementations*
                                          *<Plug>(omnisharp_find_implementations)*
 :OmniSharpFindImplementations

--- a/ftplugin/cs/OmniSharp.vim
+++ b/ftplugin/cs/OmniSharp.vim
@@ -68,6 +68,7 @@ command! -buffer -bar OmniSharpFindUsages call OmniSharp#actions#usages#Find()
 command! -buffer -bar OmniSharpFixUsings call OmniSharp#actions#usings#Fix()
 command! -buffer -bar OmniSharpGetCodeActions call OmniSharp#actions#codeactions#Get('normal')
 command! -buffer -bar OmniSharpGlobalCodeCheck call OmniSharp#actions#diagnostics#CheckGlobal()
+command! -buffer -bar -nargs=? OmniSharpGotoTypeDefinition call OmniSharp#actions#typedefinition#Find(<q-args>)
 command! -buffer -bar -nargs=? OmniSharpGotoDefinition call OmniSharp#actions#definition#Find(<q-args>)
 command! -buffer -bar OmniSharpHighlight call OmniSharp#actions#highlight#Buffer()
 command! -buffer -bar OmniSharpHighlightEcho call OmniSharp#actions#highlight#Echo()
@@ -99,6 +100,7 @@ xnoremap <buffer> <Plug>(omnisharp_code_actions) :call OmniSharp#actions#codeact
 nnoremap <buffer> <Plug>(omnisharp_code_action_repeat) :OmniSharpRepeatCodeAction<CR>
 xnoremap <buffer> <Plug>(omnisharp_code_action_repeat) :call OmniSharp#actions#codeactions#Repeat('visual')<CR>
 nnoremap <buffer> <Plug>(omnisharp_global_code_check) :OmniSharpGlobalCodeCheck<CR>
+nnoremap <buffer> <Plug>(omnisharp_go_to_type_definition) :OmniSharpGotoTypeDefinition<CR>
 nnoremap <buffer> <Plug>(omnisharp_go_to_definition) :OmniSharpGotoDefinition<CR>
 nnoremap <buffer> <Plug>(omnisharp_highlight) :OmniSharpHighlight<CR>
 nnoremap <buffer> <Plug>(omnisharp_navigate_up) :OmniSharpNavigateUp<CR>
@@ -149,6 +151,7 @@ let b:undo_ftplugin .= '
 \| delcommand OmniSharpFixUsings
 \| delcommand OmniSharpGetCodeActions
 \| delcommand OmniSharpGlobalCodeCheck
+\| delcommand OmniSharpGotoTypeDefinition
 \| delcommand OmniSharpGotoDefinition
 \| delcommand OmniSharpHighlight
 \| delcommand OmniSharpHighlightEcho


### PR DESCRIPTION
**OmniSharpGotoTypeDefinition** navigates to the type definition of the symbol under the cursor.