### PR TITLE
Receive information that a project was loaded

### DIFF
--- a/autoload/OmniSharp/actions/workspace.vim
+++ b/autoload/OmniSharp/actions/workspace.vim
@@ -22,9 +22,13 @@ function! s:ProjectsRH(job, response) abort
   " If no projects have been loaded by the time this callback is reached, there
   " are no projects and the job can be marked as ready
   let projects = get(get(a:response.Body, 'MsBuild', {}), 'Projects', {})
+
+  let a:job.projects_total = max([ get(a:job, 'projects_total', 0), len(projects) ])
+  let a:job.projects_loaded = get(a:job, 'projects_loaded', 0)
   let a:job.projects = map(projects,
   \ {_,project -> {"name": project.AssemblyName, "path": project.Path, "target": project.TargetPath}})
-  if get(a:job, 'projects_total', 0) > 0
+
+  if a:job.projects_total > 0
     call OmniSharp#log#Log(a:job, 'Workspace complete: ' . a:job.projects_total . ' project(s)')
   else
     call OmniSharp#log#Log(a:job, 'Workspace complete: no projects')

--- a/autoload/OmniSharp/project.vim
+++ b/autoload/OmniSharp/project.vim
@@ -72,22 +72,30 @@ function! OmniSharp#project#ParseEvent(job, event, eventBody) abort
         let a:job.projects_total = len(a:job.loading)
         silent doautocmd <nomodeline> User OmniSharpProjectUpdated
       endif
-    endif
-    if message =~# '^Successfully loaded project'
-    \ || message =~# '^Failed to load project'
+    elseif message =~# '^Successfully loaded project' || message =~# '^Failed to load project'
       if message[0] ==# 'F'
         echom 'Failed to load project: ' . project
       endif
-      call filter(a:job.loading, {idx,val -> val !=# project})
-      let a:job.projects_loaded = projects_loaded + 1
-      silent doautocmd <nomodeline> User OmniSharpProjectUpdated
-      if len(a:job.loading) == 0
-        call OmniSharp#project#RegisterLoaded(a:job)
-        unlet a:job.loading
-        call timer_stop(a:job.loading_timeout)
-        unlet a:job.loading_timeout
-      endif
+      call s:AcknowledgeLoadedProject(a:job, project)
     endif
+  elseif a:event ==# 'MsBuildProjectDiagnostics'
+    let project = a:eventBody.FileName
+    call s:AcknowledgeLoadedProject(a:job, project)
+  endif
+endfunction
+
+function! s:AcknowledgeLoadedProject(job, project)
+  if index(a:job.loading, a:project) < 0
+    return
+  endif
+  call filter(a:job.loading, {idx,val -> val !=# a:project})
+  let a:job.projects_loaded = get(a:job, 'projects_loaded', 0) + 1
+  silent doautocmd <nomodeline> User OmniSharpProjectUpdated
+  if empty(a:job.loading)
+    call OmniSharp#project#RegisterLoaded(a:job)
+    unlet a:job.loading
+    call timer_stop(a:job.loading_timeout)
+    unlet a:job.loading_timeout
   endif
 endfunction
 

--- a/autoload/OmniSharp/project.vim
+++ b/autoload/OmniSharp/project.vim
@@ -78,16 +78,13 @@ function! OmniSharp#project#ParseEvent(job, event, eventBody) abort
       endif
       call s:AcknowledgeLoadedProject(a:job, project)
     endif
-  elseif a:event ==# 'MsBuildProjectDiagnostics'
+  elseif has_key(a:job, 'restart_time') && a:event ==# 'MsBuildProjectDiagnostics'
     let project = a:eventBody.FileName
     call s:AcknowledgeLoadedProject(a:job, project)
   endif
 endfunction
 
 function! s:AcknowledgeLoadedProject(job, project)
-  if index(a:job.loading, a:project) < 0
-    return
-  endif
   call filter(a:job.loading, {idx,val -> val !=# a:project})
   let a:job.projects_loaded = get(a:job, 'projects_loaded', 0) + 1
   silent doautocmd <nomodeline> User OmniSharpProjectUpdated


### PR DESCRIPTION
💌 Motivation: `OmniSharpReloadProject` would otherwise throw because it does not find key `job.projects_loaded`

In order to fill this property, I tried to figure out why it did not exist. Turns out that on my codebases (dotnet6 maybe?) don't detect loaded project events.

`echomsg`-based debugging told me we did receive `MSBuildProjectDiagnostics` events, on which I started listening.

Omnisharp-roslyn seems to confirm this is a reliable source of truth (moreso than the existing detection method): https://github.com/OmniSharp/omnisharp-roslyn/blob/e5606354c5c652fc8ecc83d877a2b00d32656d5d/src/OmniSharp.MSBuild/ProjectManager.cs#L327
