### PR TITLE
Start the server with at least minimal logging

### DIFF
--- a/autoload/OmniSharp/util.vim
+++ b/autoload/OmniSharp/util.vim
@@ -181,7 +181,7 @@ function! OmniSharp#util#GetStartCmd(solution_file) abort
   endif
   let command += ['-s', solution_path]
 
-  if g:OmniSharp_loglevel !=? 'info'
+  if g:OmniSharp_loglevel !=? 'info' && g:OmniSharp_loglevel !=? 'none'
     let command += ['-l', g:OmniSharp_loglevel]
   endif
 


### PR DESCRIPTION
When running the server with loglevel "None", no project load status messages are received. This change ensures that when loglevel is set to "None", no loglevel flag is sent to the server, so it logs at its default "Info" level and we receive project status info. We just don't write any logs to disk.

This PR supercedes #849 