### PR TITLE
autoload: resolving the solution file based on a function

### DIFF
--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -108,16 +108,16 @@ function! OmniSharp#FindSolutionOrDir(...) abort
   let interactive = a:0 ? a:1 : 1
   let bufnr = a:0 > 1 ? a:2 : bufnr('%')
   if empty(getbufvar(bufnr, 'OmniSharp_buf_server'))
-    try
-      if g:OmniSharp_sln_resolve_function != v:null
-        let sln = call(g:OmniSharp_sln_resolve_function, [])
-      else
+    if exists('g:OmniSharp_find_solution')
+      let sln = call(g:OmniSharp_find_solution, [bufnr])
+    else
+      try
         let sln = s:FindSolution(interactive, bufnr)
-      endif
-      call setbufvar(bufnr, 'OmniSharp_buf_server', sln)
-    catch
-      return ''
-    endtry
+      catch
+        return ''
+      endtry
+    endif
+    call setbufvar(bufnr, 'OmniSharp_buf_server', sln)
   endif
   return getbufvar(bufnr, 'OmniSharp_buf_server')
 endfunction

--- a/autoload/OmniSharp.vim
+++ b/autoload/OmniSharp.vim
@@ -109,7 +109,11 @@ function! OmniSharp#FindSolutionOrDir(...) abort
   let bufnr = a:0 > 1 ? a:2 : bufnr('%')
   if empty(getbufvar(bufnr, 'OmniSharp_buf_server'))
     try
-      let sln = s:FindSolution(interactive, bufnr)
+      if g:OmniSharp_sln_resolve_function != v:null
+        let sln = call(g:OmniSharp_sln_resolve_function, [])
+      else
+        let sln = s:FindSolution(interactive, bufnr)
+      endif
       call setbufvar(bufnr, 'OmniSharp_buf_server', sln)
     catch
       return ''

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -190,7 +190,7 @@ Default: {} >
     \ 'C:\path\to\other\project': 2004,
     \}
 <
-                                                       *g:OmniSharp_sln_resolve_function*
+                                                      *g:OmniSharp_find_solution*
 Function used to resolve the solution file anytime it needs to be resolved
 based on the currently opened file.
 
@@ -198,10 +198,8 @@ This can be used in various ways, but one particular use case might be when
 you need Omnisharp to stick to a given solution file that would contain all
 the projects that you need to work with even though you navigate to
 subprojects where other solution files could be found there. In that case, one
-could pass a value along the following lines:
-
->
-    let g:OmniSharp_sln_resolve_function = { -> "/the/path/to/my/main_project.sln" }
+could pass a value along the following lines: >
+    let g:OmniSharp_find_solution = {bufnr -> "/path/to/main_project.sln"}
 <
 
 This is a lambda expression that always evaluates to the string

--- a/doc/omnisharp-vim.txt
+++ b/doc/omnisharp-vim.txt
@@ -190,6 +190,24 @@ Default: {} >
     \ 'C:\path\to\other\project': 2004,
     \}
 <
+                                                       *g:OmniSharp_sln_resolve_function*
+Function used to resolve the solution file anytime it needs to be resolved
+based on the currently opened file.
+
+This can be used in various ways, but one particular use case might be when
+you need Omnisharp to stick to a given solution file that would contain all
+the projects that you need to work with even though you navigate to
+subprojects where other solution files could be found there. In that case, one
+could pass a value along the following lines:
+
+>
+    let g:OmniSharp_sln_resolve_function = { -> "/the/path/to/my/main_project.sln" }
+<
+
+This is a lambda expression that always evaluates to the string
+`/the/path/to/my/main_project.sln`. One could imagine more complexed cases.
+It's up to the user to use this as he sees fit.
+
 -------------------------------------------------------------------------------
 3.2 DIAGNOSTICS                                    *omnisharp-diagnostic-options*
 

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -52,6 +52,8 @@ let g:OmniSharp_coc_snippet = get(g:, 'OmniSharp_coc_snippet', 0)
 
 let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_documentation', 1)
 
+let g:OmniSharp_sln_resolve_function = get(g:, 'OmniSharp_sln_resolve_function',  v:null)
+
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
 command! -bar -nargs=? OmniSharpOpenLog call OmniSharp#log#Open(<q-args>)
 command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)

--- a/plugin/OmniSharp.vim
+++ b/plugin/OmniSharp.vim
@@ -52,8 +52,6 @@ let g:OmniSharp_coc_snippet = get(g:, 'OmniSharp_coc_snippet', 0)
 
 let g:omnicomplete_fetch_full_documentation = get(g:, 'omnicomplete_fetch_full_documentation', 1)
 
-let g:OmniSharp_sln_resolve_function = get(g:, 'OmniSharp_sln_resolve_function',  v:null)
-
 command! -bar -nargs=? OmniSharpInstall call OmniSharp#Install(<f-args>)
 command! -bar -nargs=? OmniSharpOpenLog call OmniSharp#log#Open(<q-args>)
 command! -bar -bang OmniSharpStatus call OmniSharp#Status(<bang>0)


### PR DESCRIPTION
A user defined variable containing the function is passed to OmniSharp.
Otherwise, OmniSharp resolves the solution file by his default behaviour.

This is built on top of the idea brought by #317 even though the code was
way to old to work with.